### PR TITLE
Add missing nginx volume mapping to docker-compose.yml for ssl.

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -19,6 +19,7 @@ services:
       - MAX_BODY_SIZE=2097152
     volumes:
       - ./platform/nginx.conf.template:/etc/nginx/nginx.conf.template:ro
+      - ./ssl/server:/etc/nginx/ssl:ro
   linkeddatahub:
     image: atomgraph/linkeddatahub:latest
     ports:


### PR DESCRIPTION
Add missing volume mapping for certificates for Nginx container.