### PR TITLE
SEO features

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## [4.0.1] - 2023-04-05
+## [4.0.1] - 2023-04-23
 ### Changed
 - Navigation bar is now fully rendered server-side, i.e. the whole visible HTML body is replaced via AJAX
 - Generalized client-side navigation templates using XPath maps

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,11 @@
 ## [4.0.1] - 2023-04-23
+### Added
+- Backlink navigation on XHTML content
+
 ### Changed
 - Navigation bar is now fully rendered server-side, i.e. the whole visible HTML body is replaced via AJAX
 - Generalized client-side navigation templates using XPath maps
 - Fixed default `@id` value in `bs2:RowContent` mode
-- Backlink navigation on XHTML content
 
 ## [4.0.0] - 2023-01-04
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+## [4.0.2] - 2023-05-08
+### Added
+- [XML sitemap](https://www.sitemaps.org/protocol.html) generation when env param `GENERATE_SITEMAP=true` is specified (enabled by default)
+- JSON-LD output in the `<script>` tag containing [schema:BreadCrumbList](https://schema.org/BreadcrumbList) structured data
+
+### Changed
+- Content blocks use `@about` attributes as identifiers instead of `@data-content-uri`
+
 ## [4.0.1] - 2023-04-23
 ### Added
 - Backlink navigation on XHTML content

--- a/Dockerfile
+++ b/Dockerfile
@@ -78,9 +78,9 @@ ENV SECRETARY_CERT_ALIAS=secretary
 
 ENV CLIENT_KEYSTORE_MOUNT=/var/linkeddatahub/ssl/secretary/keystore.p12
 
-ENV CLIENT_KEYSTORE="$CATALINA_HOME/webapps/ROOT/ssl/keystore.p12"
+ENV CLIENT_KEYSTORE="$CATALINA_HOME/webapps/ROOT/WEB-INF/keystore.p12"
 
-ENV CLIENT_TRUSTSTORE="$CATALINA_HOME/webapps/ROOT/ssl/client.truststore"
+ENV CLIENT_TRUSTSTORE="$CATALINA_HOME/webapps/ROOT/WEB-INF/client.truststore"
 
 ENV OWNER_PUBLIC_KEY=/var/linkeddatahub/ssl/owner/public.pem
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -108,6 +108,8 @@ ENV GOOGLE_CLIENT_ID=
 
 ENV GOOGLE_CLIENT_SECRET=
 
+ENV GENERATE_SITEMAP=true
+
 # HEALTHCHECK --start-period=80s CMD curl -f http://localhost:$HTTP_PORT || exit 1
 
 # remove default Tomcat webapps and install xmlstarlet (used for XPath queries) and envsubst (for variable substitution)
@@ -143,6 +145,12 @@ COPY platform/root-owner.trig.template root-owner.trig.template
 COPY platform/datasets/admin.trig /var/linkeddatahub/datasets/admin.trig
 
 COPY platform/datasets/end-user.trig /var/linkeddatahub/datasets/end-user.trig
+
+# copy sitemap query & stylesheet
+
+COPY platform/sitemap/sitemap.rq.template /var/linkeddatahub/sitemap/sitemap.rq.template
+
+COPY platform/sitemap/sitemap.xsl /var/linkeddatahub/sitemap/sitemap.xsl
 
 # copy webapp config
 

--- a/README.md
+++ b/README.md
@@ -43,8 +43,8 @@ It takes a few clicks and filling out a form to install the product into your ow
      COMPOSE_PROJECT_NAME=linkeddatahub
      
      PROTOCOL=https
-     PROXY_HTTP_PORT=81
-     PROXY_HTTPS_PORT=4443
+     HTTP_PORT=81
+     HTTPS_PORT=4443
      HOST=localhost
      ABS_PATH=/
      
@@ -182,7 +182,7 @@ An environment variable `JENA_HOME` is used by all the command line tools to con
 ### Third party
 
 * [NOI OpenDataHub](https://kg.opendatahub.bz.it) – tourism Knowledge Graph portal powered by LinkedDataHub and [@ontop](https://github.com/ontop). [Source code](https://github.com/noi-techpark/it.bz.opendatahub.kg).
-* [LDH Uploader](https://github.com/tmciver/ldh-uploader) - a collection of shell scripts ussed to upload files or directory of files to a Linked Data Hub instance by [@tmciver](https://github.com/tmciver)
+* [LDH Uploader](https://github.com/tmciver/ldh-uploader) - a collection of shell scripts used to upload files or directory of files to a LinkedDataHub instance by [@tmciver](https://github.com/tmciver)
 
 ### [Demo apps](https://github.com/AtomGraph/LinkedDataHub-Apps)
 

--- a/README.md
+++ b/README.md
@@ -246,4 +246,3 @@ Commercial consulting, development, and support are available from [AtomGraph](h
 * [linkeddatahub/Lobby](https://gitter.im/linkeddatahub/Lobby) on gitter
 * [@atomgraphhq](https://twitter.com/atomgraphhq) on Twitter
 * [AtomGraph](https://www.linkedin.com/company/atomgraph/) on LinkedIn
-* W3C [Declarative Linked Data Apps Community Group](http://www.w3.org/community/declarative-apps/)

--- a/platform/entrypoint.sh
+++ b/platform/entrypoint.sh
@@ -407,6 +407,8 @@ readarray apps < <(xmlstarlet sel -B \
     -o "\" \"" \
     -v "srx:binding[@name = 'endUserQuadStore']" \
     -o "\" \"" \
+    -v "srx:binding[@name = 'endUserEndpoint']" \
+    -o "\" \"" \
     -v "srx:binding[@name = 'endUserAuthUser']" \
     -o "\" \"" \
     -v "srx:binding[@name = 'endUserAuthPwd']" \
@@ -418,6 +420,8 @@ readarray apps < <(xmlstarlet sel -B \
     -v "srx:binding[@name = 'adminBase']" \
     -o "\" \"" \
     -v "srx:binding[@name = 'adminQuadStore']" \
+    -o "\" \"" \
+    -v "srx:binding[@name = 'adminEndpoint']" \
     -o "\" \"" \
     -v "srx:binding[@name = 'adminAuthUser']" \
     -o "\" \"" \
@@ -433,15 +437,17 @@ for app in "${apps[@]}"; do
     end_user_app="${app_array[0]//\"/}"
     end_user_base_uri="${app_array[1]//\"/}"
     end_user_quad_store_url="${app_array[2]//\"/}"
-    end_user_service_auth_user="${app_array[3]//\"/}"
-    end_user_service_auth_pwd="${app_array[4]//\"/}"
-    end_user_owner="${app_array[5]//\"/}"
-    admin_app="${app_array[6]//\"/}"
-    admin_base_uri="${app_array[7]//\"/}"
-    admin_quad_store_url="${app_array[8]//\"/}"
-    admin_service_auth_user="${app_array[9]//\"/}"
-    admin_service_auth_pwd="${app_array[10]//\"/}"
-    admin_owner="${app_array[11]//\"/}"
+    end_user_endpoint_url="${app_array[3]//\"/}"
+    end_user_service_auth_user="${app_array[4]//\"/}"
+    end_user_service_auth_pwd="${app_array[5]//\"/}"
+    end_user_owner="${app_array[6]//\"/}"
+    admin_app="${app_array[7]//\"/}"
+    admin_base_uri="${app_array[8]//\"/}"
+    admin_quad_store_url="${app_array[9]//\"/}"
+    admin_endpoint_url="${app_array[10]//\"/}"
+    admin_service_auth_user="${app_array[11]//\"/}"
+    admin_service_auth_pwd="${app_array[12]//\"/}"
+    admin_owner="${app_array[13]//\"/}"
 
     printf "\n### Processing dataspace. End-user app: %s Admin app: %s\n" "$end_user_app" "$admin_app"
 
@@ -623,6 +629,20 @@ if [ -n "$OIDC_REFRESH_TOKENS" ] && [ ! -f "$OIDC_REFRESH_TOKENS" ]; then
     mkdir -p "$(dirname "$OIDC_REFRESH_TOKENS")"
 
     touch "$OIDC_REFRESH_TOKENS"
+fi
+
+# if configured, generate XML sitemap: https://www.sitemaps.org/protocol.html
+
+if [ "$GENERATE_SITEMAP" = true ]; then
+    export admin_endpoint_url
+    envsubst < /var/linkeddatahub/sitemap/sitemap.rq.template > /var/linkeddatahub/sitemap/sitemap.rq
+    sitemap_results=$(mktemp)
+
+    curl -k -G -H "Accept: application/sparql-results+xml" "$end_user_endpoint_url" --data-urlencode "query@/var/linkeddatahub/sitemap/sitemap.rq" -o "$sitemap_results"
+
+    xsltproc --output "${PWD}/webapps/ROOT/sitemap.xml" /var/linkeddatahub/sitemap/sitemap.xsl "$sitemap_results"
+
+    rm "$sitemap_results"
 fi
 
 # change context configuration

--- a/platform/select-root-services.rq
+++ b/platform/select-root-services.rq
@@ -4,15 +4,17 @@ PREFIX a:       <https://w3id.org/atomgraph/core#>
 PREFIX lapp:    <https://w3id.org/atomgraph/linkeddatahub/apps#>
 PREFIX foaf:    <http://xmlns.com/foaf/0.1/>
 
-SELECT ?endUserApp ?endUserBase ?endUserQuadStore ?endUserAuthUser ?endUserAuthPwd ?endUserMaker ?adminApp ?adminBase ?adminQuadStore ?adminAuthUser ?adminAuthPwd ?adminMaker
+SELECT ?endUserApp ?endUserBase ?endUserQuadStore ?endUserEndpoint ?endUserAuthUser ?endUserAuthPwd ?endUserMaker ?adminApp ?adminBase ?adminQuadStore ?adminEndpoint ?adminAuthUser ?adminAuthPwd ?adminMaker
 {
     ?endUserApp ldt:base ?endUserBase ;
         ldt:service ?endUserService ;
         lapp:adminApplication ?adminApp .
         ?adminApp ldt:service ?adminService ;
             ldt:base ?adminBase .
-    ?endUserService a:quadStore ?endUserQuadStore .
-    ?adminService a:quadStore ?adminQuadStore .
+    ?endUserService a:quadStore ?endUserQuadStore ;
+        sd:endpoint ?endUserEndpoint .
+    ?adminService a:quadStore ?adminQuadStore ;
+        sd:endpoint ?adminEndpoint .
     OPTIONAL
     {
         ?endUserService a:authUser ?endUserAuthUser ;

--- a/platform/sitemap/sitemap.rq.template
+++ b/platform/sitemap/sitemap.rq.template
@@ -1,0 +1,29 @@
+PREFIX  rdfs: <http://www.w3.org/2000/01/rdf-schema#>
+PREFIX  acl:  <http://www.w3.org/ns/auth/acl#>
+PREFIX  dct:  <http://purl.org/dc/terms/>
+PREFIX  sioc: <http://rdfs.org/sioc/ns#>
+
+SELECT  ?loc ?lastmod
+WHERE
+  { GRAPH ?loc
+      { ?loc  a  ?Type
+        SERVICE <$admin_endpoint_url>
+          { GRAPH ?authGraph
+              { ?auth  acl:mode  acl:Read
+                  { ?auth  acl:accessTo  ?loc }
+                UNION
+                  {   { ?auth  acl:accessToClass  ?Type }
+                    UNION
+                      { ?auth  acl:accessToClass  ?Class .
+                        ?Type (rdfs:subClassOf)* ?Class
+                      }
+                  }
+              }
+          }
+        OPTIONAL
+          { ?loc  dct:created  ?created }
+        OPTIONAL
+          { ?loc  dct:modified  ?modified }
+        BIND(coalesce(?modified, ?created) AS ?lastmod)
+      }
+  }

--- a/platform/sitemap/sitemap.rq.template
+++ b/platform/sitemap/sitemap.rq.template
@@ -1,7 +1,7 @@
 PREFIX  rdfs: <http://www.w3.org/2000/01/rdf-schema#>
 PREFIX  acl:  <http://www.w3.org/ns/auth/acl#>
 PREFIX  dct:  <http://purl.org/dc/terms/>
-PREFIX  sioc: <http://rdfs.org/sioc/ns#>
+PREFIX  foaf: <http://xmlns.com/foaf/0.1/>
 
 SELECT  ?loc ?lastmod
 WHERE
@@ -9,7 +9,8 @@ WHERE
       { ?loc  a  ?Type
         SERVICE <$admin_endpoint_url>
           { GRAPH ?authGraph
-              { ?auth  acl:mode  acl:Read
+              { ?auth  acl:mode        acl:Read ;
+                       acl:agentClass  foaf:Agent
                   { ?auth  acl:accessTo  ?loc }
                 UNION
                   {   { ?auth  acl:accessToClass  ?Type }

--- a/platform/sitemap/sitemap.xsl
+++ b/platform/sitemap/sitemap.xsl
@@ -1,0 +1,40 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xsl:stylesheet version="1.0" 
+xmlns="http://www.sitemaps.org/schemas/sitemap/0.9"
+xmlns:srx="http://www.w3.org/2005/sparql-results#"
+xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
+>
+
+    <xsl:output method="xml" version="1.0" encoding="UTF-8" indent="yes" />
+    
+    <xsl:template match="/srx:sparql">
+        <urlset>
+            <xsl:apply-templates/>
+        </urlset>
+    </xsl:template>
+
+    <xsl:template match="srx:head"/>
+
+    <xsl:template match="srx:results">
+        <xsl:apply-templates/>
+    </xsl:template>
+
+    <xsl:template match="srx:result">
+        <url>
+            <xsl:apply-templates/>
+        </url>
+    </xsl:template>
+
+    <xsl:template match="srx:binding[@name = 'loc'][srx:uri]">
+        <loc>
+            <xsl:value-of select="srx:uri"/>
+        </loc>
+    </xsl:template>
+
+    <xsl:template match="srx:binding[@name = 'lastmod'][srx:literal/@datatype = 'http://www.w3.org/2001/XMLSchema#dateTime']">
+        <lastmod>
+            <xsl:value-of select="srx:literal"/>
+        </lastmod>
+    </xsl:template>
+
+</xsl:stylesheet>

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
 
     <groupId>com.atomgraph</groupId>
     <artifactId>linkeddatahub</artifactId>
-    <version>4.0.1-SNAPSHOT</version>
+    <version>4.0.1</version>
     <packaging>${packaging.type}</packaging>
 
     <name>AtomGraph LinkedDataHub</name>
@@ -46,7 +46,7 @@
         <url>https://github.com/AtomGraph/LinkedDataHub</url>
         <connection>scm:git:git://github.com/AtomGraph/LinkedDataHub.git</connection>
         <developerConnection>scm:git:git@github.com:AtomGraph/LinkedDataHub.git</developerConnection>
-        <tag>linkeddatahub-2.1.1</tag>
+        <tag>linkeddatahub-4.0.1</tag>
     </scm>
 
     <repositories>

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
 
     <groupId>com.atomgraph</groupId>
     <artifactId>linkeddatahub</artifactId>
-    <version>4.0.1</version>
+    <version>4.0.2-SNAPSHOT</version>
     <packaging>${packaging.type}</packaging>
 
     <name>AtomGraph LinkedDataHub</name>
@@ -46,7 +46,7 @@
         <url>https://github.com/AtomGraph/LinkedDataHub</url>
         <connection>scm:git:git://github.com/AtomGraph/LinkedDataHub.git</connection>
         <developerConnection>scm:git:git@github.com:AtomGraph/LinkedDataHub.git</developerConnection>
-        <tag>linkeddatahub-4.0.1</tag>
+        <tag>linkeddatahub-2.1.1</tag>
     </scm>
 
     <repositories>

--- a/scripts/sitemap/generate-sitemap.sh
+++ b/scripts/sitemap/generate-sitemap.sh
@@ -1,0 +1,13 @@
+# This script directly queries the fuseki-end-user endpoint exposed on localhost:3030. You can configure in docker-compose.override.yml like this:
+#  fuseki-end-user:
+#    ports:
+#      - 3031:3030
+
+end_user_endpoint="http://localhost:3031/ds"
+export admin_endpoint_url="http://fuseki-admin:3030/ds"
+
+envsubst < ../../platform/sitemap/sitemap.rq.template > sitemap.rq
+
+curl -k -G -H "Accept: application/sparql-results+xml" "$end_user_endpoint" --data-urlencode "query@sitemap.rq" -o results.xml
+
+docker run --rm -v "$PWD/../../platform/sitemap/sitemap.xsl":"/transform/sitemap.xsl" -v "$PWD/results.xml":"/transform/results.xml" atomgraph/saxon -s:/transform/results.xml -xsl:/transform/sitemap.xsl

--- a/src/main/webapp/WEB-INF/web.xml
+++ b/src/main/webapp/WEB-INF/web.xml
@@ -357,6 +357,7 @@ support@atomgraph.com]]></param-value>
         <url-pattern>/static/*</url-pattern>
         <url-pattern>/robots.txt</url-pattern>
         <url-pattern>/favicon.ico</url-pattern>
+        <url-pattern>/sitemap.xml</url-pattern>
     </servlet-mapping>
     <servlet-mapping>
         <servlet-name>com.atomgraph.linkeddatahub.Application</servlet-name>

--- a/src/main/webapp/static/com/atomgraph/linkeddatahub/xsl/bootstrap/2.3.2/client/chart.xsl
+++ b/src/main/webapp/static/com/atomgraph/linkeddatahub/xsl/bootstrap/2.3.2/client/chart.xsl
@@ -169,8 +169,8 @@ exclude-result-prefixes="#all"
     <!-- chart content -->
     <xsl:template match="*[@rdf:about][spin:query/@rdf:resource][ldh:chartType/@rdf:resource]" mode="ldh:RenderContent" priority="1">
         <xsl:param name="container" as="element()"/>
-        <xsl:param name="about" as="xs:anyURI"/>
-        <xsl:param name="content-uri" select="xs:anyURI(($container/@about, ixsl:get($container, 'dataset.contentUri'))[1])" as="xs:anyURI"/>
+        <xsl:param name="this" as="xs:anyURI"/>
+        <xsl:param name="content-uri" select="xs:anyURI($container/@about)" as="xs:anyURI"/>
         <xsl:variable name="query-uri" select="xs:anyURI(spin:query/@rdf:resource)" as="xs:anyURI"/>
         <xsl:variable name="chart-type" select="xs:anyURI(ldh:chartType/@rdf:resource)" as="xs:anyURI?"/>
         <xsl:variable name="category" select="ldh:categoryProperty/@rdf:resource | ldh:categoryVarName" as="xs:string?"/>
@@ -184,6 +184,7 @@ exclude-result-prefixes="#all"
         <xsl:variable name="request" as="item()*">
             <ixsl:schedule-action http-request="map{ 'method': 'GET', 'href': $request-uri, 'headers': map{ 'Accept': 'application/rdf+xml' } }">
                 <xsl:call-template name="onChartQueryLoad">
+                    <xsl:with-param name="this" select="$this"/>
                     <xsl:with-param name="content-uri" select="$content-uri"/>
                     <xsl:with-param name="query-uri" select="$query-uri"/>
                     <xsl:with-param name="chart-type" select="$chart-type"/>
@@ -212,7 +213,7 @@ exclude-result-prefixes="#all"
             </xsl:for-each>
         </xsl:variable>
         <xsl:variable name="container" select="ancestor::div[@about][1]" as="element()?"/>
-        <xsl:variable name="content-uri" select="xs:anyURI(($container/@about, ixsl:get($container, 'dataset.contentUri'))[1])" as="xs:anyURI"/>
+        <xsl:variable name="content-uri" select="xs:anyURI($container/@about)" as="xs:anyURI"/>
         <xsl:variable name="chart-canvas-id" select="ancestor::form/following-sibling::div/@id" as="xs:string"/>
         <xsl:variable name="results" select="if (ixsl:contains(ixsl:get(ixsl:get(ixsl:window(), 'LinkedDataHub.contents'), '`' || $content-uri || '`'), 'results')) then ixsl:get(ixsl:get(ixsl:get(ixsl:window(), 'LinkedDataHub.contents'), '`' || $content-uri || '`'), 'results') else root(ixsl:get(ixsl:get(ixsl:get(ixsl:window(), 'LinkedDataHub.contents'), '`' || $content-uri || '`'), 'content'))" as="document-node()"/>
                 
@@ -244,7 +245,7 @@ exclude-result-prefixes="#all"
             </xsl:for-each>
         </xsl:variable>
         <xsl:variable name="container" select="ancestor::div[@about][1]" as="element()?"/>
-        <xsl:variable name="content-uri" select="xs:anyURI(($container/@about, ixsl:get($container, 'dataset.contentUri'))[1])" as="xs:anyURI"/>
+        <xsl:variable name="content-uri" select="xs:anyURI($container/@about)" as="xs:anyURI"/>
         <xsl:variable name="chart-canvas-id" select="ancestor::form/following-sibling::div/@id" as="xs:string"/>
         <xsl:variable name="results" select="if (ixsl:contains(ixsl:get(ixsl:get(ixsl:window(), 'LinkedDataHub.contents'), '`' || $content-uri || '`'), 'results')) then ixsl:get(ixsl:get(ixsl:get(ixsl:window(), 'LinkedDataHub.contents'), '`' || $content-uri || '`'), 'results') else root(ixsl:get(ixsl:get(ixsl:get(ixsl:window(), 'LinkedDataHub.contents'), '`' || $content-uri || '`'), 'content'))" as="document-node()"/>
 
@@ -274,7 +275,7 @@ exclude-result-prefixes="#all"
             </xsl:for-each>
         </xsl:variable>
         <xsl:variable name="container" select="ancestor::div[@about][1]" as="element()?"/>
-        <xsl:variable name="content-uri" select="xs:anyURI(($container/@about, ixsl:get($container, 'dataset.contentUri'))[1])" as="xs:anyURI"/>
+        <xsl:variable name="content-uri" select="xs:anyURI($container/@about)" as="xs:anyURI"/>
         <xsl:variable name="chart-canvas-id" select="ancestor::form/following-sibling::div/@id" as="xs:string"/>
         <xsl:variable name="results" select="if (ixsl:contains(ixsl:get(ixsl:get(ixsl:window(), 'LinkedDataHub.contents'), '`' || $content-uri || '`'), 'results')) then ixsl:get(ixsl:get(ixsl:get(ixsl:window(), 'LinkedDataHub.contents'), '`' || $content-uri || '`'), 'results') else root(ixsl:get(ixsl:get(ixsl:get(ixsl:window(), 'LinkedDataHub.contents'), '`' || $content-uri || '`'), 'content'))" as="document-node()"/>
 
@@ -336,6 +337,7 @@ exclude-result-prefixes="#all"
     <xsl:template name="onChartQueryLoad">
         <xsl:context-item as="map(*)" use="required"/>
         <xsl:param name="container" as="element()"/>
+        <xsl:param name="this" as="xs:anyURI"/>
         <xsl:param name="content-uri" as="xs:anyURI"/>
         <xsl:param name="query-uri" as="xs:anyURI"/>
         <xsl:param name="chart-type" as="xs:anyURI"/>
@@ -348,6 +350,7 @@ exclude-result-prefixes="#all"
                 <xsl:for-each select="?body">
                     <xsl:variable name="query-type" select="xs:anyURI(key('resources', $query-uri)/rdf:type/@rdf:resource)" as="xs:anyURI"/>
                     <xsl:variable name="query-string" select="key('resources', $query-uri)/sp:text" as="xs:string"/>
+                    <xsl:variable name="query-string" select="replace($query-string, '$this', '&lt;' || $this || '&gt;', 'q')" as="xs:string"/>
                     <!-- TO-DO: use SPARQLBuilder to set LIMIT -->
                     <!--<xsl:variable name="query-string" select="concat($query-string, ' LIMIT 100')" as="xs:string"/>-->
                     <xsl:variable name="service-uri" select="xs:anyURI(key('resources', $query-uri)/ldh:service/@rdf:resource)" as="xs:anyURI?"/>

--- a/src/main/webapp/static/com/atomgraph/linkeddatahub/xsl/bootstrap/2.3.2/client/container.xsl
+++ b/src/main/webapp/static/com/atomgraph/linkeddatahub/xsl/bootstrap/2.3.2/client/container.xsl
@@ -360,7 +360,7 @@ exclude-result-prefixes="#all"
     
     <xsl:template name="ldh:RenderContainer">
         <xsl:param name="container" as="element()"/>
-        <xsl:param name="content-uri" select="xs:anyURI(ixsl:get($container, 'dataset.contentUri'))" as="xs:anyURI"/>
+        <xsl:param name="content-uri" select="xs:anyURI($container/@about)" as="xs:anyURI"/>
         <xsl:param name="content" as="element()?"/>
         <xsl:param name="select-string" as="xs:string"/>
         <xsl:param name="select-xml" as="document-node()"/>
@@ -778,7 +778,7 @@ exclude-result-prefixes="#all"
         </xsl:param>
         <xsl:variable name="container" select="ancestor::div[contains-token(@class, 'resource-content')]" as="element()"/>
         <xsl:variable name="results-container" select="$container//div[contains-token(@class, 'container-results')]" as="element()"/> <!-- results in the middle column -->
-        <xsl:variable name="content-uri" select="xs:anyURI(ixsl:get($container, 'dataset.contentUri'))" as="xs:anyURI"/>
+        <xsl:variable name="content-uri" select="xs:anyURI($container/@about)" as="xs:anyURI"/>
         <xsl:variable name="content" select="ixsl:get(ixsl:get(ixsl:get(ixsl:window(), 'LinkedDataHub.contents'), '`' || $content-uri || '`'), 'content')" as="element()"/>
         <xsl:variable name="active-class" select="../@class" as="xs:string"/>
         <xsl:variable name="active-mode" select="map:get($class-modes, $active-class)" as="xs:anyURI"/>
@@ -816,7 +816,7 @@ exclude-result-prefixes="#all"
     <xsl:template match="*[contains-token(@class, 'resource-content')]//ul[@class = 'pager']/li[@class = 'previous']/a[@class = 'active']" mode="ixsl:onclick">
         <xsl:variable name="event" select="ixsl:event()"/>
         <xsl:variable name="container" select="ancestor::div[contains-token(@class, 'resource-content')]" as="element()"/>
-        <xsl:variable name="content-uri" select="xs:anyURI(ixsl:get($container, 'dataset.contentUri'))" as="xs:anyURI"/>
+        <xsl:variable name="content-uri" select="xs:anyURI($container/@about)" as="xs:anyURI"/>
         <xsl:variable name="content" select="ixsl:get(ixsl:get(ixsl:get(ixsl:window(), 'LinkedDataHub.contents'), '`' || $content-uri || '`'), 'content')" as="element()"/>
         <xsl:variable name="active-mode" select="xs:anyURI(ixsl:get($container, 'dataset.contentMode'))" as="xs:anyURI"/>
         <xsl:variable name="select-string" select="ixsl:get(ixsl:get(ixsl:get(ixsl:window(), 'LinkedDataHub.contents'), '`' || $content-uri || '`'), 'select-query')" as="xs:string"/>
@@ -858,7 +858,7 @@ exclude-result-prefixes="#all"
     <xsl:template match="*[contains-token(@class, 'resource-content')]//ul[@class = 'pager']/li[@class = 'next']/a[@class = 'active']" mode="ixsl:onclick">
         <xsl:variable name="event" select="ixsl:event()"/>
         <xsl:variable name="container" select="ancestor::div[contains-token(@class, 'resource-content')]" as="element()"/>
-        <xsl:variable name="content-uri" select="xs:anyURI(ixsl:get($container, 'dataset.contentUri'))" as="xs:anyURI"/>
+        <xsl:variable name="content-uri" select="xs:anyURI($container/@about)" as="xs:anyURI"/>
         <xsl:variable name="content" select="ixsl:get(ixsl:get(ixsl:get(ixsl:window(), 'LinkedDataHub.contents'), '`' || $content-uri || '`'), 'content')" as="element()"/>
         <xsl:variable name="active-mode" select="xs:anyURI(ixsl:get($container, 'dataset.contentMode'))" as="xs:anyURI"/>
         <xsl:variable name="select-string" select="ixsl:get(ixsl:get(ixsl:get(ixsl:window(), 'LinkedDataHub.contents'), '`' || $content-uri || '`'), 'select-query')" as="xs:string"/>
@@ -899,7 +899,7 @@ exclude-result-prefixes="#all"
     
     <xsl:template match="select[contains-token(@class, 'container-order')]" mode="ixsl:onchange">
         <xsl:variable name="container" select="ancestor::div[contains-token(@class, 'resource-content')]" as="element()"/>
-        <xsl:variable name="content-uri" select="xs:anyURI(ixsl:get($container, 'dataset.contentUri'))" as="xs:anyURI"/>
+        <xsl:variable name="content-uri" select="xs:anyURI($container/@about)" as="xs:anyURI"/>
         <xsl:variable name="content" select="ixsl:get(ixsl:get(ixsl:get(ixsl:window(), 'LinkedDataHub.contents'), '`' || $content-uri || '`'), 'content')" as="element()"/>
         <xsl:variable name="active-mode" select="xs:anyURI(ixsl:get($container, 'dataset.contentMode'))" as="xs:anyURI"/>
         <xsl:variable name="predicate" select="ixsl:get(., 'value')" as="xs:anyURI?"/>
@@ -941,7 +941,7 @@ exclude-result-prefixes="#all"
     <!-- TO-DO: unify with container ORDER BY onchange -->
     <xsl:template match="button[contains-token(@class, 'btn-order-by')]" mode="ixsl:onclick">
         <xsl:variable name="container" select="ancestor::div[contains-token(@class, 'resource-content')]" as="element()"/>
-        <xsl:variable name="content-uri" select="xs:anyURI(ixsl:get($container, 'dataset.contentUri'))" as="xs:anyURI"/>
+        <xsl:variable name="content-uri" select="xs:anyURI($container/@about)" as="xs:anyURI"/>
         <xsl:variable name="content" select="ixsl:get(ixsl:get(ixsl:get(ixsl:window(), 'LinkedDataHub.contents'), '`' || $content-uri || '`'), 'content')" as="element()"/>
         <xsl:variable name="active-mode" select="xs:anyURI(ixsl:get($container, 'dataset.contentMode'))" as="xs:anyURI"/>
         <xsl:variable name="desc" select="contains(@class, 'btn-order-by-desc')" as="xs:boolean"/>
@@ -983,7 +983,7 @@ exclude-result-prefixes="#all"
     
     <xsl:template match="div[contains-token(@class, 'faceted-nav')]//*[contains-token(@class, 'nav-header')]" mode="ixsl:onclick">
         <xsl:variable name="container" select="ancestor::div[contains-token(@class, 'resource-content')]" as="element()"/>
-        <xsl:variable name="content-uri" select="xs:anyURI(ixsl:get($container, 'dataset.contentUri'))" as="xs:anyURI"/>
+        <xsl:variable name="content-uri" select="xs:anyURI($container/@about)" as="xs:anyURI"/>
         <xsl:variable name="facet-container" select="ancestor::div[contains-token(@class, 'faceted-nav')]" as="element()"/>
         <xsl:variable name="subject-var-name" select="input[@name = 'subject']/@value" as="xs:string"/>
         <xsl:variable name="predicate" select="input[@name = 'predicate']/@value" as="xs:anyURI"/>
@@ -1077,7 +1077,7 @@ exclude-result-prefixes="#all"
 
     <xsl:template match="div[contains-token(@class, 'faceted-nav')]//input[@type = 'checkbox']" mode="ixsl:onchange">
         <xsl:variable name="container" select="ancestor::div[contains-token(@class, 'resource-content')]" as="element()"/>
-        <xsl:variable name="content-uri" select="xs:anyURI(ixsl:get($container, 'dataset.contentUri'))" as="xs:anyURI"/>
+        <xsl:variable name="content-uri" select="xs:anyURI($container/@about)" as="xs:anyURI"/>
         <xsl:variable name="content" select="ixsl:get(ixsl:get(ixsl:get(ixsl:window(), 'LinkedDataHub.contents'), '`' || $content-uri || '`'), 'content')" as="element()"/>
         <xsl:variable name="active-mode" select="xs:anyURI(ixsl:get($container, 'dataset.contentMode'))" as="xs:anyURI"/>
         <xsl:variable name="var-name" select="@name" as="xs:string"/>
@@ -1120,7 +1120,7 @@ exclude-result-prefixes="#all"
     
     <xsl:template match="div[contains-token(@class, 'parallax-nav')]/ul/li/a" mode="ixsl:onclick">
         <xsl:variable name="container" select="ancestor::div[contains-token(@class, 'resource-content')]" as="element()"/>
-        <xsl:variable name="content-uri" select="xs:anyURI(ixsl:get($container, 'dataset.contentUri'))" as="xs:anyURI"/>
+        <xsl:variable name="content-uri" select="xs:anyURI($container/@about)" as="xs:anyURI"/>
         <xsl:variable name="content" select="ixsl:get(ixsl:get(ixsl:get(ixsl:window(), 'LinkedDataHub.contents'), '`' || $content-uri || '`'), 'content')" as="element()"/>
         <xsl:variable name="active-mode" select="xs:anyURI(ixsl:get($container, 'dataset.contentMode'))" as="xs:anyURI"/>
         <xsl:variable name="predicate" select="input/@value" as="xs:anyURI"/>

--- a/src/main/webapp/static/com/atomgraph/linkeddatahub/xsl/bootstrap/2.3.2/client/content.xsl
+++ b/src/main/webapp/static/com/atomgraph/linkeddatahub/xsl/bootstrap/2.3.2/client/content.xsl
@@ -132,13 +132,13 @@ exclude-result-prefixes="#all"
     <!-- SELECT query -->
     
     <xsl:template match="*[@rdf:about][rdf:type/@rdf:resource = '&sp;Select'][sp:text]" mode="ldh:RenderContent" priority="1">
-        <xsl:param name="about" as="xs:anyURI"/>
+        <xsl:param name="this" as="xs:anyURI"/>
         <xsl:param name="container" as="element()"/>
         <xsl:param name="mode" as="xs:anyURI?"/>
         <xsl:param name="refresh-content" as="xs:boolean?"/>
-        <xsl:param name="content-uri" select="xs:anyURI(ixsl:get($container, 'dataset.contentUri'))" as="xs:anyURI"/>
+        <xsl:param name="content-uri" select="xs:anyURI($container/@about)" as="xs:anyURI"/>
         <!-- set $this variable value unless getting the query string from state -->
-        <xsl:param name="select-string" select="replace(sp:text, '$this', '&lt;' || $about || '&gt;', 'q')" as="xs:string"/>
+        <xsl:param name="select-string" select="replace(sp:text, '$this', '&lt;' || $this || '&gt;', 'q')" as="xs:string"/>
         <xsl:param name="select-xml" as="document-node()">
             <xsl:variable name="select-json" as="item()">
                 <xsl:variable name="select-builder" select="ixsl:call(ixsl:get(ixsl:get(ixsl:window(), 'SPARQLBuilder'), 'SelectBuilder'), 'fromString', [ $select-string ])"/>
@@ -218,13 +218,13 @@ exclude-result-prefixes="#all"
     <!-- DESCRIBE/CONSTRUCT queries -->
     
     <xsl:template match="*[@rdf:about][rdf:type/@rdf:resource = ('&sp;Describe', '&sp;Construct')][sp:text]" mode="ldh:RenderContent" priority="1">
-        <xsl:param name="about" as="xs:anyURI"/>
+        <xsl:param name="this" as="xs:anyURI"/>
         <xsl:param name="container" as="element()"/>
         <xsl:param name="mode" as="xs:anyURI?"/>
         <xsl:param name="refresh-content" as="xs:boolean?"/>
-        <xsl:param name="content-uri" select="xs:anyURI(ixsl:get($container, 'dataset.contentUri'))" as="xs:anyURI"/>
+        <xsl:param name="content-uri" select="xs:anyURI($container/@about)" as="xs:anyURI"/>
         <!-- set $this variable value unless getting the query string from state -->
-        <xsl:param name="query-string" select="replace(sp:text, '$this', '&lt;' || $about || '&gt;', 'q')" as="xs:string"/>
+        <xsl:param name="query-string" select="replace(sp:text, '$this', '&lt;' || $this || '&gt;', 'q')" as="xs:string"/>
         <!-- service can be explicitly specified on content using ldh:service -->
         <xsl:param name="service-uri" select="xs:anyURI(ldh:service/@rdf:resource)" as="xs:anyURI?"/>
         <xsl:param name="service" select="key('resources', $service-uri, ixsl:get(ixsl:window(), 'LinkedDataHub.apps'))" as="element()?"/>
@@ -523,8 +523,8 @@ exclude-result-prefixes="#all"
 
         <xsl:choose>
             <!-- updating existing content -->
-            <xsl:when test="ixsl:contains($container, 'dataset.contentUri')">
-                <xsl:variable name="content-uri" select="ixsl:get($container, 'dataset.contentUri')" as="xs:anyURI"/>
+            <xsl:when test="$container/@about">
+                <xsl:variable name="content-uri" select="$container/@about" as="xs:anyURI"/>
                 <xsl:variable name="update-string" select="replace($content-update-string, '$this', '&lt;' || ac:uri() || '&gt;', 'q')" as="xs:string"/>
                 <xsl:variable name="update-string" select="replace($update-string, '$content', '&lt;' || $content-uri || '&gt;', 'q')" as="xs:string"/>
                 <xsl:variable name="update-string" select="replace($update-string, '$newValue', '&quot;' || $content-string || '&quot;^^&lt;&rdf;XMLLiteral&gt;', 'q')" as="xs:string"/>
@@ -581,8 +581,8 @@ exclude-result-prefixes="#all"
 
                 <xsl:choose>
                     <!-- updating existing content -->
-                    <xsl:when test="ixsl:contains($container, 'dataset.contentUri')">
-                        <xsl:variable name="content-uri" select="ixsl:get($container, 'dataset.contentUri')" as="xs:anyURI"/>
+                    <xsl:when test="$container/@about">
+                        <xsl:variable name="content-uri" select="$container/@about" as="xs:anyURI"/>
                         <xsl:variable name="update-string" select="replace($content-update-string, '$this', '&lt;' || ac:uri() || '&gt;', 'q')" as="xs:string"/>
                         <xsl:variable name="update-string" select="replace($update-string, '$content', '&lt;' || $content-uri || '&gt;', 'q')" as="xs:string"/>
                         <xsl:variable name="update-string" select="replace($update-string, '$newValue', '&lt;' || $content-value || '&gt;', 'q')" as="xs:string"/>
@@ -637,10 +637,10 @@ exclude-result-prefixes="#all"
         <xsl:if test="ixsl:call(ixsl:window(), 'confirm', [ ac:label(key('resources', 'are-you-sure', document(resolve-uri('static/com/atomgraph/linkeddatahub/xsl/bootstrap/2.3.2/translations.rdf', $ac:contextUri)))) ])">
             <xsl:choose>
                 <!-- delete existing content -->
-                <xsl:when test="ixsl:contains($container, 'dataset.contentUri')">
+                <xsl:when test="$container/@about">
                     <ixsl:set-style name="cursor" select="'progress'" object="ixsl:page()//body"/>
 
-                    <xsl:variable name="content-uri" select="ixsl:get($container, 'dataset.contentUri')" as="xs:anyURI"/>
+                    <xsl:variable name="content-uri" select="$container/@about" as="xs:anyURI"/>
                     <xsl:variable name="update-string" select="replace($content-delete-string, '$this', '&lt;' || ac:uri() || '&gt;', 'q')" as="xs:string"/>
                     <xsl:variable name="update-string" select="replace($update-string, '$content', '&lt;' || $content-uri || '&gt;', 'q')" as="xs:string"/>
                     <xsl:variable name="request-uri" select="ldh:href($ldt:base, ldh:absolute-path(ldh:href()), map{}, ac:uri())" as="xs:anyURI"/>
@@ -670,7 +670,7 @@ exclude-result-prefixes="#all"
 
         <xsl:choose>
             <!-- restore existing content -->
-            <xsl:when test="ixsl:contains($container, 'dataset.contentUri')">
+            <xsl:when test="$container/@about">
                 <xsl:variable name="textarea" select="ancestor::div[contains-token(@class, 'main')]//textarea[contains-token(@class, 'wymeditor')]" as="element()"/>
                 <xsl:variable name="old-content-string" select="string($textarea)" as="xs:string"/>
                 <xsl:variable name="content-value" select="ldh:parse-html('&lt;div&gt;' || $old-content-string || '&lt;/div&gt;', 'application/xhtml+xml')" as="document-node()"/>
@@ -701,7 +701,7 @@ exclude-result-prefixes="#all"
 
         <xsl:choose>
             <!-- updating existing content -->
-            <xsl:when test="ixsl:contains($container, 'dataset.contentUri')">
+            <xsl:when test="$container/@about">
                 <xsl:for-each select="$container">
                     <xsl:call-template name="ldh:LoadContent">
 <!--                        <xsl:with-param name="uri" select="ac:uri()"/>  content value gets read from dataset.contentValue -->
@@ -917,8 +917,8 @@ exclude-result-prefixes="#all"
         <xsl:context-item as="element()" use="required"/> <!-- container element -->
         <xsl:param name="acl-modes" as="xs:anyURI*"/>
         <xsl:param name="refresh-content" as="xs:boolean?"/>
-        <xsl:variable name="about" select="ancestor::div[@about][1]/@about" as="xs:anyURI"/>
-        <xsl:variable name="content-uri" select="(ixsl:get(., 'dataset.contentUri'), $about)[1]" as="xs:anyURI"/> <!-- fallback to @about for charts, queries etc. -->
+        <xsl:variable name="this" select="ancestor::div[@about][1]/@about" as="xs:anyURI"/>
+        <xsl:variable name="content-uri" select="(@about, $this)[1]" as="xs:anyURI"/> <!-- fallback to @about for charts, queries etc. -->
         <xsl:variable name="content-value" select="ixsl:get(., 'dataset.contentValue')" as="xs:anyURI"/> <!-- get the value of the @data-content-value attribute -->
         <xsl:variable name="mode" select="if (ixsl:contains(., 'dataset.contentMode')) then xs:anyURI(ixsl:get(., 'dataset.contentMode')) else ()" as="xs:anyURI?"/> <!-- get the value of the @data-content-mode attribute -->
         <xsl:variable name="container" select="." as="element()"/>
@@ -939,7 +939,7 @@ exclude-result-prefixes="#all"
         <xsl:variable name="request" as="item()*">
             <ixsl:schedule-action http-request="map{ 'method': 'GET', 'href': ac:document-uri($request-uri), 'headers': map{ 'Accept': 'application/rdf+xml' } }">
                 <xsl:call-template name="onContentValueLoad">
-                    <xsl:with-param name="about" select="$about"/>
+                    <xsl:with-param name="this" select="$this"/>
                     <xsl:with-param name="content-uri" select="$content-uri"/>
                     <xsl:with-param name="content-value" select="$content-value"/>
                     <xsl:with-param name="container" select="$container"/>
@@ -956,7 +956,7 @@ exclude-result-prefixes="#all"
     
     <xsl:template name="onContentValueLoad">
         <xsl:context-item as="map(*)" use="required"/>
-        <xsl:param name="about" as="xs:anyURI"/>
+        <xsl:param name="this" as="xs:anyURI"/>
         <xsl:param name="container" as="element()"/>
         <xsl:param name="container-id" select="ixsl:get($container, 'id')" as="xs:string"/>
         <xsl:param name="content-uri" as="xs:anyURI"/>
@@ -981,7 +981,7 @@ exclude-result-prefixes="#all"
                 </xsl:for-each>
 
                 <xsl:apply-templates select="$value" mode="ldh:RenderContent">
-                    <xsl:with-param name="about" select="$about"/>
+                    <xsl:with-param name="this" select="$this"/>
                     <xsl:with-param name="container" select="$container"/>
                     <xsl:with-param name="mode" select="$mode"/>
                     <xsl:with-param name="refresh-content" select="$refresh-content"/>
@@ -1022,7 +1022,7 @@ exclude-result-prefixes="#all"
                 <xsl:variable name="request" as="item()*">
                     <ixsl:schedule-action http-request="map{ 'method': 'GET', 'href': ac:document-uri($request-uri), 'headers': map{ 'Accept': 'application/rdf+xml' } }">
                         <xsl:call-template name="onContentValueLoad">
-                            <xsl:with-param name="about" select="$about"/>
+                            <xsl:with-param name="this" select="$this"/>
                             <xsl:with-param name="content-uri" select="$content-uri"/>
                             <xsl:with-param name="content-value" select="$content-value"/>
                             <xsl:with-param name="container" select="$container"/>

--- a/src/main/webapp/static/com/atomgraph/linkeddatahub/xsl/bootstrap/2.3.2/client/map.xsl
+++ b/src/main/webapp/static/com/atomgraph/linkeddatahub/xsl/bootstrap/2.3.2/client/map.xsl
@@ -325,7 +325,7 @@ exclude-result-prefixes="#all"
         <xsl:context-item as="map(*)" use="required"/>
         <xsl:param name="container" as="element()"/>
         <xsl:param name="content-id" as="xs:string"/>
-        <xsl:param name="content-uri" select="xs:anyURI(ixsl:get($container, 'dataset.contentUri'))" as="xs:anyURI"/>
+        <xsl:param name="content-uri" select="xs:anyURI($container/@about)" as="xs:anyURI"/>
         <xsl:param name="content" as="element()?"/>
         
         <ixsl:set-style name="cursor" select="'default'" object="ixsl:page()//body"/>
@@ -449,7 +449,7 @@ exclude-result-prefixes="#all"
     <!-- close popup overlay (info window) -->
     
     <xsl:template match="div[contains-token(@class, 'ol-overlay-container')]//div[contains-token(@class, 'modal-header')]/button[contains-token(@class, 'close')]" mode="ixsl:onclick" >
-        <xsl:variable name="content-uri" select="ancestor::div[ixsl:contains(., 'dataset.contentUri')][1]/ixsl:get(., 'dataset.contentUri')" as="xs:anyURI"/>
+        <xsl:variable name="content-uri" select="ancestor::div[@about][1]/@about" as="xs:anyURI"/>
         <xsl:variable name="container" select="ancestor::div[contains-token(@class, 'ol-overlay-container')]/div" as="element()"/>
         <xsl:variable name="map" select="ixsl:get(ixsl:get(ixsl:get(ixsl:window(), 'LinkedDataHub.contents'), '`' || $content-uri || '`'), 'map')"/>
         <xsl:variable name="overlay" select="ixsl:call(ixsl:call($map, 'getOverlays', []), 'getArray', [])[ ixsl:call(., 'getElement', []) is $container ]"/>

--- a/src/main/webapp/static/com/atomgraph/linkeddatahub/xsl/bootstrap/2.3.2/layout.xsl
+++ b/src/main/webapp/static/com/atomgraph/linkeddatahub/xsl/bootstrap/2.3.2/layout.xsl
@@ -35,6 +35,7 @@
     <!ENTITY spl    "http://spinrdf.org/spl#">
     <!ENTITY void   "http://rdfs.org/ns/void#">
     <!ENTITY nfo    "http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#">
+    <!ENTITY schema "https://schema.org/">
 ]>
 <xsl:stylesheet version="3.0"
 xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
@@ -71,11 +72,11 @@ xmlns:nfo="&nfo;"
 xmlns:geo="&geo;"
 xmlns:srx="&srx;"
 xmlns:google="&google;"
+xmlns:schema="&schema;"
 xmlns:bs2="http://graphity.org/xsl/bootstrap/2.3.2"
 exclude-result-prefixes="#all">
 
     <xsl:import href="imports/xml-to-string.xsl"/>
-    <xsl:import href="../../../../client/xsl/converters/RDFXML2JSON-LD.xsl"/>
     <xsl:import href="../../../../client/xsl/bootstrap/2.3.2/internal-layout.xsl"/>
     <xsl:import href="imports/default.xsl"/>
     <xsl:import href="imports/ac.xsl"/>
@@ -328,7 +329,7 @@ LIMIT   100
         <xsl:param name="load-sparql-builder" select="not($ac:mode = ('&ac;ModalMode', '&ldht;InfoWindowMode'))" as="xs:boolean"/>
         <xsl:param name="load-sparql-map" select="not($ac:mode = ('&ac;ModalMode', '&ldht;InfoWindowMode'))" as="xs:boolean"/>
         <xsl:param name="load-google-charts" select="not($ac:mode = ('&ac;ModalMode', '&ldht;InfoWindowMode'))" as="xs:boolean"/>
-        <xsl:param name="output-json-ld" select="false()" as="xs:boolean"/>
+        <xsl:param name="output-schema-org" select="true()" as="xs:boolean"/>
 
         <!-- Web-Client scripts -->
         <script type="text/javascript" src="{resolve-uri('static/js/jquery.min.js', $ac:contextUri)}" defer="defer"></script>
@@ -439,10 +440,10 @@ LIMIT   100
                 ]]>
             </script>
         </xsl:if>
-        <xsl:if test="$output-json-ld">
+        <xsl:if test="$output-schema-org">
             <!-- output structured data: https://developers.google.com/search/docs/guides/intro-structured-data -->
             <script type="application/ld+json">
-                <xsl:apply-templates select="." mode="ac:JSON-LD"/>
+                <xsl:apply-templates select="." mode="schema:BreadCrumbList"/>
             </script>
         </xsl:if>
     </xsl:template>

--- a/src/main/webapp/static/com/atomgraph/linkeddatahub/xsl/bootstrap/2.3.2/resource.xsl
+++ b/src/main/webapp/static/com/atomgraph/linkeddatahub/xsl/bootstrap/2.3.2/resource.xsl
@@ -26,12 +26,14 @@
     <!ENTITY spin   "http://spinrdf.org/spin#">
     <!ENTITY void   "http://rdfs.org/ns/void#">
     <!ENTITY nfo    "http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#">
+    <!ENTITY schema "https://schema.org/">
 ]>
 <xsl:stylesheet version="3.0"
 xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
 xmlns:xhtml="http://www.w3.org/1999/xhtml"
 xmlns:xs="http://www.w3.org/2001/XMLSchema"
 xmlns:map="http://www.w3.org/2005/xpath-functions/map"
+xmlns:json="http://www.w3.org/2005/xpath-functions"
 xmlns:lacl="&lacl;"
 xmlns:ldh="&ldh;"
 xmlns:ldht="&ldht;"
@@ -53,6 +55,7 @@ xmlns:sp="&sp;"
 xmlns:spin="&spin;"
 xmlns:geo="&geo;"
 xmlns:void="&void;"
+xmlns:schema="&schema;"
 xmlns:bs2="http://graphity.org/xsl/bootstrap/2.3.2"
 xmlns:ixsl="http://saxonica.com/ns/interactiveXSLT"
 exclude-result-prefixes="#all"
@@ -300,6 +303,17 @@ extension-element-prefixes="ixsl"
         </xsl:if>
     </xsl:template>
 
+    <!-- schema.org BREADCRUMBS -->
+    
+    <xsl:template match="*[@rdf:about]" mode="schema:BreadCrumbListItem">
+        <json:map>
+            <json:string key="@type">&schema;ListItem</json:string>
+            <json:number key="&schema;position"><xsl:value-of select="position()"/></json:number>
+            <json:string key="&schema;name"><xsl:value-of select="ac:label(.)"/></json:string>
+            <json:string key="&schema;item"><xsl:value-of select="@rdf:about"/></json:string>
+        </json:map>
+    </xsl:template>
+    
     <!-- BREADCRUMBS -->
 
     <xsl:template match="*[@rdf:about]" mode="bs2:BreadCrumbListItem">

--- a/src/main/webapp/static/com/atomgraph/linkeddatahub/xsl/bootstrap/2.3.2/resource.xsl
+++ b/src/main/webapp/static/com/atomgraph/linkeddatahub/xsl/bootstrap/2.3.2/resource.xsl
@@ -514,7 +514,7 @@ extension-element-prefixes="ixsl"
             <xsl:apply-templates select="." mode="bs2:Right"/>
                     
             <!-- render contents attached to the types of this resource using ldh:template -->
-            <xsl:param name="types" select="rdf:type/@rdf:resource" as="xs:anyURI*"/>
+            <xsl:variable name="types" select="rdf:type/@rdf:resource" as="xs:anyURI*"/>
             <xsl:variable name="content-values" select="if (exists($types) and doc-available(resolve-uri('ns?query=ASK%20%7B%7D', $ldt:base))) then (ldh:query-result(map{}, resolve-uri('ns', $ldt:base), $template-query || ' VALUES $Type { ' || string-join(for $type in $types return '&lt;' || $type || '&gt;', ' ') || ' }')//srx:binding[@name = 'content']/srx:uri/xs:anyURI(.)) else ()" as="xs:anyURI*" use-when="system-property('xsl:product-name') = 'SAXON'"/>
             <xsl:for-each select="$content-values" use-when="system-property('xsl:product-name') = 'SAXON'">
                 <xsl:if test="doc-available(ac:document-uri(.))">

--- a/src/main/webapp/static/com/atomgraph/linkeddatahub/xsl/bootstrap/2.3.2/resource.xsl
+++ b/src/main/webapp/static/com/atomgraph/linkeddatahub/xsl/bootstrap/2.3.2/resource.xsl
@@ -514,7 +514,7 @@ extension-element-prefixes="ixsl"
             <xsl:apply-templates select="." mode="bs2:Right"/>
                     
             <!-- render contents attached to the types of this resource using ldh:template -->
-            <xsl:variable name="types" select="rdf:type/@rdf:resource" as="xs:anyURI*"/>
+            <xsl:variable name="types" select="rdf:type/@rdf:resource" as="xs:anyURI*" use-when="system-property('xsl:product-name') = 'SAXON'"/>
             <xsl:variable name="content-values" select="if (exists($types) and doc-available(resolve-uri('ns?query=ASK%20%7B%7D', $ldt:base))) then (ldh:query-result(map{}, resolve-uri('ns', $ldt:base), $template-query || ' VALUES $Type { ' || string-join(for $type in $types return '&lt;' || $type || '&gt;', ' ') || ' }')//srx:binding[@name = 'content']/srx:uri/xs:anyURI(.)) else ()" as="xs:anyURI*" use-when="system-property('xsl:product-name') = 'SAXON'"/>
             <xsl:for-each select="$content-values" use-when="system-property('xsl:product-name') = 'SAXON'">
                 <xsl:if test="doc-available(ac:document-uri(.))">

--- a/src/main/webapp/static/com/atomgraph/linkeddatahub/xsl/bootstrap/2.3.2/resource.xsl
+++ b/src/main/webapp/static/com/atomgraph/linkeddatahub/xsl/bootstrap/2.3.2/resource.xsl
@@ -708,7 +708,6 @@ extension-element-prefixes="ixsl"
     <!-- ROW CONTENT -->
     
     <xsl:template match="*[@rdf:about][rdf:type/@rdf:resource = '&ldh;Content'][rdf:value[@rdf:parseType = 'Literal']/xhtml:div]" mode="bs2:RowContent" priority="2">
-        <xsl:param name="content-uri" select="@rdf:about" as="xs:string?"/>
         <xsl:param name="id" select="if (contains(@rdf:about, ac:uri() || '#')) then substring-after(@rdf:about, ac:uri() || '#') else generate-id()" as="xs:string?"/>
         <xsl:param name="class" select="'row-fluid content xhtml-content'" as="xs:string?"/>
         <xsl:param name="left-class" as="xs:string?"/>
@@ -717,10 +716,7 @@ extension-element-prefixes="ixsl"
         <xsl:param name="transclude" select="false()" as="xs:boolean"/>
         <xsl:param name="base" as="xs:anyURI?"/>
 
-        <div>
-            <xsl:if test="$content-uri">
-                <xsl:attribute name="data-content-uri" select="$content-uri"/>
-            </xsl:if>
+        <div about="{@rdf:about}">
             <xsl:if test="$id">
                 <xsl:attribute name="id" select="$id"/>
             </xsl:if>
@@ -750,7 +746,6 @@ extension-element-prefixes="ixsl"
     </xsl:template>
 
     <xsl:template match="*[@rdf:about][rdf:type/@rdf:resource = '&ldh;Content'][rdf:value/@rdf:resource]" mode="bs2:RowContent" priority="2">
-        <xsl:param name="content-uri" select="@rdf:about" as="xs:string?"/>
         <xsl:param name="id" select="if (contains(@rdf:about, ac:uri() || '#')) then substring-after(@rdf:about, ac:uri() || '#') else generate-id()" as="xs:string?"/>
         <xsl:param name="class" select="'row-fluid content resource-content'" as="xs:string?"/>
         <xsl:param name="mode" select="ac:mode/@rdf:resource" as="xs:anyURI?"/>
@@ -761,10 +756,7 @@ extension-element-prefixes="ixsl"
         <xsl:apply-templates select="." mode="bs2:RowContentHeader"/>
         
         <!-- @data-content-value is used to retrieve $content-value in client.xsl -->
-        <div data-content-value="{rdf:value/@rdf:resource}">
-            <xsl:if test="$content-uri">
-                <xsl:attribute name="data-content-uri" select="$content-uri"/>
-            </xsl:if>
+        <div about="{@rdf:about}" data-content-value="{rdf:value/@rdf:resource}">
             <xsl:if test="$id">
                 <xsl:attribute name="id" select="$id"/>
             </xsl:if>


### PR DESCRIPTION
### Added
- [XML sitemap](https://www.sitemaps.org/protocol.html) generation when env param `GENERATE_SITEMAP=true` is specified (enabled by default)
- JSON-LD output in the `<script>` tag containing [schema:BreadCrumbList](https://schema.org/BreadcrumbList) structured data

### Changed
- Content blocks use `@about` attributes as identifiers instead of `@data-content-uri`