### PR TITLE
Content drag & drop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 ## [4.0.2] - 2023-05-08
 ### Added
 - [XML sitemap](https://www.sitemaps.org/protocol.html) generation when env param `GENERATE_SITEMAP=true` is specified (enabled by default)
-- JSON-LD output in the `<script>` tag containing [schema:BreadCrumbList](https://schema.org/BreadcrumbList) structured data
+- JSON-LD output in the `<script>` tag containing [`schema:BreadCrumbList`](https://schema.org/BreadcrumbList) structured data
 
 ### Changed
 - Content blocks use `@about` attributes as identifiers instead of `@data-content-uri`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## [4.0.3] - 2023-05-24
+### Added
+- Option to re-arrange content blocks by drag & drop in content mode (enabled only when the agent has write access)
+
+### Changed
+- Instead of writing JSON-LD directly, `schema:BreadCrumbList` mode returns RDF/XML which is then transformed to JSON-LD using `ac:JSON-LD`
+
 ## [4.0.2] - 2023-05-08
 ### Added
 - [XML sitemap](https://www.sitemaps.org/protocol.html) generation when env param `GENERATE_SITEMAP=true` is specified (enabled by default)

--- a/src/main/webapp/static/com/atomgraph/linkeddatahub/css/bootstrap.css
+++ b/src/main/webapp/static/com/atomgraph/linkeddatahub/css/bootstrap.css
@@ -85,6 +85,7 @@ li button.btn-edit-constructors, li button.btn-add-data, li button.btn-add-ontol
 .parallax-nav a { cursor: pointer; }
 #content-body { min-height: calc(100% - 14em); }
 .content.row-fluid, .constructor-triple.row-fluid { border-bottom: 2px solid rgb(223, 223, 223); }
+.content.row-fluid.drag-over { border-bottom: 4px dotted #0f82f5; }
 .list-mode.active { background-image: url('../icons/ic_navigate_before_black_24px.svg'); }
 legend.create-action { background-image: url('../icons/ic_note_add_black_24px.svg'); background-position: 12px center; background-repeat: no-repeat; padding-left: 40px; }
 alert.violation { background-image: url('../icons/ic_error_white_24px.svg '); background-position: 12px center; background-repeat: no-repeat; padding-left: 40px; }

--- a/src/main/webapp/static/com/atomgraph/linkeddatahub/xsl/bootstrap/2.3.2/client/content.xsl
+++ b/src/main/webapp/static/com/atomgraph/linkeddatahub/xsl/bootstrap/2.3.2/client/content.xsl
@@ -126,7 +126,52 @@ exclude-result-prefixes="#all"
             }
         ]]>
     </xsl:variable>
+    <xsl:variable name="content-swap-string" as="xs:string">
+        <![CDATA[
+            PREFIX  xsd:  <http://www.w3.org/2001/XMLSchema#>
+            PREFIX  ldh:  <https://w3id.org/atomgraph/linkeddatahub#>
+            PREFIX  ac:   <https://w3id.org/atomgraph/client#>
+            PREFIX  rdf:  <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
+
+            DELETE {
+              $this ?sourceSeq $sourceContent .
+              $this ?targetSeq $targetContent .
+              $this ?seq ?content .
+            }
+            INSERT {
+              $this ?newSourceSeq $sourceContent .
+              $this ?newTargetSeq $targetContent .
+              $this ?newSeq ?content .
+            }
+            WHERE
+              { $this  ?sourceSeq  $sourceContent
+                BIND(xsd:integer(substr(str(?sourceSeq), 45)) AS ?sourceIndex)
+                $this  ?targetSeq  $targetContent
+                BIND(xsd:integer(substr(str(?targetSeq), 45)) AS ?targetIndex)
+                BIND(if(( ?sourceIndex < ?targetIndex ), ( ?targetIndex - 1 ), ?targetIndex) AS ?newTargetIndex)
+                BIND(if(( ?sourceIndex < ?targetIndex ), ?targetIndex, ( ?targetIndex + 1 )) AS ?newSourceIndex)
+                BIND(IRI(concat(str(rdf:), "_", str(?newSourceIndex))) AS ?newSourceSeq)
+                BIND(IRI(concat(str(rdf:), "_", str(?newTargetIndex))) AS ?newTargetSeq)
+                OPTIONAL
+                  { $this  ?sourceSeq  $sourceContent
+                    BIND(xsd:integer(substr(str(?sourceSeq), 45)) AS ?sourceIndex)
+                    $this  ?targetSeq  $targetContent
+                    BIND(xsd:integer(substr(str(?targetSeq), 45)) AS ?targetIndex)
+                    $this  ?seq  ?content
+                    FILTER strstarts(str(?seq), str(rdf:_))
+                    BIND(xsd:integer(substr(str(?seq), 45)) AS ?index)
+                    BIND(( ( ?index > ?sourceIndex ) && ( ?index < ?targetIndex ) ) AS ?isBetweenSourceAndTarget)
+                    BIND(( ( ?index < ?sourceIndex ) && ( ?index > ?targetIndex ) ) AS ?isBetweenTargetAndSource)
+                    FILTER ( ?isBetweenSourceAndTarget || ?isBetweenTargetAndSource )
+                    BIND(( ?index + if(?isBetweenSourceAndTarget, -1, +1) ) AS ?newIndex)
+                    BIND(IRI(concat(str(rdf:), "_", str(?newIndex))) AS ?newSeq)
+                  }
+              }
+        ]]>
+    </xsl:variable>
     
+    <xsl:key name="content-by-about" match="*[@about]" use="@about"/>
+
     <!-- TEMPLATES -->
 
     <!-- SELECT query -->
@@ -909,6 +954,68 @@ exclude-result-prefixes="#all"
         </xsl:for-each>
     </xsl:template>
     
+    <!-- start dragging content -->
+    
+    <xsl:template match="div[contains-token(@class, 'content')][contains-token(@class, 'row-fluid')]" mode="ixsl:ondragstart">
+        <xsl:variable name="content-uri" select="@about" as="xs:anyURI"/>
+        <ixsl:set-property name="dataTransfer.effectAllowed" select="'move'" object="ixsl:event()"/>
+        <xsl:sequence select="ixsl:call(ixsl:get(ixsl:event(), 'dataTransfer'), 'setData', [ 'text/uri-list', $content-uri ])"/>
+    </xsl:template>
+
+    <!-- dragging content over other content -->
+    
+    <xsl:template match="div[contains-token(@class, 'content')][contains-token(@class, 'row-fluid')][acl:mode() = '&acl;Write']" mode="ixsl:ondragover">
+        <xsl:sequence select="ixsl:call(ixsl:event(), 'preventDefault', [])"/>
+        <ixsl:set-property name="dataTransfer.dropEffect" select="'move'" object="ixsl:event()"/>
+    </xsl:template>
+
+    <!-- change the style of elements when content is dragged over them -->
+    
+    <xsl:template match="div[contains-token(@class, 'content')][contains-token(@class, 'row-fluid')][acl:mode() = '&acl;Write']" mode="ixsl:ondragenter">
+        <xsl:sequence select="ixsl:call(ixsl:get(., 'classList'), 'toggle', [ 'drag-over', true() ])[current-date() lt xs:date('2000-01-01')]"/>
+    </xsl:template>
+
+    <xsl:template match="div[contains-token(@class, 'content')][contains-token(@class, 'row-fluid')][acl:mode() = '&acl;Write']" mode="ixsl:ondragleave">
+        <xsl:variable name="related-target" select="ixsl:get(ixsl:event(), 'relatedTarget')" as="element()?"/> <!-- the element drag entered (optional) -->
+
+        <!-- only remove class if the related target does not have this div as ancestor (is not its child) -->
+        <xsl:if test="not($related-target/ancestor-or-self::div[. is current()])">
+            <xsl:sequence select="ixsl:call(ixsl:get(., 'classList'), 'toggle', [ 'drag-over', false() ])[current-date() lt xs:date('2000-01-01')]"/>
+        </xsl:if>
+    </xsl:template>
+
+    <!-- dropping content over other content -->
+    
+    <xsl:template match="div[contains-token(@class, 'content')][contains-token(@class, 'row-fluid')][acl:mode() = '&acl;Write']" mode="ixsl:ondrop">
+        <xsl:sequence select="ixsl:call(ixsl:event(), 'preventDefault', [])"/>
+        <xsl:variable name="container" select="." as="element()"/>
+        <xsl:variable name="content-uri" select="@about" as="xs:anyURI"/>
+        <xsl:variable name="drop-content-uri" select="ixsl:call(ixsl:get(ixsl:event(), 'dataTransfer'), 'getData', [ 'text/uri-list' ])" as="xs:anyURI"/>
+        
+        <xsl:sequence select="ixsl:call(ixsl:get(., 'classList'), 'toggle', [ 'drag-over', false() ])[current-date() lt xs:date('2000-01-01')]"/>
+
+        <!-- move dropped element after this element, if they're not the same -->
+        <xsl:if test="not($content-uri = $drop-content-uri)">
+            <ixsl:set-style name="cursor" select="'progress'" object="ixsl:page()//body"/>
+
+            <xsl:variable name="drop-content" select="key('content-by-about', $drop-content-uri)" as="element()"/>
+            <xsl:sequence select="ixsl:call(., 'after', [ $drop-content ])"/>
+            
+            <xsl:variable name="update-string" select="replace($content-swap-string, '$this', '&lt;' || ac:uri() || '&gt;', 'q')" as="xs:string"/>
+            <xsl:variable name="update-string" select="replace($update-string, '$targetContent', '&lt;' || $content-uri || '&gt;', 'q')" as="xs:string"/>
+            <xsl:variable name="update-string" select="replace($update-string, '$sourceContent', '&lt;' || $drop-content-uri || '&gt;', 'q')" as="xs:string"/>
+            <xsl:variable name="request-uri" select="ldh:href($ldt:base, ldh:absolute-path(ldh:href()), map{}, ac:uri())" as="xs:anyURI"/>
+            <xsl:variable name="request" as="item()*">
+                <ixsl:schedule-action http-request="map{ 'method': 'PATCH', 'href': $request-uri, 'media-type': 'application/sparql-update', 'body': $update-string }">
+                    <xsl:call-template name="onContentSwap">
+                        <xsl:with-param name="container" select="$container"/>
+                    </xsl:call-template>
+                </ixsl:schedule-action>
+            </xsl:variable>
+            <xsl:sequence select="$request[current-date() lt xs:date('2000-01-01')]"/>
+        </xsl:if>
+    </xsl:template>
+    
     <!-- CALLBACKS -->
     
     <!-- load content -->
@@ -1180,6 +1287,23 @@ exclude-result-prefixes="#all"
             </xsl:when>
             <xsl:otherwise>
                 <xsl:sequence select="ixsl:call(ixsl:window(), 'alert', [ 'Could not delete content' ])[current-date() lt xs:date('2000-01-01')]"/>
+            </xsl:otherwise>
+        </xsl:choose>
+    </xsl:template>
+    
+    <!-- content swap (drag & drop) -->
+    
+    <xsl:template name="onContentSwap">
+        <xsl:context-item as="map(*)" use="required"/>
+        <xsl:param name="container" as="element()"/>
+
+        <ixsl:set-style name="cursor" select="'default'" object="ixsl:page()//body"/>
+        
+        <xsl:choose>
+            <xsl:when test="?status = 200">
+            </xsl:when>
+            <xsl:otherwise>
+                <xsl:sequence select="ixsl:call(ixsl:window(), 'alert', [ 'Could not swap content' ])[current-date() lt xs:date('2000-01-01')]"/>
             </xsl:otherwise>
         </xsl:choose>
     </xsl:template>

--- a/src/main/webapp/static/com/atomgraph/linkeddatahub/xsl/bootstrap/2.3.2/client/graph.xsl
+++ b/src/main/webapp/static/com/atomgraph/linkeddatahub/xsl/bootstrap/2.3.2/client/graph.xsl
@@ -116,7 +116,7 @@ exclude-result-prefixes="#all"
             <xsl:variable name="selected-node" select="ixsl:get(ixsl:window(), 'LinkedDataHub.graph.selected-node')" as="element()"/>
             <xsl:variable name="offset-x" select="ixsl:get(ixsl:window(), 'LinkedDataHub.graph.offset-x')"/>
             <xsl:variable name="offset-y" select="ixsl:get(ixsl:window(), 'LinkedDataHub.graph.offset-y')"/>
-            <!-- add the mouse offset within the element which was stored in onmousedown -->?
+            <!-- add the mouse offset within the element which was stored in onmousedown -->
             <xsl:variable name="dom-x" select="ixsl:get(ixsl:event(), 'clientX') + $offset-x"/>
             <xsl:variable name="dom-y" select="ixsl:get(ixsl:event(), 'clientY') + $offset-y"/>
             <xsl:variable name="point" select="ldh:new('DOMPoint', [ $dom-x, $dom-y ])"/>

--- a/src/main/webapp/static/com/atomgraph/linkeddatahub/xsl/bootstrap/2.3.2/document.xsl
+++ b/src/main/webapp/static/com/atomgraph/linkeddatahub/xsl/bootstrap/2.3.2/document.xsl
@@ -69,17 +69,20 @@ extension-element-prefixes="ixsl"
 
         <xsl:if test="$resource">
             <xsl:variable name="doc-with-ancestors" select="ldh:doc-with-ancestors($resource)" as="element()*"/>
-            <xsl:variable name="json-xml" as="element()">
-                <json:map>
-                    <json:string key="@type">&schema;BreadcrumbList</json:string>
 
-                    <json:array key="&schema;itemListElement">
-                        <!-- position index has to start from Root=1, so we need to reverse the ancestor sequence -->
-                        <xsl:apply-templates select="reverse($doc-with-ancestors)" mode="schema:BreadCrumbListItem"/>
-                    </json:array>
-                </json:map>
-            </xsl:variable>
-            <xsl:sequence select="xml-to-json($json-xml)"/>
+            <rdf:RDF>
+                <rdf:Description rdf:nodeID="breadcrumb-list">
+                    <rdf:type rdf:resource="&schema;BreadcrumbList"/>
+
+                    <!-- position index has to start from Root=1, so we need to reverse the ancestor sequence -->
+                    <xsl:for-each select="reverse($doc-with-ancestors)">
+                        <schema:itemListElement rdf:nodeID="item{position()}"/> <!-- rdf:nodeID aligned with schema:BreadCrumbListItem output -->
+                    </xsl:for-each>
+                </rdf:Description>
+
+                <!-- position index has to start from Root=1, so we need to reverse the ancestor sequence -->
+                <xsl:apply-templates select="reverse($doc-with-ancestors)" mode="schema:BreadCrumbListItem"/>
+            </rdf:RDF>
         </xsl:if>
     </xsl:template>
 

--- a/src/main/webapp/static/com/atomgraph/linkeddatahub/xsl/bootstrap/2.3.2/layout.xsl
+++ b/src/main/webapp/static/com/atomgraph/linkeddatahub/xsl/bootstrap/2.3.2/layout.xsl
@@ -77,6 +77,7 @@ xmlns:bs2="http://graphity.org/xsl/bootstrap/2.3.2"
 exclude-result-prefixes="#all">
 
     <xsl:import href="imports/xml-to-string.xsl"/>
+    <xsl:import href="../../../../client/xsl/converters/RDFXML2JSON-LD.xsl"/>
     <xsl:import href="../../../../client/xsl/bootstrap/2.3.2/internal-layout.xsl"/>
     <xsl:import href="imports/default.xsl"/>
     <xsl:import href="imports/ac.xsl"/>
@@ -441,10 +442,18 @@ LIMIT   100
             </script>
         </xsl:if>
         <xsl:if test="$output-schema-org">
-            <!-- output structured data: https://developers.google.com/search/docs/guides/intro-structured-data -->
-            <script type="application/ld+json">
+            <xsl:variable name="rdf" as="element()?">
                 <xsl:apply-templates select="." mode="schema:BreadCrumbList"/>
-            </script>
+            </xsl:variable>
+            <xsl:if test="exists($rdf)">
+                <!-- output structured data: https://developers.google.com/search/docs/guides/intro-structured-data -->
+                <script type="application/ld+json">
+                    <xsl:variable name="json-xml" as="element()">
+                        <xsl:apply-templates select="$rdf" mode="ac:JSON-LD"/>
+                    </xsl:variable>
+                    <xsl:sequence select="xml-to-json($json-xml)"/>
+                </script>
+            </xsl:if>
         </xsl:if>
     </xsl:template>
     

--- a/src/main/webapp/static/com/atomgraph/linkeddatahub/xsl/bootstrap/2.3.2/resource.xsl
+++ b/src/main/webapp/static/com/atomgraph/linkeddatahub/xsl/bootstrap/2.3.2/resource.xsl
@@ -305,13 +305,13 @@ extension-element-prefixes="ixsl"
 
     <!-- schema.org BREADCRUMBS -->
     
-    <xsl:template match="*[@rdf:about]" mode="schema:BreadCrumbListItem">
-        <json:map>
-            <json:string key="@type">&schema;ListItem</json:string>
-            <json:number key="&schema;position"><xsl:value-of select="position()"/></json:number>
-            <json:string key="&schema;name"><xsl:value-of select="ac:label(.)"/></json:string>
-            <json:string key="&schema;item"><xsl:value-of select="@rdf:about"/></json:string>
-        </json:map>
+    <xsl:template match="*[@rdf:about]" mode="schema:BreadCrumbListItem" as="element()">
+        <rdf:Description rdf:nodeID="item{position()}">
+            <rdf:type rdf:resource="&schema;ListItem"/>
+            <schema:position><xsl:value-of select="position()"/></schema:position>
+            <schema:name><xsl:value-of select="ac:label(.)"/></schema:name>
+            <schema:item><xsl:value-of select="@rdf:about"/></schema:item>
+        </rdf:Description>
     </xsl:template>
     
     <!-- BREADCRUMBS -->
@@ -730,7 +730,7 @@ extension-element-prefixes="ixsl"
         <xsl:param name="transclude" select="false()" as="xs:boolean"/>
         <xsl:param name="base" as="xs:anyURI?"/>
 
-        <div about="{@rdf:about}">
+        <div about="{@rdf:about}" draggable="true">
             <xsl:if test="$id">
                 <xsl:attribute name="id" select="$id"/>
             </xsl:if>
@@ -770,7 +770,7 @@ extension-element-prefixes="ixsl"
         <xsl:apply-templates select="." mode="bs2:RowContentHeader"/>
         
         <!-- @data-content-value is used to retrieve $content-value in client.xsl -->
-        <div about="{@rdf:about}" data-content-value="{rdf:value/@rdf:resource}">
+        <div about="{@rdf:about}" data-content-value="{rdf:value/@rdf:resource}" draggable="true">
             <xsl:if test="$id">
                 <xsl:attribute name="id" select="$id"/>
             </xsl:if>


### PR DESCRIPTION
### Added
- Option to re-arrange content blocks by drag & drop in content mode (enabled only when the agent has write access) - fixes #151

### Changed
- Instead of writing JSON-LD directly, `schema:BreadCrumbList` mode returns RDF/XML which is then transformed to JSON-LD using `ac:JSON-LD`