### PR TITLE
Config option to skip authorization checks on `HEAD` and `GET`

### DIFF
--- a/src/main/java/com/atomgraph/linkeddatahub/apps/model/Application.java
+++ b/src/main/java/com/atomgraph/linkeddatahub/apps/model/Application.java
@@ -71,11 +71,10 @@ public interface Application extends Resource, com.atomgraph.processor.model.App
     Resource getStylesheet();
     
     /**
-     * Returns true if application is read-only.
-     * Read-only application does not allow changes to its state.
+     * Returns true if read methods are allowed without authorization.
      * 
      * @return true if read-only
      */
-    boolean isReadOnly();
+    boolean isReadAllowed();
     
 }

--- a/src/main/java/com/atomgraph/linkeddatahub/apps/model/impl/ApplicationImpl.java
+++ b/src/main/java/com/atomgraph/linkeddatahub/apps/model/impl/ApplicationImpl.java
@@ -95,9 +95,9 @@ public class ApplicationImpl extends ResourceImpl implements Application
     }
 
     @Override
-    public boolean isReadOnly()
+    public boolean isReadAllowed()
     {
-        Statement stmt = getProperty(LAPP.readOnly);
+        Statement stmt = getProperty(LAPP.allowRead);
         
         if (stmt != null) return stmt.getBoolean();
         

--- a/src/main/java/com/atomgraph/linkeddatahub/server/filter/request/AuthorizationFilter.java
+++ b/src/main/java/com/atomgraph/linkeddatahub/server/filter/request/AuthorizationFilter.java
@@ -120,17 +120,13 @@ public class AuthorizationFilter implements ContainerRequestFilter
             return;
         }
         
-        if (getApplication().isReadOnly())
+        if (getApplication().isReadAllowed())
         {
             if (request.getMethod().equals(HttpMethod.GET) || request.getMethod().equals(HttpMethod.HEAD)) // allow read-only methods
             {
-                if (log.isTraceEnabled()) log.trace("App is read-only, skipping authorization for request URI: {}", request.getUriInfo().getAbsolutePath());
+                if (log.isTraceEnabled()) log.trace("Read methods are allowed on app, skipping authorization for request URI: {}", request.getUriInfo().getAbsolutePath());
                 return;
             }
-
-            // throw 403 exception otherwise
-            if (log.isTraceEnabled()) log.trace("Write access not authorized (app is read-only) for request URI: {}", request.getUriInfo().getAbsolutePath());
-            throw new AuthorizationException("Write access not authorized (app is read-only)", request.getUriInfo().getAbsolutePath(), accessMode);
         }
 
         if (getDataset().isPresent()) return; // skip proxied dataspaces

--- a/src/main/java/com/atomgraph/linkeddatahub/vocabulary/LAPP.java
+++ b/src/main/java/com/atomgraph/linkeddatahub/vocabulary/LAPP.java
@@ -77,6 +77,6 @@ public class LAPP
     public static final ObjectProperty prefix = m_model.createObjectProperty( NS + "prefix" );
     
     /** Read-only property */
-    public static final DatatypeProperty readOnly = m_model.createDatatypeProperty( NS + "readOnly" );
+    public static final DatatypeProperty allowRead = m_model.createDatatypeProperty( NS + "allowRead" );
 
 }

--- a/src/main/resources/com/atomgraph/linkeddatahub/lapp.ttl
+++ b/src/main/resources/com/atomgraph/linkeddatahub/lapp.ttl
@@ -53,6 +53,13 @@
     rdfs:comment "If true, this application can be listed as public (ACL still applies). If false, it is private and will not be listed" ;
     rdfs:isDefinedBy : .
 
+:allowRead a owl:DatatypeProperty ;
+    rdfs:domain :Application ;
+    rdfs:range xsd:boolean ;
+    rdfs:label "Allow read" ;
+    rdfs:comment "If true, this application allows GET an HEAD methods for all request URIs without authorization check" ;
+    rdfs:isDefinedBy : .
+
 # CLASSES
 
 # dataset


### PR DESCRIPTION
Enabled by setting `lapp:allowRead` on app instances in the system config.