### PR TITLE
Allow proxying to registered lapp:Application endpoints regardless of…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## [5.3.5] - 2026-04-06
+### Changed
+- `ProxyRequestFilter` now proxies all HTTP methods generically instead of whitelisting GET/POST/PUT/PATCH/DELETE
+- Allow proxying to registered `lapp:Application` endpoints regardless of `ENABLE_LINKED_DATA_PROXY`
+
 ## [5.3.4] - 2026-04-05
 ### Fixed
 - Do not append facet well into left-nav when there are no BGP triples

--- a/pom.xml
+++ b/pom.xml
@@ -182,6 +182,12 @@
             <version>4.13.2</version>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-core</artifactId>
+            <version>5.12.0</version>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>

--- a/src/main/java/com/atomgraph/linkeddatahub/server/filter/request/ProxyRequestFilter.java
+++ b/src/main/java/com/atomgraph/linkeddatahub/server/filter/request/ProxyRequestFilter.java
@@ -151,9 +151,9 @@ public class ProxyRequestFilter implements ContainerRequestFilter
 
         try
         {
-            Invocation.Builder builder = target.request()
-                .accept(readableMediaTypesArray)
-                .header(HttpHeaders.USER_AGENT, GraphStoreClient.USER_AGENT);
+            Invocation.Builder builder = target.request().
+                accept(readableMediaTypesArray).
+                header(HttpHeaders.USER_AGENT, GraphStoreClient.USER_AGENT);
 
             Response clientResponse = requestContext.hasEntity()
                 ? builder.method(requestContext.getMethod(),

--- a/src/main/java/com/atomgraph/linkeddatahub/server/filter/request/ProxyRequestFilter.java
+++ b/src/main/java/com/atomgraph/linkeddatahub/server/filter/request/ProxyRequestFilter.java
@@ -38,12 +38,12 @@ import java.util.List;
 import java.util.Optional;
 import jakarta.annotation.Priority;
 import jakarta.inject.Inject;
-import jakarta.ws.rs.HttpMethod;
 import jakarta.ws.rs.NotAcceptableException;
 import jakarta.ws.rs.NotAllowedException;
 import jakarta.ws.rs.Priorities;
 import jakarta.ws.rs.ProcessingException;
 import jakarta.ws.rs.client.Entity;
+import jakarta.ws.rs.client.Invocation;
 import jakarta.ws.rs.client.WebTarget;
 import jakarta.ws.rs.container.ContainerRequestContext;
 import jakarta.ws.rs.container.ContainerRequestFilter;
@@ -151,33 +151,14 @@ public class ProxyRequestFilter implements ContainerRequestFilter
 
         try
         {
-            Response clientResponse = switch (requestContext.getMethod())
-            {
-                case HttpMethod.GET ->
-                    target.request(readableMediaTypesArray)
-                        .header(HttpHeaders.USER_AGENT, GraphStoreClient.USER_AGENT)
-                        .get();
-                case HttpMethod.POST ->
-                    target.request()
-                        .accept(readableMediaTypesArray)
-                        .header(HttpHeaders.USER_AGENT, GraphStoreClient.USER_AGENT)
-                        .post(Entity.entity(requestContext.getEntityStream(), requestContext.getMediaType()));
-                case "PATCH" ->
-                    target.request()
-                        .accept(readableMediaTypesArray)
-                        .header(HttpHeaders.USER_AGENT, GraphStoreClient.USER_AGENT)
-                        .method("PATCH", Entity.entity(requestContext.getEntityStream(), requestContext.getMediaType()));
-                case HttpMethod.PUT ->
-                    target.request()
-                        .accept(readableMediaTypesArray)
-                        .header(HttpHeaders.USER_AGENT, GraphStoreClient.USER_AGENT)
-                        .put(Entity.entity(requestContext.getEntityStream(), requestContext.getMediaType()));
-                case HttpMethod.DELETE ->
-                    target.request()
-                        .header(HttpHeaders.USER_AGENT, GraphStoreClient.USER_AGENT)
-                        .delete();
-                default -> throw new NotAllowedException(requestContext.getMethod());
-            };
+            Invocation.Builder builder = target.request()
+                .accept(readableMediaTypesArray)
+                .header(HttpHeaders.USER_AGENT, GraphStoreClient.USER_AGENT);
+
+            Response clientResponse = requestContext.hasEntity()
+                ? builder.method(requestContext.getMethod(),
+                    Entity.entity(requestContext.getEntityStream(), requestContext.getMediaType()))
+                : builder.method(requestContext.getMethod());
 
             try (clientResponse)
             {

--- a/src/main/java/com/atomgraph/linkeddatahub/server/filter/request/ProxyRequestFilter.java
+++ b/src/main/java/com/atomgraph/linkeddatahub/server/filter/request/ProxyRequestFilter.java
@@ -123,7 +123,9 @@ public class ProxyRequestFilter implements ContainerRequestFilter
             return;
         }
 
-        if (!getSystem().isEnableLinkedDataProxy()) throw new NotAllowedException("Linked Data proxy not enabled");
+        boolean isRegisteredApp = getSystem().matchApp(targetURI) != null;
+        if (!isRegisteredApp && !getSystem().isEnableLinkedDataProxy())
+            throw new NotAllowedException("Linked Data proxy not enabled");
         // LNK-009: validate that the target URI is not an internal/private address (SSRF protection)
         getSystem().getURLValidator().validate(targetURI);
 

--- a/src/main/java/com/atomgraph/linkeddatahub/server/filter/request/ProxyRequestFilter.java
+++ b/src/main/java/com/atomgraph/linkeddatahub/server/filter/request/ProxyRequestFilter.java
@@ -143,8 +143,8 @@ public class ProxyRequestFilter implements ContainerRequestFilter
         }
 
         List<MediaType> readableMediaTypesList = new ArrayList<>();
-        readableMediaTypesList.addAll(mediaTypes.getReadable(Model.class));
-        readableMediaTypesList.addAll(mediaTypes.getReadable(ResultSet.class));
+        readableMediaTypesList.addAll(getMediaTypes().getReadable(Model.class));
+        readableMediaTypesList.addAll(getMediaTypes().getReadable(ResultSet.class));
         MediaType[] readableMediaTypesArray = readableMediaTypesList.toArray(MediaType[]::new);
 
         if (log.isDebugEnabled()) log.debug("Proxying {} {} → {}", requestContext.getMethod(), requestContext.getUriInfo().getRequestUri(), targetURI);
@@ -259,11 +259,11 @@ public class ProxyRequestFilter implements ContainerRequestFilter
     protected Response getResponse(Model model, Response.StatusType statusType)
     {
         List<Variant> variants = com.atomgraph.core.model.impl.Response.getVariants(
-            mediaTypes.getWritable(Model.class),
+            getMediaTypes().getWritable(Model.class),
             getSystem().getSupportedLanguages(),
             new ArrayList<>());
 
-        return new com.atomgraph.core.model.impl.Response(request,
+        return new com.atomgraph.core.model.impl.Response(getRequest(),
                 model,
                 null,
                 new EntityTag(Long.toHexString(ModelUtils.hashModel(model))),
@@ -287,11 +287,11 @@ public class ProxyRequestFilter implements ContainerRequestFilter
         resultSet.reset();
 
         List<Variant> variants = com.atomgraph.core.model.impl.Response.getVariants(
-            mediaTypes.getWritable(ResultSet.class),
+            getMediaTypes().getWritable(ResultSet.class),
             getSystem().getSupportedLanguages(),
             new ArrayList<>());
 
-        return new com.atomgraph.core.model.impl.Response(request,
+        return new com.atomgraph.core.model.impl.Response(getRequest(),
                 resultSet,
                 null,
                 new EntityTag(Long.toHexString(hash)),
@@ -310,6 +310,26 @@ public class ProxyRequestFilter implements ContainerRequestFilter
     public com.atomgraph.linkeddatahub.Application getSystem()
     {
         return system;
+    }
+
+    /**
+     * Returns the media types registry.
+     *
+     * @return media types
+     */
+    public MediaTypes getMediaTypes()
+    {
+        return mediaTypes;
+    }
+
+    /**
+     * Returns the JAX-RS request.
+     *
+     * @return request
+     */
+    public Request getRequest()
+    {
+        return request;
     }
 
 }

--- a/src/test/java/com/atomgraph/linkeddatahub/server/filter/request/ProxyRequestFilterTest.java
+++ b/src/test/java/com/atomgraph/linkeddatahub/server/filter/request/ProxyRequestFilterTest.java
@@ -1,0 +1,139 @@
+/**
+ *  Copyright 2025 Martynas Jusevičius <martynas@atomgraph.com>
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ */
+package com.atomgraph.linkeddatahub.server.filter.request;
+
+import com.atomgraph.client.MediaTypes;
+import com.atomgraph.client.util.DataManager;
+import com.atomgraph.linkeddatahub.server.security.AgentContext;
+import com.atomgraph.linkeddatahub.server.util.URLValidator;
+import com.atomgraph.linkeddatahub.vocabulary.LAPP;
+import jakarta.ws.rs.NotAllowedException;
+import jakarta.ws.rs.client.Client;
+import jakarta.ws.rs.client.Invocation;
+import jakarta.ws.rs.client.WebTarget;
+import jakarta.ws.rs.container.ContainerRequestContext;
+import jakarta.ws.rs.core.MediaType;
+import jakarta.ws.rs.core.MultivaluedHashMap;
+import jakarta.ws.rs.core.Request;
+import jakarta.ws.rs.core.Response;
+import jakarta.ws.rs.core.UriInfo;
+import java.io.IOException;
+import java.net.URI;
+import java.util.List;
+import org.apache.jena.query.ResultSet;
+import org.apache.jena.rdf.model.Model;
+import org.apache.jena.rdf.model.Resource;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.when;
+
+/**
+ * Unit tests for {@link ProxyRequestFilter}.
+ *
+ * @author Martynas Jusevičius {@literal <martynas@atomgraph.com>}
+ */
+@RunWith(MockitoJUnitRunner.Silent.class)
+public class ProxyRequestFilterTest
+{
+
+    @Mock com.atomgraph.linkeddatahub.Application system;
+    @Mock MediaTypes mediaTypes;
+    @Mock Request request;
+
+    @InjectMocks ProxyRequestFilter filter;
+
+    @Mock ContainerRequestContext requestContext;
+    @Mock UriInfo uriInfo;
+    @Mock DataManager dataManager;
+    @Mock URLValidator urlValidator;
+    @Mock Client externalClient;
+    @Mock WebTarget webTarget;
+    @Mock Invocation.Builder invocationBuilder;
+    @Mock Response clientResponse;
+    @Mock Resource registeredApp;
+
+    private static final URI ADMIN_URI = URI.create("https://admin.localhost:4443/");
+    private static final URI EXTERNAL_URI = URI.create("https://example.com/data");
+
+    @Before
+    public void setUp()
+    {
+        when(requestContext.getUriInfo()).thenReturn(uriInfo);
+        when(requestContext.getProperty(LAPP.Application.getURI())).thenReturn(null);
+        when(requestContext.getProperty(LAPP.Dataset.getURI())).thenReturn(null);
+        when(system.getDataManager()).thenReturn(dataManager);
+        when(dataManager.isMapped(anyString())).thenReturn(false);
+        when(system.isEnableLinkedDataProxy()).thenReturn(false);
+    }
+
+    /**
+     * When the proxy is disabled, a {@code ?uri=} pointing to an unregistered external URL must be blocked.
+     */
+    @Test(expected = NotAllowedException.class)
+    public void testUnregisteredUriBlockedWhenProxyDisabled() throws IOException
+    {
+        MultivaluedHashMap<String, String> params = new MultivaluedHashMap<>();
+        params.putSingle("uri", EXTERNAL_URI.toString());
+        when(uriInfo.getQueryParameters()).thenReturn(params);
+
+        filter.filter(requestContext);
+    }
+
+    /**
+     * When the proxy is disabled, a {@code ?uri=} pointing to a registered {@code lapp:Application}
+     * must be allowed through — it is a first-party endpoint, not a third-party resource.
+     */
+    @Test
+    public void testRegisteredAppAllowedWhenProxyDisabled() throws IOException
+    {
+        MultivaluedHashMap<String, String> params = new MultivaluedHashMap<>();
+        params.putSingle("uri", ADMIN_URI.toString());
+        when(uriInfo.getQueryParameters()).thenReturn(params);
+
+        // matchApp() returns a non-null Resource for the admin app (registered lapp:Application)
+        when(system.matchApp(ADMIN_URI)).thenReturn(registeredApp);
+
+        // SSRF validator is a no-op (mock void method)
+        when(system.getURLValidator()).thenReturn(urlValidator);
+
+        // HTTP call chain: GET to the admin app
+        when(system.getExternalClient()).thenReturn(externalClient);
+        when(requestContext.getMethod()).thenReturn("GET");
+        when(requestContext.getProperty(AgentContext.class.getCanonicalName())).thenReturn(null);
+        when(mediaTypes.getReadable(Model.class)).thenReturn(List.of());
+        when(mediaTypes.getReadable(ResultSet.class)).thenReturn(List.of());
+        when(externalClient.target(ADMIN_URI)).thenReturn(webTarget);
+        when(webTarget.request(any(MediaType[].class))).thenReturn(invocationBuilder);
+        when(invocationBuilder.header(anyString(), any())).thenReturn(invocationBuilder);
+        when(invocationBuilder.get()).thenReturn(clientResponse);
+
+        // null media type triggers the early-return path in getResponse(Response)
+        when(clientResponse.getHeaders()).thenReturn(new MultivaluedHashMap<>());
+        when(clientResponse.getMediaType()).thenReturn(null);
+        when(clientResponse.getStatus()).thenReturn(200);
+
+        filter.filter(requestContext); // must not throw NotAllowedException
+    }
+
+}

--- a/src/test/java/com/atomgraph/linkeddatahub/server/filter/request/ProxyRequestFilterTest.java
+++ b/src/test/java/com/atomgraph/linkeddatahub/server/filter/request/ProxyRequestFilterTest.java
@@ -124,9 +124,10 @@ public class ProxyRequestFilterTest
         when(mediaTypes.getReadable(Model.class)).thenReturn(List.of());
         when(mediaTypes.getReadable(ResultSet.class)).thenReturn(List.of());
         when(externalClient.target(ADMIN_URI)).thenReturn(webTarget);
-        when(webTarget.request(any(MediaType[].class))).thenReturn(invocationBuilder);
+        when(webTarget.request()).thenReturn(invocationBuilder);
+        when(invocationBuilder.accept(any(MediaType[].class))).thenReturn(invocationBuilder);
         when(invocationBuilder.header(anyString(), any())).thenReturn(invocationBuilder);
-        when(invocationBuilder.get()).thenReturn(clientResponse);
+        when(invocationBuilder.method(anyString())).thenReturn(clientResponse);
 
         // null media type triggers the early-return path in getResponse(Response)
         when(clientResponse.getHeaders()).thenReturn(new MultivaluedHashMap<>());

--- a/src/test/resources/mockito-extensions/org.mockito.plugins.MockMaker
+++ b/src/test/resources/mockito-extensions/org.mockito.plugins.MockMaker
@@ -1,0 +1,1 @@
+mock-maker-subclass


### PR DESCRIPTION
… ENABLE_LINKED_DATA_PROXY

When ENABLE_LINKED_DATA_PROXY=false, requests to registered lapp:Application base URIs (e.g. demo.linkeddatahub.com from linkeddatahub.com) were incorrectly blocked. These are first-party endpoints, not third-party proxy targets.

ProxyRequestFilter now calls matchApp(targetURI) before the proxy-enabled check; if the target's origin matches a registered application, the check is skipped. SSRF validation is preserved for all requests.