### PR TITLE
Enable gzip compression in nginx for RDF and JSON content types

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -193,6 +193,24 @@ configs:
 
           client_max_body_size ${MAX_CONTENT_LENGTH:-2097152};
 
+          gzip on;
+          gzip_types
+              application/json
+              application/ld+json
+              application/rdf+xml
+              application/sparql-results+json
+              application/sparql-results+xml
+              application/trig
+              application/n-quads
+              application/n-triples
+              application/xml
+              text/turtle
+              text/css
+              text/javascript
+              application/javascript
+              image/svg+xml;
+          gzip_min_length 1024;
+
           # server with optional client cert authentication
           server {
               listen 8443 ssl;

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -194,6 +194,7 @@ configs:
           client_max_body_size ${MAX_CONTENT_LENGTH:-2097152};
 
           gzip on;
+          gzip_proxied any;
           gzip_types
               application/json
               application/ld+json

--- a/http-tests/misc/gzip-rdfxml.sh
+++ b/http-tests/misc/gzip-rdfxml.sh
@@ -9,9 +9,10 @@ purge_cache "$FRONTEND_VARNISH_SERVICE"
 
 # Test that nginx gzip compression is active for RDF/XML dynamic content
 
-response=$(curl -i -k -s \
+response=$(curl -k -s -D - -o /dev/null \
   -H "Accept-Encoding: gzip" \
   -H "Accept: application/rdf+xml" \
+  --cert "$OWNER_CERT_FILE:$OWNER_CERT_PWD" \
   "$END_USER_BASE_URL")
 
 if ! echo "$response" | grep -qi "Content-Encoding: gzip"; then

--- a/http-tests/misc/gzip-rdfxml.sh
+++ b/http-tests/misc/gzip-rdfxml.sh
@@ -7,13 +7,39 @@ purge_cache "$END_USER_VARNISH_SERVICE"
 purge_cache "$ADMIN_VARNISH_SERVICE"
 purge_cache "$FRONTEND_VARNISH_SERVICE"
 
-# Test that nginx gzip compression is active for RDF/XML dynamic content
+# Test that nginx gzip compression is active for RDF/XML dynamic content.
+# Create an item, append enough data to exceed gzip_min_length, then retrieve it as RDF/XML.
+
+add-agent-to-group.sh \
+  -f "$OWNER_CERT_FILE" \
+  -p "$OWNER_CERT_PWD" \
+  --agent "$AGENT_URI" \
+  "${ADMIN_BASE_URL}acl/groups/writers/"
+
+item=$(create-item.sh \
+  -f "$AGENT_CERT_FILE" \
+  -p "$AGENT_CERT_PWD" \
+  -b "$END_USER_BASE_URL" \
+  --title "Gzip test item" \
+  --slug "gzip-test" \
+  --container "$END_USER_BASE_URL")
+
+printf '@prefix ex: <http://example.org/> .\n
+<> ex:prop1 "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed do eiusmod tempor incididunt ut labore." ;\n
+   ex:prop2 "Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo." ;\n
+   ex:prop3 "Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur." ;\n
+   ex:prop4 "Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est." .\n' \
+| post.sh \
+  -f "$AGENT_CERT_FILE" \
+  -p "$AGENT_CERT_PWD" \
+  -t "text/turtle" \
+  "$item"
 
 response=$(curl -k -s -D - -o /dev/null \
   -H "Accept-Encoding: gzip" \
   -H "Accept: application/rdf+xml" \
-  --cert "$OWNER_CERT_FILE:$OWNER_CERT_PWD" \
-  "$END_USER_BASE_URL")
+  -E "$AGENT_CERT_FILE":"$AGENT_CERT_PWD" \
+  "$item")
 
 if ! echo "$response" | grep -qi "Content-Encoding: gzip"; then
   echo "Content-Encoding: gzip not found on RDF/XML response"

--- a/http-tests/misc/gzip-rdfxml.sh
+++ b/http-tests/misc/gzip-rdfxml.sh
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+initialize_dataset "$END_USER_BASE_URL" "$TMP_END_USER_DATASET" "$END_USER_ENDPOINT_URL"
+initialize_dataset "$ADMIN_BASE_URL" "$TMP_ADMIN_DATASET" "$ADMIN_ENDPOINT_URL"
+purge_cache "$END_USER_VARNISH_SERVICE"
+purge_cache "$ADMIN_VARNISH_SERVICE"
+purge_cache "$FRONTEND_VARNISH_SERVICE"
+
+# Test that nginx gzip compression is active for RDF/XML dynamic content
+
+response=$(curl -i -k -s \
+  -H "Accept-Encoding: gzip" \
+  -H "Accept: application/rdf+xml" \
+  "$END_USER_BASE_URL")
+
+if ! echo "$response" | grep -qi "Content-Encoding: gzip"; then
+  echo "Content-Encoding: gzip not found on RDF/XML response"
+  exit 1
+fi
+
+if ! echo "$response" | grep -q "HTTP/.* 200"; then
+  echo "RDF/XML request did not return 200 OK"
+  exit 1
+fi

--- a/http-tests/misc/gzip-sefjson.sh
+++ b/http-tests/misc/gzip-sefjson.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Test that nginx gzip compression is active for static JSON (SEF file)
+
+response=$(curl -i -k -s \
+  -H "Accept-Encoding: gzip" \
+  "${END_USER_BASE_URL}static/com/atomgraph/linkeddatahub/xsl/client.xsl.sef.json")
+
+if ! echo "$response" | grep -qi "Content-Encoding: gzip"; then
+  echo "Content-Encoding: gzip not found on client.xsl.sef.json"
+  exit 1
+fi
+
+if ! echo "$response" | grep -q "HTTP/.* 200"; then
+  echo "client.xsl.sef.json did not return 200 OK"
+  exit 1
+fi

--- a/http-tests/misc/gzip-sefjson.sh
+++ b/http-tests/misc/gzip-sefjson.sh
@@ -3,7 +3,7 @@ set -euo pipefail
 
 # Test that nginx gzip compression is active for static JSON (SEF file)
 
-response=$(curl -i -k -s \
+response=$(curl -k -s -D - -o /dev/null \
   -H "Accept-Encoding: gzip" \
   "${END_USER_BASE_URL}static/com/atomgraph/linkeddatahub/xsl/client.xsl.sef.json")
 


### PR DESCRIPTION
## Summary

- Enables `gzip` in the nginx `http {}` block for all compressible content types served by LDH
- Covers `application/json`, `application/ld+json`, `application/rdf+xml`, `application/sparql-results+json`, `application/sparql-results+xml`, `application/trig`, `application/n-quads`, `application/n-triples`, `application/xml`, `text/turtle`, `text/css`, `text/javascript`, `application/javascript`, `image/svg+xml`
- Primary motivation: `client.xsl.sef.json` (11.8MB uncompressed) will compress to ~2-3MB, reducing cold-load transfer by ~75-80%

`text/html` and `text/plain` are always compressed by nginx and do not need to be listed.

## Test plan

- [ ] Restart nginx and confirm `Content-Encoding: gzip` on `client.xsl.sef.json`: `curl -sI -H "Accept-Encoding: gzip" https://<host>/static/com/atomgraph/linkeddatahub/xsl/client.xsl.sef.json | grep -i content-encoding`
- [ ] Verify transfer size in browser DevTools drops from ~11.8MB to ~2-3MB on cold load
- [ ] Confirm RDF responses (Turtle, JSON-LD, etc.) are also gzip-encoded

🤖 Generated with [Claude Code](https://claude.com/claude-code)