### PR TITLE
Derive server-side `acl:mode()` from Link response headers

### DIFF
--- a/src/main/java/com/atomgraph/linkeddatahub/vocabulary/LDH.java
+++ b/src/main/java/com/atomgraph/linkeddatahub/vocabulary/LDH.java
@@ -94,6 +94,9 @@ public class LDH
     
     /** Request URI property */
     public static final ObjectProperty requestUri = m_model.createObjectProperty(NS + "requestUri");
+
+    /** HTTP headers property */
+    public static final ObjectProperty httpHeaders = m_model.createObjectProperty(NS + "httpHeaders");
     
     /** Service property */
     public static final ObjectProperty service = m_model.createObjectProperty( NS + "service" );

--- a/src/main/java/com/atomgraph/linkeddatahub/writer/XSLTWriterBase.java
+++ b/src/main/java/com/atomgraph/linkeddatahub/writer/XSLTWriterBase.java
@@ -54,6 +54,7 @@ import javax.xml.transform.stream.StreamSource;
 import net.sf.saxon.s9api.QName;
 import net.sf.saxon.s9api.SaxonApiException;
 import net.sf.saxon.s9api.XdmAtomicValue;
+import net.sf.saxon.s9api.XdmMap;
 import net.sf.saxon.s9api.XdmValue;
 import net.sf.saxon.s9api.XsltExecutable;
 import org.apache.http.HttpHeaders;
@@ -144,9 +145,15 @@ public abstract class XSLTWriterBase extends com.atomgraph.client.writer.XSLTWri
                 params.put(new QName("foaf", FOAF.Agent.getNameSpace(), FOAF.Agent.getLocalName()),
                     getXsltExecutable().getProcessor().newDocumentBuilder().build(source));
             }
-            if (getAuthorizationContext().get().isPresent())
-                params.put(new QName("acl", ACL.mode.getNameSpace(), ACL.mode.getLocalName()),
-                    XdmValue.makeSequence(getAuthorizationContext().get().get().getModeURIs()));
+            XdmMap responseHeaders = new XdmMap();
+            for (Map.Entry<String, List<Object>> entry : headerMap.entrySet())
+            {
+                List<XdmAtomicValue> values = entry.getValue().stream().
+                    map(v -> new XdmAtomicValue(v.toString())).
+                    collect(Collectors.toList());
+                responseHeaders = responseHeaders.put(new XdmAtomicValue(entry.getKey()), XdmValue.makeSequence(values));
+            }
+            params.put(new QName("ldh", LDH.httpHeaders.getNameSpace(), LDH.httpHeaders.getLocalName()), responseHeaders);
 
             if (getHttpHeaders().getRequestHeader(HttpHeaders.REFERER) != null)
             {

--- a/src/main/webapp/static/com/atomgraph/linkeddatahub/xsl/bootstrap/2.3.2/admin/layout.xsl
+++ b/src/main/webapp/static/com/atomgraph/linkeddatahub/xsl/bootstrap/2.3.2/admin/layout.xsl
@@ -71,7 +71,7 @@ exclude-result-prefixes="#all">
     
     <!-- ADD DATA -->
     
-    <xsl:template match="rdf:RDF[$acl:mode = '&acl;Append']" mode="bs2:AddData" priority="1">
+    <xsl:template match="rdf:RDF[acl:mode() = '&acl;Append']" mode="bs2:AddData" priority="1">
         <div class="btn-group pull-left">
             <button type="button" class="btn btn-primary dropdown-toggle" title="{ac:label(key('resources', 'add', document('../translations.rdf')))}">
                 <xsl:value-of>

--- a/src/main/webapp/static/com/atomgraph/linkeddatahub/xsl/bootstrap/2.3.2/document.xsl
+++ b/src/main/webapp/static/com/atomgraph/linkeddatahub/xsl/bootstrap/2.3.2/document.xsl
@@ -68,8 +68,7 @@ extension-element-prefixes="ixsl"
 
     <xsl:param name="main-doc" select="/" as="document-node()"/>
     <xsl:param name="acl:Agent" as="document-node()?"/>
-    <xsl:param name="acl:mode" select="$foaf:Agent//*[acl:accessToClass/@rdf:resource = (key('resources', ac:absolute-path(ldh:base-uri(.)), $main-doc)/rdf:type/@rdf:resource, key('resources', ac:absolute-path(ldh:base-uri(.)), $main-doc)/rdf:type/@rdf:resource/ldh:listSuperClasses(.))]/acl:mode/@rdf:resource" as="xs:anyURI*"/>
-    
+
     <!-- schema.org BREADCRUMBS -->
     
     <xsl:template match="rdf:RDF" mode="schema:BreadCrumbList">

--- a/src/main/webapp/static/com/atomgraph/linkeddatahub/xsl/bootstrap/2.3.2/imports/default.xsl
+++ b/src/main/webapp/static/com/atomgraph/linkeddatahub/xsl/bootstrap/2.3.2/imports/default.xsl
@@ -116,7 +116,8 @@ exclude-result-prefixes="#all"
     </xsl:template>
     
     <xsl:function name="acl:mode" as="xs:anyURI*" use-when="system-property('xsl:product-name') = 'SAXON'">
-        <xsl:sequence select="$acl:mode"/>
+        <xsl:variable name="entries" select="for $line in $ldh:httpHeaders('Link') return tokenize($line, ',\s*(?=&lt;)')" as="xs:string*"/>
+        <xsl:sequence select="for $entry in $entries return if (matches($entry, '^&lt;[^&gt;]+&gt;\s*;.*\brel\s*=\s*&quot;?[^&quot;\s,;]*acl#mode&quot;?')) then xs:anyURI(replace($entry, '^&lt;([^&gt;]+)&gt;.*$', '$1')) else ()"/>
     </xsl:function>
 
     <xsl:function name="ac:uri" as="xs:anyURI?">
@@ -290,33 +291,7 @@ exclude-result-prefixes="#all"
             <xsl:apply-templates select="@* | node()" mode="#current"/>
         </xsl:copy>
     </xsl:template>
-    
-    <xsl:function name="ldh:listSuperClasses" as="attribute()*" cache="yes">
-        <xsl:param name="class" as="xs:anyURI"/>
-        
-        <xsl:sequence select="ldh:listSuperClasses($class, false())"/>
-    </xsl:function>
-    
-    <xsl:function name="ldh:listSuperClasses" as="attribute()*" cache="yes">
-        <xsl:param name="class" as="xs:anyURI"/>
-        <xsl:param name="direct" as="xs:boolean"/>
-        
-        <xsl:if test="doc-available(ac:document-uri($class))">
-            <xsl:variable name="document" select="document(ac:document-uri($class))" as="document-node()"/>
 
-            <xsl:for-each select="$document">
-                <xsl:variable name="superclasses" select="key('resources', $class)/rdfs:subClassOf/@rdf:resource[not(. = $class)]" as="attribute()*"/>
-                <xsl:sequence select="$superclasses"/>
-
-                <xsl:if test="not($direct)">
-                    <xsl:for-each select="$superclasses">
-                        <xsl:sequence select="ldh:listSuperClasses(., $direct)"/>
-                    </xsl:for-each>
-                </xsl:if>
-            </xsl:for-each>
-        </xsl:if>
-    </xsl:function>
-    
     <xsl:function name="ldh:ontologyImports" as="attribute()*" cache="yes">
         <xsl:param name="ontology" as="xs:anyURI"/>
         

--- a/src/main/webapp/static/com/atomgraph/linkeddatahub/xsl/bootstrap/2.3.2/imports/default.xsl
+++ b/src/main/webapp/static/com/atomgraph/linkeddatahub/xsl/bootstrap/2.3.2/imports/default.xsl
@@ -292,31 +292,6 @@ exclude-result-prefixes="#all"
         </xsl:copy>
     </xsl:template>
 
-    <xsl:function name="ldh:ontologyImports" as="attribute()*" cache="yes">
-        <xsl:param name="ontology" as="xs:anyURI"/>
-        
-        <xsl:sequence select="ldh:ontologyImports($ontology, false())"/>
-    </xsl:function>
-    
-    <xsl:function name="ldh:ontologyImports" as="attribute()*" cache="yes">
-        <xsl:param name="ontology" as="xs:anyURI"/>
-        <xsl:param name="direct" as="xs:boolean"/>
-
-        <xsl:if test="doc-available(ac:document-uri($ontology))">
-            <xsl:variable name="document" select="document(ac:document-uri($ontology))" as="document-node()"/>
-            <xsl:for-each select="$document">
-                <xsl:variable name="imports" select="key('resources', $ontology)/owl:imports/@rdf:resource[not(. = $ontology)]" as="attribute()*"/>
-                <xsl:sequence select="$imports"/>
-                
-                <xsl:if test="not($direct)">
-                    <xsl:for-each select="$imports">
-                        <xsl:sequence select="ldh:ontologyImports(., $direct)"/>
-                    </xsl:for-each>
-                </xsl:if>
-            </xsl:for-each>
-        </xsl:if>
-    </xsl:function>
-
     <xsl:function name="ac:value-intersect" as="xs:anyAtomicType*">
         <xsl:param name="arg1" as="xs:anyAtomicType*"/>
         <xsl:param name="arg2" as="xs:anyAtomicType*"/>

--- a/src/main/webapp/static/com/atomgraph/linkeddatahub/xsl/bootstrap/2.3.2/layout.xsl
+++ b/src/main/webapp/static/com/atomgraph/linkeddatahub/xsl/bootstrap/2.3.2/layout.xsl
@@ -107,7 +107,7 @@ exclude-result-prefixes="#all">
     <xsl:param name="foaf:Agent" select="if ($acl:agent) then document(ac:document-uri($acl:agent)) else ()" as="document-node()?"/>
     <xsl:param name="ac:httpHeaders" as="xs:string"/>
     <xsl:param name="ac:method" as="xs:string"/>
-    <xsl:param name="ldh:httpHeaders" as="map(xs:string, xs:string*)" select="map{}"/>
+    <xsl:param name="ldh:httpHeaders" select="map{}" as="map(xs:string, xs:string*)"/>
     <xsl:param name="ldh:ajaxRendering" select="true()" as="xs:boolean"/>
     <xsl:param name="ldhc:enableWebIDSignUp" as="xs:boolean"/>
     <xsl:param name="ldh:renderSystemResources" select="false()" as="xs:boolean"/>
@@ -409,20 +409,6 @@ exclude-result-prefixes="#all">
                                     <xsl:text>,&#xa;</xsl:text>
                                 </xsl:if>
                             </xsl:for-each>
-                            <!--<xsl:variable name="ontology-imports" select="for $value in distinct-values(ldh:ontologyImports($ldt:ontology)) return xs:anyURI($value)" as="xs:anyURI*"/>
-                            <xsl:if test="exists($ontology-imports)">
-                                <xsl:text>,</xsl:text>
-                                <xsl:for-each select="$ontology-imports">
-                                    <xsl:text>{ name: "</xsl:text>
-                                    <xsl:value-of select="ac:document-uri(.)"/>
-                                    <xsl:text>", altName: baseUri + "?uri=" + encodeURIComponent("</xsl:text>
-                                    <xsl:value-of select="ac:document-uri(.)"/>
-                                    <xsl:text>") + "&amp;accept=" + encodeURIComponent("application/rdf+xml") }</xsl:text>
-                                    <xsl:if test="position() != last()">
-                                        <xsl:text>,&#xa;</xsl:text>
-                                    </xsl:if>
-                                </xsl:for-each>
-                            </xsl:if> -->
                             <xsl:text disable-output-escaping="yes">
                             <![CDATA[
                         ];

--- a/src/main/webapp/static/com/atomgraph/linkeddatahub/xsl/bootstrap/2.3.2/layout.xsl
+++ b/src/main/webapp/static/com/atomgraph/linkeddatahub/xsl/bootstrap/2.3.2/layout.xsl
@@ -105,9 +105,9 @@ exclude-result-prefixes="#all">
     <xsl:param name="acl:agent" as="xs:anyURI?"/>
     <xsl:param name="lapp:Context" as="document-node()"/>
     <xsl:param name="foaf:Agent" select="if ($acl:agent) then document(ac:document-uri($acl:agent)) else ()" as="document-node()?"/>
-    <xsl:param name="ac:httpHeaders" as="xs:string"/> 
+    <xsl:param name="ac:httpHeaders" as="xs:string"/>
     <xsl:param name="ac:method" as="xs:string"/>
-    <xsl:param name="acl:mode" as="xs:anyURI*"/>
+    <xsl:param name="ldh:httpHeaders" as="map(xs:string, xs:string*)" select="map{}"/>
     <xsl:param name="ldh:ajaxRendering" select="true()" as="xs:boolean"/>
     <xsl:param name="ldhc:enableWebIDSignUp" as="xs:boolean"/>
     <xsl:param name="ldh:renderSystemResources" select="false()" as="xs:boolean"/>


### PR DESCRIPTION
## Summary

- Java pushes outgoing response headers to XSLT as a new `$ldh:httpHeaders` map (`map(xs:string, xs:string*)`).
- Server-side `acl:mode()` is rewritten to parse Link entries with `rel=acl#mode` out of that map, replacing the pre-aggregated `$acl:mode` param push.
- Drops now-dead supertype-closure helpers (`ldh:listSuperClasses`, `ldh:ontologyImports`) and the empty `$acl:mode` declaration in `layout.xsl`; converts the lone direct `$acl:mode` reference in `admin/layout.xsl` to `acl:mode()`.

## Changes

- `XSLTWriterBase` — populates `$ldh:httpHeaders` from outgoing response headers (`LDH.httpHeaders` vocabulary term added).
- `imports/default.xsl` — `acl:mode()` parses Link entries via `xsl:analyze-string`; removes `ldh:listSuperClasses` and `ldh:ontologyImports` (unused).
- `layout.xsl` — removes the `$acl:mode` param and the commented-out ontology-imports block in the JS docs config.
- `admin/layout.xsl`, `document.xsl` — switch to `acl:mode()` function call.

## Notes

- XPath F&O regex doesn't support lookahead or `\b`; the Link header is split with `xsl:analyze-string` (regex `<[^>]+>[^<]*`) and the `rel` match uses `[;\s]rel` for word boundary.
- Uncommitted on the branch right now: the `acl:mode` regex fix described above — fold it into the second commit (or add as a follow-up) before opening the PR.

## Test plan

- [ ] `mvn clean install`
- [ ] `docker-compose up --build` — container starts, no XSLT transformation errors in logs on first page load
- [ ] Authenticated request returns expected `acl:mode` values (e.g. owner sees Read/Write, anonymous sees Read only) and the rendered UI reflects them
- [ ] `cd http-tests && ./run.sh ssl/owner/cert.pem … ssl/secretary/cert.pem …` passes
- [ ] Confirm no remaining references to `$acl:mode` param or `ldh:listSuperClasses` / `ldh:ontologyImports` in the codebase