### PR TITLE
Path-aware view ordering for modal search; assorted fixes

### DIFF
--- a/src/main/webapp/static/com/atomgraph/linkeddatahub/css/bootstrap.css
+++ b/src/main/webapp/static/com/atomgraph/linkeddatahub/css/bootstrap.css
@@ -1,4 +1,4 @@
-html { height: 100%; overscroll-behavior-y: none; }
+html { height: 100%; }
 /* only the main navbar is fixed-top now; tab bar + action bar are sticky inside #tab-body */
 body { height: calc(100% - 51px); padding-top: 51px; padding-bottom: 0; }
 #tab-bar { position: sticky; top: 51px; z-index: 1000; margin-bottom: 0; }
@@ -27,8 +27,10 @@ ul.dropdown-menu ul { margin: 0; }
 .dropdown-menu li form { margin-bottom: 0; }
 .dropdown-menu li form button { width: 100%; text-align: left; }
 #collapsing-top-navbar .brand.context { display: inline-block; vertical-align: middle; }
-.navbar-form input#uri { width: calc(100% - 50px); }
-.navbar-form .btn-search { background-image: url('../icons/ic_search_white_24px.svg'); background-position: center center; background-repeat: no-repeat; width: 34px; height: 34px; }
+.btn-search { background-image: url('../icons/ic_search_white_24px.svg'); background-position: center center; background-repeat: no-repeat; width: 34px; height: 34px; }
+.search-form .input-append, .search-form-modal .input-append { display: flex; width: 100%; align-items: stretch; }
+.search-form .input-append .search-query, .search-form-modal .input-append .search-query { flex: 1 1 auto; min-width: 0; height: 34px; box-sizing: border-box; margin: 0; }
+.search-form .input-append .btn-search, .search-form-modal .input-append .btn-search { flex: 0 0 34px; margin: 0; }
 .action-bar { position: sticky; top: var(--action-bar-top, 51px); z-index: 999; background: #dfdfdf; padding: 0; box-shadow: none; }
 .action-bar form { margin-bottom: 0; }
 .action-bar .span7 .row-fluid > * { margin-top: 10px; }
@@ -165,7 +167,7 @@ fieldset fieldset { margin-left: 3%; margin-bottom: 3%; }
 .constructor-triple .controls label.radio { display: inline-block; padding-top: 10px; margin-right: 10px; }
 .constructor-triple .controls .help-inline { vertical-align: top; padding-top: 5px; }
 .control-group.error .checkbox, .control-group.error .radio, .control-group.error input, .control-group.error select, .control-group.error textarea { color: unset; }
-#uri { height: 24px; }
+#uri { height: 24px; width: 100%; }
 #query-form fieldset { border: initial; margin: initial; }
 button.add-typeahead { width: 219px; }
 .btn.btn-remove-property, .btn.btn-remove-resource { background-image: url('../icons/ic_remove_black_24px.svg'); background-position: center center; background-repeat: no-repeat; height: 30px; width: 30px; }

--- a/src/main/webapp/static/com/atomgraph/linkeddatahub/xsl/bootstrap/2.3.2/client/block.xsl
+++ b/src/main/webapp/static/com/atomgraph/linkeddatahub/xsl/bootstrap/2.3.2/client/block.xsl
@@ -237,10 +237,14 @@ exclude-result-prefixes="#all"
 
     <xsl:template match="div[contains-token(@class, 'block')][key('elements-by-class', 'drag-handle', .)][acl:mode() = '&acl;Write'][not(ixsl:style(ancestor::div[contains-token(@class, 'tab-pane')]/div[contains-token(@class, 'left-sidebar')])?display = 'block')]" mode="ixsl:onmousemove" priority="2">
         <xsl:variable name="uri" select="xs:anyURI(ancestor::div[contains-token(@class, 'document-body')]/@about)" as="xs:anyURI"/>
-        <xsl:variable name="results" select="ixsl:get(ixsl:get(ixsl:get(ixsl:window(), 'LinkedDataHub.contents'), '`' || $uri || '`'), 'results')" as="document-node()"/>
-        <xsl:variable name="mode" select="ac:mode($results)" as="xs:anyURI"/>
- 
-        <xsl:if test="$mode = xs:anyURI('&ldh;ContentMode')">
+        <xsl:variable name="contents" select="ixsl:get(ixsl:window(), 'LinkedDataHub.contents')"/>
+        <xsl:variable name="cache-key" select="'`' || $uri || '`'" as="xs:string"/>
+        <!-- cache may not have an entry for the hovered block's document URI (e.g. inactive tab); skip silently to avoid an ixsl:get warning on every mousemove -->
+        <xsl:if test="ixsl:contains($contents, $cache-key) and ixsl:contains(ixsl:get($contents, $cache-key), 'results')">
+            <xsl:variable name="results" select="ixsl:get(ixsl:get($contents, $cache-key), 'results')" as="document-node()"/>
+            <xsl:variable name="mode" select="ac:mode($results)" as="xs:anyURI"/>
+
+            <xsl:if test="$mode = xs:anyURI('&ldh;ContentMode')">
             <xsl:variable name="dom-x" select="ixsl:get(ixsl:event(), 'clientX')" as="xs:double"/>
             <xsl:variable name="rect" select="ixsl:call(., 'getBoundingClientRect', [])"/>
             <xsl:variable name="offset-x" select="$dom-x - ixsl:get($rect, 'x')" as="xs:double"/>
@@ -286,10 +290,11 @@ exclude-result-prefixes="#all"
             </xsl:choose>
 
             <!-- call the next matching template to preserve existing block controls functionality -->
-            <xsl:next-match/>
+                <xsl:next-match/>
+            </xsl:if>
         </xsl:if>
     </xsl:template>
-    
+
     <!-- hide drag handle when mouse leaves block -->
     
     <xsl:template match="div[contains-token(@class, 'block')][key('elements-by-class', 'drag-handle', .)][acl:mode() = '&acl;Write']" mode="ixsl:onmouseout">

--- a/src/main/webapp/static/com/atomgraph/linkeddatahub/xsl/bootstrap/2.3.2/client/block/view.xsl
+++ b/src/main/webapp/static/com/atomgraph/linkeddatahub/xsl/bootstrap/2.3.2/client/block/view.xsl
@@ -104,6 +104,19 @@ exclude-result-prefixes="#all"
         "/>
     </xsl:template>
     
+    <!-- flatten a SPARQL.js predicate node to its candidate URIs: simple URI (json:string) returns one; alt-path (pathType '|') recurses through items; sequence/inverse/variable predicates return empty -->
+    <xsl:function name="ldh:alt-path-uris" as="xs:anyURI*">
+        <xsl:param name="node" as="element()"/>
+        <xsl:choose>
+            <xsl:when test="$node/self::json:string[not(starts-with(., '?'))]">
+                <xsl:sequence select="xs:anyURI($node)"/>
+            </xsl:when>
+            <xsl:when test="$node/self::json:map[json:string[@key = 'type'] = 'path'][json:string[@key = 'pathType'] = '|']">
+                <xsl:sequence select="for $item in $node/json:array[@key = 'items']/* return ldh:alt-path-uris($item)"/>
+            </xsl:when>
+        </xsl:choose>
+    </xsl:function>
+
     <xsl:function name="ldh:view-self-thunk" as="item()*" ixsl:updating="yes">
         <xsl:param name="context" as="map(*)"/>
 
@@ -354,31 +367,6 @@ exclude-result-prefixes="#all"
             on-failure="ldh:promise-failure#1"/>
     </xsl:template>
     
-    <!-- order by -->
-    
-    <xsl:template match="*[@rdf:about]" mode="bs2:OrderBy">
-        <xsl:param name="id" as="xs:string?"/>
-        <xsl:param name="class" as="xs:string?"/>
-        <xsl:param name="order-by-predicate" as="xs:anyURI?"/>
-
-        <!-- TO-DO: order options -->
-        <option value="{@rdf:about}">
-            <xsl:if test="$id">
-                <xsl:attribute name="id" select="$id"/>
-            </xsl:if>
-            <xsl:if test="$class">
-                <xsl:attribute name="class" select="$class"/>
-            </xsl:if>
-            <xsl:if test="@rdf:about = $order-by-predicate">
-                <xsl:attribute name="selected" select="'selected'"/>
-            </xsl:if>
-            
-            <xsl:value-of>
-                <xsl:apply-templates select="." mode="ac:label"/>
-            </xsl:value-of>
-        </option>
-    </xsl:template>
-    
     <!-- pager -->
 
     <xsl:template name="bs2:PagerList">
@@ -525,11 +513,7 @@ exclude-result-prefixes="#all"
 
     <xsl:template name="ldh:ViewOrder">
         <xsl:param name="select-xml" as="document-node()"/>
-        <xsl:param name="initial-var-name" as="xs:string"/>
-        <xsl:param name="predicate" as="xs:anyURI"/>
-
-        <xsl:variable name="bgp-triples-map" select="$select-xml//json:map[json:string[@key = 'type'] = 'bgp']/json:array[@key = 'triples']/json:map[json:string[@key = 'subject'] = '?' || $initial-var-name][json:string[@key = 'predicate'] = $predicate][starts-with(json:string[@key = 'object'], '?')]" as="element()*"/>
-        <xsl:variable name="var-name" select="$bgp-triples-map/json:string[@key = 'object'][1]/substring-after(., '?')" as="xs:string?"/>
+        <xsl:param name="var-name" as="xs:string?"/>
 
         <xsl:document>
             <xsl:apply-templates select="$select-xml" mode="ldh:replace-order-by">
@@ -768,9 +752,9 @@ exclude-result-prefixes="#all"
         <xsl:param name="container" as="element()"/>
         <xsl:param name="results" as="document-node()"/>
         <xsl:param name="select-xml" as="document-node()"/>
-        <xsl:param name="bgp-triples-map" as="element()*"/>
+        <xsl:param name="var-predicates" as="map(xs:string, xs:anyURI*)"/>
         <xsl:param name="desc" as="xs:boolean?"/>
-        <xsl:param name="order-by-predicate" as="xs:anyURI?"/>
+        <xsl:param name="order-by-var-name" as="xs:string?"/>
         <xsl:param name="container-id" as="xs:string"/>
         <xsl:param name="focus-var-name" as="xs:string"/>
         <xsl:param name="endpoint" as="xs:anyURI"/>
@@ -817,6 +801,19 @@ exclude-result-prefixes="#all"
                                         </xsl:value-of>
                                     </option>
                                 </xsl:if>
+                                <!-- alt-path-bound vars: emit options synchronously with var-name as label (no single canonical predicate URI to fetch ac:label for). Single-predicate vars are appended asynchronously below, with ac:label fetched from the predicate's vocab document. -->
+                                <xsl:for-each select="map:keys($var-predicates)">
+                                    <xsl:sort select="."/>
+                                    <xsl:variable name="var-name" select="." as="xs:string"/>
+                                    <xsl:if test="count($var-predicates(.)) gt 1">
+                                        <option value="{$var-name}">
+                                            <xsl:if test="$var-name = $order-by-var-name">
+                                                <xsl:attribute name="selected">selected</xsl:attribute>
+                                            </xsl:if>
+                                            <xsl:value-of select="$var-name"/>
+                                        </option>
+                                    </xsl:if>
+                                </xsl:for-each>
                             </select>
 
                             <xsl:choose>
@@ -855,24 +852,24 @@ exclude-result-prefixes="#all"
                     <xsl:with-param name="cache" select="$cache"/>
                 </xsl:call-template>
             </xsl:for-each>
-             
-            <xsl:for-each select="$bgp-triples-map">
-                <!-- only simple properties in the BGP are supported, not property paths etc. -->
-                <xsl:if test="json:string[@key = 'predicate']">
-                    <xsl:variable name="id" select="generate-id()" as="xs:string"/>
-                    <xsl:variable name="predicate" select="json:string[@key = 'predicate']" as="xs:anyURI"/>
+
+            <!-- single-predicate vars: fetch the predicate's vocab document and append the option with ac:label as visible text. Alt-path-bound vars are already rendered inline above. -->
+            <xsl:for-each select="map:keys($var-predicates)">
+                <xsl:variable name="var-name" select="." as="xs:string"/>
+                <xsl:variable name="predicates" select="$var-predicates(.)" as="xs:anyURI*"/>
+                <xsl:if test="count($predicates) eq 1">
+                    <xsl:variable name="predicate" select="$predicates[1]" as="xs:anyURI"/>
                     <xsl:variable name="request-uri" select="ldh:href(ac:build-uri(ldt:base(), map{ 'uri': ac:document-uri($predicate), 'accept': 'application/rdf+xml' }), map{})" as="xs:anyURI"/>
                     <xsl:variable name="request" select="map{ 'method': 'GET', 'href': $request-uri, 'headers': map{ 'Accept': 'application/rdf+xml' } }" as="map(*)"/>
                     <xsl:variable name="context" as="map(*)" select="
                       map{
                         'request': $request,
                         'container': id($order-by-container-id, ixsl:page()),
-                        'id': $id,
                         'predicate': $predicate,
-                        'order-by-predicate': $order-by-predicate,
+                        'var-name': $var-name,
+                        'order-by-var-name': $order-by-var-name,
                         'cache': $cache
                       }"/>
-
                     <ixsl:promise select="ixsl:http-request($context('request')) =>
                         ixsl:then(ldh:rethread-response($context, ?)) =>
                         ixsl:then(ldh:handle-response#1) =>
@@ -1335,7 +1332,7 @@ exclude-result-prefixes="#all"
     <xsl:template match="div[@typeof = '&ldh;View']//select[contains-token(@class, 'container-order')]" mode="ixsl:onchange">
         <xsl:param name="container" select="ancestor::div[@typeof = '&ldh;View'][1]" as="element()"/>
         <xsl:param name="cache" select="ixsl:get(ixsl:get(ixsl:window(), 'LinkedDataHub.contents'), '`' || $container/@id || '`')" as="item()"/>
-        <xsl:variable name="predicate" select="ixsl:get(., 'value')" as="xs:anyURI?"/>
+        <xsl:variable name="var-name" select="ixsl:get(., 'value')" as="xs:string?"/>
         <xsl:variable name="select-string" select="ixsl:get($cache, 'select-string')" as="xs:string"/>
         <xsl:variable name="select-xml" select="ixsl:get($cache, 'select-xml')" as="document-node()"/>
         <xsl:variable name="initial-var-name" select="ixsl:get($cache, 'initial-var-name')" as="xs:string"/>
@@ -1348,8 +1345,7 @@ exclude-result-prefixes="#all"
         <xsl:variable name="select-xml" as="document-node()">
             <xsl:call-template name="ldh:ViewOrder">
                 <xsl:with-param name="select-xml" select="$select-xml"/>
-                <xsl:with-param name="initial-var-name" select="$initial-var-name"/>
-                <xsl:with-param name="predicate" select="$predicate"/>
+                <xsl:with-param name="var-name" select="$var-name"/>
             </xsl:call-template>
         </xsl:variable>
 
@@ -1822,24 +1818,53 @@ exclude-result-prefixes="#all"
         <xsl:message>ldh:render-view</xsl:message>
 
         <xsl:for-each select="$results">
-            <!-- use the BGPs where the predicate is a URI value and the subject and object are variables -->
-            <xsl:variable name="bgp-triples-map" select="$select-xml//json:map[json:string[@key = 'type'] = 'bgp']/json:array[@key = 'triples']/json:map[json:string[@key = 'subject'] = '?' || $initial-var-name][not(starts-with(json:string[@key = 'predicate'], '?'))][starts-with(json:string[@key = 'object'], '?')]" as="element()*"/>
+            <!-- map { object-var-name -> candidate predicate URIs } from BGP triples whose subject is the focus variable; deduped per var. SPARQL ORDER BY uses variables, but the wrapped DESCRIBE returns an unordered RDF graph, so the view sorts by predicates client-side - this map bridges the two. -->
+            <xsl:variable name="var-predicates" as="map(xs:string, xs:anyURI*)">
+                <xsl:map>
+                    <xsl:for-each-group select="$select-xml//json:map[json:string[@key = 'type'] = 'bgp']/json:array[@key = 'triples']/json:map[json:string[@key = 'subject'] = '?' || $initial-var-name][starts-with(json:string[@key = 'object'], '?')]" group-by="substring-after(json:string[@key = 'object'], '?')">
+                        <xsl:variable name="predicates" as="xs:anyURI*">
+                            <xsl:for-each select="current-group()">
+                                <xsl:sequence select="ldh:alt-path-uris((json:string[@key = 'predicate'], json:map[@key = 'predicate'])[1])"/>
+                            </xsl:for-each>
+                        </xsl:variable>
+                        <xsl:if test="exists($predicates)">
+                            <xsl:map-entry key="current-grouping-key()" select="distinct-values($predicates) ! xs:anyURI(.)"/>
+                        </xsl:if>
+                    </xsl:for-each-group>
+                </xsl:map>
+            </xsl:variable>
 
             <xsl:variable name="order-by-var-name" select="$select-xml/json:map/json:array[@key = 'order']/json:map[1]/json:string[@key = 'expression']/substring-after(., '?')" as="xs:string?"/>
-            <xsl:variable name="order-by-predicate" select="$bgp-triples-map[json:string[@key = 'object'] = '?' || $order-by-var-name][1]/json:string[@key = 'predicate']" as="xs:anyURI?"/>
+            <xsl:variable name="order-by-predicates" select="if ($order-by-var-name and map:contains($var-predicates, $order-by-var-name)) then $var-predicates($order-by-var-name) else ()" as="xs:anyURI*"/>
             <xsl:variable name="desc" select="$select-xml/json:map/json:array[@key = 'order']/json:map[1]/json:boolean[@key = 'descending']" as="xs:boolean?"/>
             <xsl:variable name="default-order-by-var-name" select="$select-xml/json:map/json:array[@key = 'order']/json:map[2]/json:string[@key = 'expression']/substring-after(., '?')" as="xs:string?"/>
-            <xsl:variable name="default-order-by-predicate" select="$bgp-triples-map[json:string[@key = 'object'] = '?' || $default-order-by-var-name][1]/json:string[@key = 'predicate']" as="xs:anyURI?"/>
+            <xsl:variable name="default-order-by-predicates" select="if ($default-order-by-var-name and map:contains($var-predicates, $default-order-by-var-name)) then $var-predicates($default-order-by-var-name) else ()" as="xs:anyURI*"/>
             <xsl:variable name="default-desc" select="$select-xml/json:map/json:array[@key = 'order']/json:map[2]/json:boolean[@key = 'descending']" as="xs:boolean?"/>
             <xsl:variable name="sorted-results" as="document-node()">
                 <xsl:document>
                     <xsl:for-each select="/rdf:RDF">
                         <xsl:copy>
                             <xsl:perform-sort select="*">
-                                <!-- sort by $order-by-predicate if it is set (multiple properties might match) -->
-                                <xsl:sort select="if ($order-by-predicate) then *[concat(namespace-uri(), local-name()) = $order-by-predicate][1]/(text(), @rdf:resource, @rdf:nodeID)[1]/string() else ()" order="{if ($desc) then 'descending' else 'ascending'}"/>
-                                <!-- sort by $default-order-by-predicate if it is set and not equal to $order-by-predicate (multiple properties might match) -->
-                                <xsl:sort select="if ($default-order-by-predicate and not($order-by-predicate = $default-order-by-predicate)) then *[concat(namespace-uri(), local-name()) = $default-order-by-predicate][1]/(text(), @rdf:resource, @rdf:nodeID)[1]/string() else ()" order="{if ($default-desc) then 'descending' else 'ascending'}"/>
+                                <!-- sort key COALESCEs across $order-by-predicates in path order, preferring values whose @xml:lang primary subtag matches $ac:lang. Inlined rather than calling ldh:sort-key() because SaxonJS xsl:sort doesn't appear to thread the user-function return value back into the comparison even though the function executes. -->
+                                <xsl:sort select="
+                                    (let $children := for $p in $order-by-predicates return *[concat(namespace-uri(), local-name()) = $p]
+                                     return (
+                                       ($children[tokenize(@xml:lang, '-')[1] = tokenize($ac:lang, '-')[1]]/string(text()))[1],
+                                       ($children[not(@xml:lang)]/string(text()))[1],
+                                       ($children/string((text(), @rdf:resource, @rdf:nodeID)[1]))[1]
+                                     )[. ne ''][1])
+                                " order="{if ($desc) then 'descending' else 'ascending'}"/>
+                                <!-- secondary sort by $default-order-by-predicates if distinct from the primary -->
+                                <xsl:sort select="
+                                    if (exists($default-order-by-predicates) and not(deep-equal($order-by-predicates, $default-order-by-predicates))) then
+                                        (let $children := for $p in $default-order-by-predicates return *[concat(namespace-uri(), local-name()) = $p]
+                                         return (
+                                           ($children[tokenize(@xml:lang, '-')[1] = tokenize($ac:lang, '-')[1]]/string(text()))[1],
+                                           ($children[not(@xml:lang)]/string(text()))[1],
+                                           ($children/string((text(), @rdf:resource, @rdf:nodeID)[1]))[1]
+                                         )[. ne ''][1])
+                                    else ()
+                                " order="{if ($default-desc) then 'descending' else 'ascending'}"/>
                                 <!-- soft by URI/bnode ID otherwise -->
                                 <xsl:sort select="if (@rdf:about) then @rdf:about else @rdf:nodeID" order="{if ($default-desc) then 'descending' else 'ascending'}"/>
                             </xsl:perform-sort>
@@ -1853,12 +1878,12 @@ exclude-result-prefixes="#all"
                     <xsl:with-param name="container" select="$container"/>
                     <xsl:with-param name="results" select="$sorted-results"/>
                     <xsl:with-param name="select-xml" select="$select-xml"/>
-                    <xsl:with-param name="bgp-triples-map" select="$bgp-triples-map"/>
+                    <xsl:with-param name="var-predicates" select="$var-predicates"/>
                     <xsl:with-param name="container-id" select="$container-id"/>
                     <xsl:with-param name="endpoint" select="$endpoint"/>
                     <xsl:with-param name="focus-var-name" select="$focus-var-name"/>
                     <xsl:with-param name="desc" select="$desc"/>
-                    <xsl:with-param name="order-by-predicate" select="$order-by-predicate"/>
+                    <xsl:with-param name="order-by-var-name" select="$order-by-var-name"/>
                     <xsl:with-param name="result-count-container-id" select="$result-count-container-id"/>
                     <xsl:with-param name="active-mode" select="$active-mode"/>
                     <xsl:with-param name="object-metadata" select="$object-metadata"/>
@@ -2236,27 +2261,29 @@ exclude-result-prefixes="#all"
 
         <xsl:sequence select="$context"/>
     </xsl:function>
-        
-    <!-- order by -->
-    
+
+    <!-- order by: append a single-predicate var's option using ac:label of the predicate's description (fetched from the proxied predicate URI's vocab document) -->
     <xsl:function name="ldh:order-by-response" as="map(*)" ixsl:updating="yes">
         <xsl:param name="context" as="map(*)"/>
         <xsl:variable name="response" select="$context('response')" as="map(*)"/>
         <xsl:variable name="container" select="$context('container')" as="element()"/>
-        <xsl:variable name="id" select="$context('id')" as="xs:string?"/>
         <xsl:variable name="predicate" select="$context('predicate')" as="xs:anyURI"/>
-        <xsl:variable name="order-by-predicate" select="$context('order-by-predicate')" as="xs:anyURI?"/>
-
-        <xsl:message>ldh:order-by-response</xsl:message>
+        <xsl:variable name="var-name" select="$context('var-name')" as="xs:string"/>
+        <xsl:variable name="order-by-var-name" select="$context('order-by-var-name')" as="xs:string?"/>
 
         <xsl:for-each select="$response">
             <xsl:if test="?status = 200 and ?media-type = 'application/rdf+xml' and ?body">
                 <xsl:variable name="body" select="?body" as="document-node()"/>
                 <xsl:for-each select="$container">
                     <xsl:result-document href="?." method="ixsl:append-content">
-                        <xsl:apply-templates select="key('resources', $predicate, $body)" mode="bs2:OrderBy">
-                            <xsl:with-param name="order-by-predicate" select="$order-by-predicate"/>
-                        </xsl:apply-templates>
+                        <option value="{$var-name}">
+                            <xsl:if test="$var-name = $order-by-var-name">
+                                <xsl:attribute name="selected" select="'selected'"/>
+                            </xsl:if>
+                            <xsl:value-of>
+                                <xsl:apply-templates select="key('resources', $predicate, $body)" mode="ac:label"/>
+                            </xsl:value-of>
+                        </option>
                     </xsl:result-document>
                 </xsl:for-each>
             </xsl:if>
@@ -2265,5 +2292,5 @@ exclude-result-prefixes="#all"
 
         <xsl:sequence select="$context"/>
     </xsl:function>
-    
+
 </xsl:stylesheet>

--- a/src/main/webapp/static/com/atomgraph/linkeddatahub/xsl/bootstrap/2.3.2/client/navigation.xsl
+++ b/src/main/webapp/static/com/atomgraph/linkeddatahub/xsl/bootstrap/2.3.2/client/navigation.xsl
@@ -94,6 +94,18 @@ ORDER BY DESC(?created)
     <xsl:template name="ldh:LeftSidebar">
         <xsl:param name="base" select="ldt:base()" as="xs:anyURI"/>
 
+        <!-- dataspace-scoped search form -->
+        <form class="form-search search-form" accept-charset="UTF-8" title="{ac:label(key('resources', 'search-title', document(resolve-uri('static/com/atomgraph/linkeddatahub/xsl/bootstrap/2.3.2/translations.rdf', $ac:contextUri))))}">
+            <div class="input-append">
+                <input type="text" name="q" class="search-query" placeholder="{ac:label(key('resources', 'search-placeholder', document(resolve-uri('static/com/atomgraph/linkeddatahub/xsl/bootstrap/2.3.2/translations.rdf', $ac:contextUri))))}"/>
+                <button type="submit">
+                    <xsl:apply-templates select="key('resources', 'search', document(resolve-uri('static/com/atomgraph/linkeddatahub/xsl/bootstrap/2.3.2/translations.rdf', $ac:contextUri)))" mode="ldh:logo">
+                        <xsl:with-param name="class" select="'btn btn-primary'"/>
+                    </xsl:apply-templates>
+                </button>
+            </div>
+        </form>
+
         <!-- document tree container -->
         <div class="document-tree">
             <h2 class="nav-header btn">
@@ -963,7 +975,7 @@ ORDER BY DESC(?created)
     </xsl:template>
 
     <!-- close modals when a link inside them is clicked -->
-    <xsl:template match="div[@id = ('class-instances-modal', 'geo-modal', 'latest-modal')]//a[@href]" mode="ixsl:onclick" priority="1">
+    <xsl:template match="div[@id = ('class-instances-modal', 'geo-modal', 'latest-modal', 'search-modal')]//a[@href]" mode="ixsl:onclick" priority="1">
         <xsl:variable name="modal" select="ancestor::div[contains-token(@class, 'modal')][@id][1]" as="element()"/>
 
         <!-- remove the modal -->
@@ -1187,6 +1199,216 @@ ORDER BY DESC(?created)
                 <xsl:with-param name="select-string" select="$select-string"/>
                 <xsl:with-param name="select-xml" select="$select-xml"/>
                 <xsl:with-param name="initial-var-name" select="'dated'"/>
+                <xsl:with-param name="endpoint" select="$endpoint"/>
+                <xsl:with-param name="cache" select="$cache"/>
+            </xsl:call-template>
+        </xsl:variable>
+        <xsl:variable name="context" select="map:merge((map{ 'block': $container }, $view-context))" as="map(*)"/>
+
+        <ixsl:promise select="
+            ixsl:resolve($context) =>
+                ixsl:then(ldh:view-results-thunk#1)
+            "
+            on-failure="ldh:promise-failure#1"/>
+    </xsl:template>
+
+    <!-- sidebar search form: open modal pre-populated with the typed value and run the search -->
+    <xsl:template match="form[contains-token(@class, 'search-form')]" mode="ixsl:onsubmit">
+        <xsl:sequence select="ixsl:call(ixsl:event(), 'preventDefault', [])"/>
+        <xsl:variable name="text" select=".//input[@name = 'q']/ixsl:get(., 'value')" as="xs:string?"/>
+        <xsl:variable name="container-id" select="'search-results-container'" as="xs:string"/>
+
+        <xsl:variable name="modal" as="element()">
+            <div class="modal modal-constructor fade in" id="search-modal">
+                <div class="modal-header">
+                    <button type="button" class="close">×</button>
+                    <legend>
+                        <xsl:apply-templates select="key('resources', 'search', document(resolve-uri('static/com/atomgraph/linkeddatahub/xsl/bootstrap/2.3.2/translations.rdf', $ac:contextUri)))" mode="ac:label"/>
+                    </legend>
+                    <form class="form-search search-form-modal" accept-charset="UTF-8">
+                        <div class="input-append">
+                            <input type="text" name="q" class="search-query" value="{$text}" placeholder="{ac:label(key('resources', 'search-placeholder', document(resolve-uri('static/com/atomgraph/linkeddatahub/xsl/bootstrap/2.3.2/translations.rdf', $ac:contextUri))))}"/>
+                            <button type="submit">
+                                <xsl:apply-templates select="key('resources', 'search', document(resolve-uri('static/com/atomgraph/linkeddatahub/xsl/bootstrap/2.3.2/translations.rdf', $ac:contextUri)))" mode="ldh:logo">
+                                    <xsl:with-param name="class" select="'btn btn-primary'"/>
+                                </xsl:apply-templates>
+                            </button>
+                        </div>
+                    </form>
+                </div>
+                <div class="modal-body">
+                    <div class="row-fluid block">
+                        <div class="span12 progress progress-striped active">
+                            <div class="row-fluid row-block-controls" style="position: relative; top: 30px; margin-top: -30px; z-index: 1;">
+                                <div class="span12">
+                                    <div class="row-fluid">
+                                        <div style="width: 0%;" class="span12 bar"></div>
+                                    </div>
+                                </div>
+                            </div>
+
+                            <div id="{$container-id}" class="row-fluid" typeof="&ldh;View">
+                                <div class="main span12">
+                                    <!-- view results will be rendered here -->
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+                <div class="form-actions modal-footer">
+                    <button type="button" class="btn btn-primary btn-close">
+                        <xsl:value-of>
+                            <xsl:apply-templates select="key('resources', 'close', document(resolve-uri('static/com/atomgraph/linkeddatahub/xsl/bootstrap/2.3.2/translations.rdf', $ac:contextUri)))" mode="ac:label"/>
+                        </xsl:value-of>
+                    </button>
+                </div>
+            </div>
+        </xsl:variable>
+
+        <xsl:call-template name="ldh:ShowModalForm">
+            <xsl:with-param name="form" select="$modal"/>
+        </xsl:call-template>
+
+        <xsl:if test="not(ixsl:contains(ixsl:get(ixsl:window(), 'LinkedDataHub.contents'), '`' || $container-id || '`'))">
+            <ixsl:set-property name="{'`' || $container-id || '`'}" select="ldh:new-object()" object="ixsl:get(ixsl:window(), 'LinkedDataHub.contents')"/>
+        </xsl:if>
+        <xsl:variable name="cache" select="ixsl:get(ixsl:get(ixsl:window(), 'LinkedDataHub.contents'), '`' || $container-id || '`')" as="item()"/>
+        <ixsl:set-property name="select-string" select="$select-labelled-string" object="$cache"/>
+        <ixsl:set-property name="initial-var-name" select="'resource'" object="$cache"/>
+        <ixsl:set-property name="endpoint" select="sd:endpoint()" object="$cache"/>
+
+        <xsl:if test="string-length($text) gt 0">
+            <xsl:call-template name="ldh:SearchLoad">
+                <xsl:with-param name="container" select="id($container-id, ixsl:page())"/>
+                <xsl:with-param name="text" select="$text"/>
+                <xsl:with-param name="endpoint" select="sd:endpoint()"/>
+                <xsl:with-param name="cache" select="$cache"/>
+            </xsl:call-template>
+        </xsl:if>
+
+        <xsl:for-each select="id('search-modal', ixsl:page())//input[@name = 'q']">
+            <xsl:sequence select="ixsl:call(., 'focus', [])[current-date() lt xs:date('2000-01-01')]"/>
+        </xsl:for-each>
+    </xsl:template>
+
+    <!-- in-modal search form: re-run search immediately on Enter (no debounce) -->
+    <xsl:template match="form[contains-token(@class, 'search-form-modal')]" mode="ixsl:onsubmit">
+        <xsl:sequence select="ixsl:call(ixsl:event(), 'preventDefault', [])"/>
+        <xsl:variable name="text" select=".//input[@name = 'q']/ixsl:get(., 'value')" as="xs:string?"/>
+        <xsl:variable name="container-id" select="'search-results-container'" as="xs:string"/>
+        <xsl:variable name="cache" select="ixsl:get(ixsl:get(ixsl:window(), 'LinkedDataHub.contents'), '`' || $container-id || '`')" as="item()"/>
+
+        <xsl:choose>
+            <xsl:when test="string-length($text) gt 0">
+                <xsl:call-template name="ldh:SearchLoad">
+                    <xsl:with-param name="container" select="id($container-id, ixsl:page())"/>
+                    <xsl:with-param name="text" select="$text"/>
+                    <xsl:with-param name="endpoint" select="sd:endpoint()"/>
+                    <xsl:with-param name="cache" select="$cache"/>
+                </xsl:call-template>
+            </xsl:when>
+            <xsl:otherwise>
+                <xsl:for-each select="id($container-id, ixsl:page())/div[contains-token(@class, 'main')]">
+                    <xsl:result-document href="?." method="ixsl:replace-content"/>
+                </xsl:for-each>
+            </xsl:otherwise>
+        </xsl:choose>
+    </xsl:template>
+
+    <!-- in-modal search input: debounced live search (form-submit handles Enter) -->
+    <xsl:template match="div[@id = 'search-modal']//input[@name = 'q']" mode="ixsl:onkeyup">
+        <xsl:param name="delay" select="400" as="xs:integer"/>
+        <xsl:variable name="key-code" select="ixsl:get(ixsl:event(), 'code')" as="xs:string"/>
+        <xsl:variable name="text" select="ixsl:get(., 'value')" as="xs:string?"/>
+        <xsl:variable name="container-id" select="'search-results-container'" as="xs:string"/>
+        <xsl:variable name="cache" select="ixsl:get(ixsl:get(ixsl:window(), 'LinkedDataHub.contents'), '`' || $container-id || '`')" as="item()"/>
+
+        <xsl:choose>
+            <xsl:when test="$key-code = 'Enter'"/> <!-- handled by form-submit -->
+            <xsl:when test="string-length($text) gt 0">
+                <ixsl:schedule-action wait="$delay" document="ixsl:page()">
+                    <xsl:call-template name="ldh:SearchLoadDeferred">
+                        <xsl:with-param name="input" select="."/>
+                        <xsl:with-param name="text" select="$text"/>
+                        <xsl:with-param name="container-id" select="$container-id"/>
+                        <xsl:with-param name="cache" select="$cache"/>
+                    </xsl:call-template>
+                </ixsl:schedule-action>
+            </xsl:when>
+            <xsl:otherwise>
+                <xsl:for-each select="id($container-id, ixsl:page())/div[contains-token(@class, 'main')]">
+                    <xsl:result-document href="?." method="ixsl:replace-content"/>
+                </xsl:for-each>
+            </xsl:otherwise>
+        </xsl:choose>
+    </xsl:template>
+
+    <!-- deferred dispatch: only run the search if the input value still matches the captured text
+         (drops stale debounce hits when the user keeps typing) -->
+    <xsl:template name="ldh:SearchLoadDeferred">
+        <xsl:param name="input" as="element()"/>
+        <xsl:param name="text" as="xs:string"/>
+        <xsl:param name="container-id" as="xs:string"/>
+        <xsl:param name="cache" as="item()"/>
+
+        <xsl:if test="ixsl:get($input, 'value') = $text">
+            <xsl:call-template name="ldh:SearchLoad">
+                <xsl:with-param name="container" select="id($container-id, ixsl:page())"/>
+                <xsl:with-param name="text" select="$text"/>
+                <xsl:with-param name="endpoint" select="sd:endpoint()"/>
+                <xsl:with-param name="cache" select="$cache"/>
+            </xsl:call-template>
+        </xsl:if>
+    </xsl:template>
+
+    <!-- run a labelled-resource search filtered by $text and render results into $container -->
+    <xsl:template name="ldh:SearchLoad">
+        <xsl:param name="container" as="element()"/>
+        <xsl:param name="text" as="xs:string"/>
+        <xsl:param name="endpoint" as="xs:anyURI"/>
+        <xsl:param name="page-size" select="20" as="xs:integer"/>
+        <xsl:param name="cache" as="item()"/>
+        <xsl:param name="select-string" select="$select-labelled-string" as="xs:string"/>
+        <xsl:param name="label-var-name" select="'label'" as="xs:string"/>
+
+        <ixsl:set-style name="cursor" select="'progress'" object="ixsl:page()//body"/>
+
+        <xsl:variable name="select-json" as="item()">
+            <xsl:variable name="select-builder" select="ixsl:call(ixsl:get(ixsl:get(ixsl:window(), 'SPARQLBuilder'), 'SelectBuilder'), 'fromString', [ $select-string ])"/>
+            <xsl:sequence select="ixsl:call($select-builder, 'build', [])"/>
+        </xsl:variable>
+        <xsl:variable name="select-json-string" select="ixsl:call(ixsl:get(ixsl:window(), 'JSON'), 'stringify', [ $select-json ])" as="xs:string"/>
+        <xsl:variable name="select-xml" select="json-to-xml($select-json-string)" as="document-node()"/>
+        <!-- append FILTER(regex(?label, $text, 'iq')) to the WHERE clause -->
+        <xsl:variable name="select-xml" as="document-node()">
+            <xsl:document>
+                <xsl:apply-templates select="$select-xml" mode="ldh:add-regex-filter">
+                    <xsl:with-param name="var-name" select="$label-var-name" tunnel="yes"/>
+                    <xsl:with-param name="pattern" select="$text" tunnel="yes"/>
+                    <xsl:with-param name="flags" select="'iq'" tunnel="yes"/>
+                </xsl:apply-templates>
+            </xsl:document>
+        </xsl:variable>
+        <!-- LIMIT $page-size -->
+        <xsl:variable name="select-xml" as="document-node()">
+            <xsl:document>
+                <xsl:apply-templates select="$select-xml" mode="ldh:replace-limit">
+                    <xsl:with-param name="limit" select="$page-size" tunnel="yes"/>
+                </xsl:apply-templates>
+            </xsl:document>
+        </xsl:variable>
+
+        <ixsl:set-property name="select-xml" select="$select-xml" object="$cache"/>
+
+        <xsl:sequence select="ldh:update-progress-counter($cache, map{'container': $container}, 'init', 3)"/>
+
+        <xsl:variable name="view-context" as="map(*)">
+            <xsl:call-template name="ldh:RenderView">
+                <xsl:with-param name="container" select="$container"/>
+                <xsl:with-param name="active-mode" select="xs:anyURI('&ac;ListMode')"/>
+                <xsl:with-param name="select-string" select="$select-string"/>
+                <xsl:with-param name="select-xml" select="$select-xml"/>
+                <xsl:with-param name="initial-var-name" select="'resource'"/>
                 <xsl:with-param name="endpoint" select="$endpoint"/>
                 <xsl:with-param name="cache" select="$cache"/>
             </xsl:call-template>

--- a/src/main/webapp/static/com/atomgraph/linkeddatahub/xsl/bootstrap/2.3.2/layout.xsl
+++ b/src/main/webapp/static/com/atomgraph/linkeddatahub/xsl/bootstrap/2.3.2/layout.xsl
@@ -563,17 +563,9 @@ exclude-result-prefixes="#all">
 
     <!-- check if agent has access to the user endpoint by executing a dummy query ASK {} -->
     <xsl:template match="rdf:RDF[doc-available(resolve-uri('sparql?query=ASK%20%7B%7D', $ldt:base))] | srx:sparql[doc-available(resolve-uri('sparql?query=ASK%20%7B%7D', $ldt:base))]" mode="bs2:SearchBar" priority="1">
-        <form action="{ac:absolute-path(ldh:request-uri())}" method="get" class="navbar-form" accept-charset="UTF-8" title="{ac:label(key('resources', 'search-title', document('translations.rdf')))}">
+        <form action="{ac:absolute-path(ldh:request-uri())}" method="get" class="navbar-form" accept-charset="UTF-8" title="{ac:label(key('resources', 'address-bar-title', document('translations.rdf')))}">
             <div>
-                <input type="text" id="uri" name="uri" class="input-xxlarge typeahead"/>
-                <!-- placeholder used by the client-side typeahead -->
-                 <ul id="ul-{generate-id()}" class="search-typeahead typeahead dropdown-menu" style="display: none"/> 
-
-                <button type="submit">
-                    <xsl:apply-templates select="key('resources', 'search', document('translations.rdf'))" mode="ldh:logo">
-                        <xsl:with-param name="class" select="'btn btn-primary'"/>
-                    </xsl:apply-templates>
-                </button>
+                <input type="text" id="uri" name="uri" class="input-xxlarge"/>
             </div>
         </form>
     </xsl:template>

--- a/src/main/webapp/static/com/atomgraph/linkeddatahub/xsl/bootstrap/2.3.2/translations.rdf
+++ b/src/main/webapp/static/com/atomgraph/linkeddatahub/xsl/bootstrap/2.3.2/translations.rdf
@@ -148,6 +148,18 @@
         <rdfs:label xml:lang="en-US">Search for resources by title, label, content etc.</rdfs:label>
         <rdfs:label xml:lang="es-ES">Buscar recursos por título, etiqueta, contenido, etc.</rdfs:label>
     </rdf:Description>
+    <rdf:Description rdf:nodeID="address-bar">
+        <rdfs:label xml:lang="en-US">Go</rdfs:label>
+        <rdfs:label xml:lang="es-ES">Ir</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:nodeID="address-bar-title">
+        <rdfs:label xml:lang="en-US">Enter an http(s):// URI to navigate to</rdfs:label>
+        <rdfs:label xml:lang="es-ES">Introduzca una URI http(s):// para navegar</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:nodeID="search-placeholder">
+        <rdfs:label xml:lang="en-US">Search…</rdfs:label>
+        <rdfs:label xml:lang="es-ES">Buscar…</rdfs:label>
+    </rdf:Description>
     <rdf:Description rdf:nodeID="application-list-title">
         <rdfs:label xml:lang="en-US">Applications</rdfs:label>
         <rdfs:label xml:lang="es-ES">Aplicaciones</rdfs:label>

--- a/src/main/webapp/static/com/atomgraph/linkeddatahub/xsl/client.xsl
+++ b/src/main/webapp/static/com/atomgraph/linkeddatahub/xsl/client.xsl
@@ -120,7 +120,7 @@ extension-element-prefixes="ixsl"
     <xsl:param name="ldt:ontology" as="xs:anyURI?"/> <!-- used in Web-Client TO-DO: remove -->
     <xsl:param name="acl:agent" as="xs:anyURI?"/>
     <xsl:param name="foaf:Agent" select="if ($acl:agent) then document(ac:document-uri($acl:agent)) else ()" as="document-node()?"/> <!-- should be in SaxonJS documentPool -->
-    <xsl:param name="ac:lang" select="ixsl:get(ixsl:get(ixsl:page(), 'documentElement'), 'lang')" as="xs:string"/>
+    <xsl:param name="ac:lang" select="tokenize(ixsl:get(ixsl:get(ixsl:window(), 'navigator'), 'language'), '-')[1]" as="xs:string"/>
     <xsl:param name="ac:forClass" as="xs:anyURI?"/> <!-- used by Web-Client -->
     <xsl:param name="ac:query" select="ixsl:query-params()?query" as="xs:string?"/>
     <xsl:param name="ac:googleMapsKey" select="''" as="xs:string"/>  <!-- cannot remove yet as it's used by container.xsl in Web-Client -->
@@ -154,8 +154,9 @@ WHERE
         ?resource  a  $Type .
         ?resource rdfs:label|sh:name|dc:title|dct:title|foaf:name|foaf:givenName|foaf:familyName|sioc:name|skos:prefLabel|schema1:name|schema2:name $label
         FILTER isURI(?resource)
-    }  
+    }
   }
+ORDER BY ?label
 ]]>
     </xsl:param>
     <xsl:param name="backlinks-string" as="xs:string">
@@ -237,6 +238,7 @@ WHERE
         <xsl:message>xsl:product-name: <xsl:value-of select="system-property('xsl:product-name')"/></xsl:message>
         <xsl:message>saxon:platform: <xsl:value-of select="system-property('saxon:platform')"/></xsl:message>
         <xsl:message>$ac:contextUri: <xsl:value-of select="$ac:contextUri"/></xsl:message>
+        <xsl:message>$ac:lang: <xsl:value-of select="$ac:lang"/></xsl:message>
         <xsl:message>$acl:agent: <xsl:value-of select="$acl:agent"/></xsl:message>
         <xsl:message>ac:uri(): <xsl:value-of select="ac:uri()"/></xsl:message>
         <xsl:message>UTC offset: <xsl:value-of select="implicit-timezone()"/></xsl:message>
@@ -880,9 +882,9 @@ WHERE
         <xsl:if test="not(empty($state))">
             <xsl:variable name="href" select="map:get($state, 'href')" as="xs:anyURI?"/>
 
-            <!-- decode URI from the ?uri query param if the URI was proxied -->
+            <!-- decode URI from the ?uri query param if the URI was proxied; otherwise strip the query string so the cache key matches document-body/@about -->
             <xsl:variable name="query-params" select="ldh:parse-query-params(substring-after($href, '?'))" as="map(xs:string, xs:string*)"/>
-            <xsl:variable name="uri" select="if (map:contains($query-params, 'uri')) then xs:anyURI(map:get($query-params, 'uri')) else $href" as="xs:anyURI"/>
+            <xsl:variable name="uri" select="if (map:contains($query-params, 'uri')) then xs:anyURI(map:get($query-params, 'uri')) else ac:absolute-path($href)" as="xs:anyURI"/>
 
             <xsl:call-template name="ldh:DocumentNavigate">
                 <xsl:with-param name="uri" select="$uri"/>
@@ -901,7 +903,8 @@ WHERE
         <xsl:sequence select="ixsl:call(ixsl:event(), 'preventDefault', [])"/>
         <xsl:variable name="href" select="xs:anyURI(ac:document-uri(resolve-uri(@href, ldh:base-uri(.))))" as="xs:anyURI"/>
         <xsl:variable name="query-params" select="ldh:parse-query-params(substring-after($href, '?'))" as="map(xs:string, xs:string*)"/>
-        <xsl:variable name="uri" select="if (map:contains($query-params, 'uri')) then xs:anyURI(map:get($query-params, 'uri')) else $href" as="xs:anyURI"/>
+        <!-- proxied link: $uri is the external target (?uri=…); local link: $uri is the bare document URI without query so the cache key matches document-body/@about -->
+        <xsl:variable name="uri" select="if (map:contains($query-params, 'uri')) then xs:anyURI(map:get($query-params, 'uri')) else ac:absolute-path($href)" as="xs:anyURI"/>
 
         <xsl:call-template name="ldh:DocumentNavigate">
             <xsl:with-param name="uri" select="$uri"/>
@@ -947,102 +950,7 @@ WHERE
     <xsl:template match="*[contains-token(@class, 'btn-group')][*[contains-token(@class, 'dropdown-toggle')]]" mode="ixsl:onclick">
         <xsl:sequence select="ixsl:call(ixsl:get(., 'classList'), 'toggle', [ 'open' ])[current-date() lt xs:date('2000-01-01')]"/>
     </xsl:template>
-    
-    <!-- trigger typeahead in the search bar -->
-    
-    <xsl:template match="input[@id = 'uri']" mode="ixsl:onkeyup" priority="1">
-        <xsl:param name="text" select="ixsl:get(., 'value')" as="xs:string?"/>
-        <xsl:param name="menu" select="following-sibling::ul" as="element()"/>
-        <xsl:param name="delay" select="400" as="xs:integer"/>
-        <xsl:param name="resource-types" as="xs:anyURI?"/>
-        <xsl:param name="select-string" select="$select-labelled-string" as="xs:string"/>
-        <xsl:param name="limit" select="100" as="xs:integer"/>
-        <xsl:param name="label-var-name" select="'label'" as="xs:string"/>
-        <xsl:variable name="key-code" select="ixsl:get(ixsl:event(), 'code')" as="xs:string"/>
 
-        <xsl:choose>
-            <xsl:when test="$key-code = 'Escape'">
-                <xsl:call-template name="typeahead:hide">
-                    <xsl:with-param name="menu" select="$menu"/>
-                </xsl:call-template>
-            </xsl:when>
-            <xsl:when test="$key-code = 'Enter'">
-                <xsl:if test="$menu/li[contains-token(@class, 'active')]">
-                    <xsl:variable name="uri" select="$menu/li[contains-token(@class, 'active')]/input[@name = 'ou']/ixsl:get(., 'value')" as="xs:anyURI"/>
-
-                    <xsl:call-template name="ldh:DocumentNavigate">
-                        <xsl:with-param name="uri" select="$uri"/>
-                    </xsl:call-template>
-                </xsl:if>
-            </xsl:when>
-            <xsl:when test="$key-code = 'ArrowUp'">
-                <xsl:call-template name="typeahead:selection-up">
-                    <xsl:with-param name="menu" select="$menu"/>
-                </xsl:call-template>
-            </xsl:when>
-            <xsl:when test="$key-code = 'ArrowDown'">
-                <xsl:call-template name="typeahead:selection-down">
-                    <xsl:with-param name="menu" select="$menu"/>
-                </xsl:call-template>
-            </xsl:when>
-            <!-- if the input is not a URI, execute a keyword search with SPARQL regex() -->
-            <xsl:when test="not(starts-with(ixsl:get(., 'value'), 'http://')) and not(starts-with(ixsl:get(., 'value'), 'https://'))">
-                <xsl:variable name="select-builder" select="ixsl:call(ixsl:get(ixsl:get(ixsl:window(), 'SPARQLBuilder'), 'SelectBuilder'), 'fromString', [ $select-string ])"/>
-                <xsl:variable name="select-json-string" select="ixsl:call(ixsl:get(ixsl:window(), 'JSON'), 'stringify', [ ixsl:call($select-builder, 'build', []) ])" as="xs:string"/>
-                <xsl:variable name="select-xml" select="json-to-xml($select-json-string)" as="document-node()"/>
-                <!-- append FILTER(regex()) -->
-                <xsl:variable name="select-xml" as="document-node()">
-                    <xsl:document>
-                        <xsl:apply-templates select="$select-xml" mode="ldh:add-regex-filter">
-                            <xsl:with-param name="var-name" select="$label-var-name" tunnel="yes"/>
-                            <xsl:with-param name="pattern" select="$text" tunnel="yes"/>
-                            <xsl:with-param name="flags" select="'iq'" tunnel="yes"/> <!-- case insensitive, ignore meta-characters: https://www.w3.org/TR/xpath-functions-31/#flags -->
-                        </xsl:apply-templates>
-                    </xsl:document>
-                </xsl:variable>
-                <!-- set LIMIT -->
-                <xsl:variable name="select-xml" as="document-node()">
-                    <xsl:document>
-                        <xsl:apply-templates select="$select-xml" mode="ldh:replace-limit"/>
-                    </xsl:document>
-                </xsl:variable>
-                <!-- wrap SELECT into a DESCRIBE -->
-                <xsl:variable name="query-xml" as="element()">
-                    <xsl:apply-templates select="$select-xml" mode="ldh:wrap-describe"/>
-                </xsl:variable>
-                <xsl:variable name="query-json-string" select="xml-to-json($query-xml)" as="xs:string"/>
-                <xsl:variable name="query-json" select="ixsl:call(ixsl:get(ixsl:window(), 'JSON'), 'parse', [ $query-json-string ])"/>
-                <xsl:variable name="query-string" select="ixsl:call(ixsl:call(ixsl:get(ixsl:get(ixsl:window(), 'SPARQLBuilder'), 'SelectBuilder'), 'fromQuery', [ $query-json ]), 'toString', [])" as="xs:string"/>
-                <xsl:variable name="endpoint" select="sd:endpoint()" as="xs:anyURI"/>
-                <xsl:variable name="results-uri" select="ac:build-uri($endpoint, map{ 'query': string($query-string) })" as="xs:anyURI"/>
-                <xsl:variable name="request-uri" select="ldh:href($results-uri, map{})" as="xs:anyURI"/>
-                
-                <ixsl:schedule-action wait="$delay">
-                    <xsl:call-template name="typeahead:load-xml">
-                        <xsl:with-param name="element" select="."/>
-                        <xsl:with-param name="query" select="$text"/>
-                        <xsl:with-param name="uri" select="$request-uri"/>
-                    </xsl:call-template>
-                </ixsl:schedule-action>
-            </xsl:when>
-            <xsl:otherwise>
-                <xsl:call-template name="typeahead:hide">
-                    <xsl:with-param name="menu" select="$menu"/>
-                </xsl:call-template>
-            </xsl:otherwise>
-        </xsl:choose>
-    </xsl:template>
-    
-    <!-- navbar search typeahead item selected -->
-    
-    <xsl:template match="form[contains-token(@class, 'navbar-form')]//ul[contains-token(@class, 'dropdown-menu')][contains-token(@class, 'typeahead')]/li" mode="ixsl:onmousedown" priority="1">
-        <xsl:variable name="uri" select="input[@name = 'ou']/ixsl:get(., 'value')" as="xs:anyURI"/>
-
-        <xsl:call-template name="ldh:DocumentNavigate">
-            <xsl:with-param name="uri" select="$uri"/>
-        </xsl:call-template>
-    </xsl:template>
-    
     <xsl:template match="button[contains-token(@class, 'btn-delete')][not(contains-token(@class, 'disabled'))]" mode="ixsl:onclick">
         <xsl:variable name="request-uri" select="ldh:href(ac:absolute-path(ldh:base-uri(.)), map{})" as="xs:anyURI"/>
 
@@ -1104,7 +1012,8 @@ WHERE
         <xsl:sequence select="ixsl:call(ixsl:event(), 'preventDefault', [])"/>
         <xsl:variable name="href" select="xs:anyURI(resolve-uri(@href, ldh:base-uri(.)))" as="xs:anyURI"/>
         <xsl:variable name="query-params" select="ldh:parse-query-params(substring-after($href, '?'))" as="map(xs:string, xs:string*)"/>
-        <xsl:variable name="uri" select="if (map:contains($query-params, 'uri')) then xs:anyURI(map:get($query-params, 'uri')) else $href" as="xs:anyURI"/>
+        <!-- proxied tab: $uri is the external target (?uri=…); local tab: $uri is the bare document URI (no query string) - matches data-uri / document-body/@about, so the cache key downstream stays consistent -->
+        <xsl:variable name="uri" select="if (map:contains($query-params, 'uri')) then xs:anyURI(map:get($query-params, 'uri')) else ac:absolute-path($href)" as="xs:anyURI"/>
 
         <xsl:apply-templates select=".." mode="ldh:ActivateTab"/>
 
@@ -1137,7 +1046,7 @@ WHERE
 
             <xsl:variable name="fallback-href" select="xs:anyURI(resolve-uri($fallback-li/a/@href, ldh:base-uri(.)))" as="xs:anyURI"/>
             <xsl:variable name="fallback-query-params" select="ldh:parse-query-params(substring-after($fallback-href, '?'))" as="map(xs:string, xs:string*)"/>
-            <xsl:variable name="fallback-uri" select="if (map:contains($fallback-query-params, 'uri')) then xs:anyURI(map:get($fallback-query-params, 'uri')) else $fallback-href" as="xs:anyURI"/>
+            <xsl:variable name="fallback-uri" select="if (map:contains($fallback-query-params, 'uri')) then xs:anyURI(map:get($fallback-query-params, 'uri')) else ac:absolute-path($fallback-href)" as="xs:anyURI"/>
 
             <xsl:call-template name="ldh:DocumentNavigate">
                 <xsl:with-param name="uri" select="$fallback-uri"/>


### PR DESCRIPTION
View block now derives a variable→predicate-URI-set map from the SELECT's BGPs (handling alternative property paths like rdfs:label|sh:name|... whose items are URIs) and drives three things from it: the order-by dropdown (one option per variable, deduped), auto-pickup of ORDER BY from the SELECT, and a COALESCE-style client-side sort key that prefers literals whose @xml:lang primary subtag matches $ac:lang. `ORDER BY ?label` baked into $select-labelled-string so the modal search returns alphabetically by label.

Search modal: form moved into the modal-header with a magnifier submit button; `.search-form-modal` CSS extends `.search-form`'s flex layout so input + button fit naturally.

Empty address-bar submit button removed from the navbar-form (its ldh:logo template was never added; pressing Enter still submits).

$ac:lang now reads the primary subtag of navigator.language so existing `lang($ac:lang)` checks (which spec-match `xml:lang='en'` for input `'en'`, not for `'en-US'`) keep working under browser preferences like `en-US`.

Block mousemove handler guards the LinkedDataHub.contents cache lookup with ixsl:contains to avoid a warning per pixel when the hovered document-body's URI isn't cached.

Local-document navigation handlers (tab activate, tab-close fallback, popstate, generic link click) now strip the query string from $uri via ac:absolute-path before passing it to ldh:DocumentNavigate. The cache key downstream now matches document-body/@about / tab data-uri, both already canonicalised via ac:absolute-path.