### PR TITLE
Fix constructor-form staleness via xkey purge + async XSLT refactor

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -440,6 +440,14 @@ configs:
               ban("req.url == " + bereq.url + " && req.http.host == " + bereq.http.host);
           }
 
+          /* NS (ontology) SPARQL queries from authenticated clients are cache-busted per-request with _nc;
+             skip caching only for them (otherwise we'd both waste Varnish storage on one-shot entries
+             and open a DDoS vector for anonymous traffic crafting unique URLs) */
+          if (bereq.url ~ "^/ns\?" && bereq.http.Client-Cert) {
+              set beresp.uncacheable = true;
+              set beresp.ttl = 0s;
+          }
+
           return (deliver);
       }
   varnish-admin_vcl:
@@ -447,6 +455,7 @@ configs:
       vcl 4.0;
 
       import std;
+      import xkey;
 
       backend default {
           .host = "${VARNISH_ADMIN_BACKEND_HOST:-fuseki-admin}";
@@ -479,6 +488,14 @@ configs:
               return (synth(200, "Banned"));
           }
 
+          if (req.method == "XKEY-PURGE") {
+              if (!client.ip ~ local) {
+                  return (synth(403, "Unknown IP address '" + client.ip + "'. Access denied."));
+              }
+              set req.http.n-purged = xkey.softpurge(req.http.xkey-purge);
+              return (synth(200, "Purged " + req.http.n-purged + " objects for key " + req.http.xkey-purge));
+          }
+
           if (req.method != "GET" &&
             req.method != "HEAD" &&
             req.method != "PUT" &&
@@ -504,6 +521,11 @@ configs:
           if ((beresp.status == 200 || beresp.status == 201 || beresp.status == 204) && bereq.method ~ "POST|PUT|DELETE|PATCH") {
               set beresp.http.X-LinkedDataHub = "Banned";
               ban("req.url == " + bereq.url + " && req.http.host == " + bereq.http.host);
+          }
+
+          /* promote outbound surrogate-key hint from LDH into the indexed xkey header on the cached response */
+          if (bereq.http.X-Xkey-Promote) {
+              set beresp.http.xkey = bereq.http.X-Xkey-Promote;
           }
 
           return (deliver);
@@ -570,6 +592,8 @@ configs:
           if ((beresp.status == 200 || beresp.status == 201 || beresp.status == 204) && bereq.method ~ "POST|PUT|DELETE|PATCH") {
               set beresp.http.X-LinkedDataHub = "Banned";
               ban("req.url == " + bereq.url + " && req.http.host == " + bereq.http.host);
+              /* SPARQL query results depend on dataset state — any write invalidates every cached query. */
+              ban("req.url ~ \?(query|default-graph-uri|named-graph-uri)=");
           }
 
           return (deliver);

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -492,7 +492,11 @@ configs:
               if (!client.ip ~ local) {
                   return (synth(403, "Unknown IP address '" + client.ip + "'. Access denied."));
               }
-              set req.http.n-purged = xkey.softpurge(req.http.xkey-purge);
+              # hard purge, not softpurge: ClearOntology and CacheInvalidationFilter need strong
+              # consistency, not stale-while-revalidate. Softpurge would serve the just-purged
+              # object during beresp.grace (default 10s) and OntologyModelGetter's immediate reload
+              # would repopulate OntDocumentManager with stale data.
+              set req.http.n-purged = xkey.purge(req.http.xkey-purge);
               return (synth(200, "Purged " + req.http.n-purged + " objects for key " + req.http.xkey-purge));
           }
 

--- a/src/main/java/com/atomgraph/linkeddatahub/resource/admin/ClearOntology.java
+++ b/src/main/java/com/atomgraph/linkeddatahub/resource/admin/ClearOntology.java
@@ -89,30 +89,30 @@ public class ClearOntology
             ontModelSpec.getDocumentManager().getFileManager().removeCacheModel(ontologyURI);
 
             URI ontologyDocURI = UriBuilder.fromUri(ontologyURI).fragment(null).build(); // skip fragment from the ontology URI to get its graph URI
-            // purge from admin cache
+            // frontend proxy still uses URL-pattern BAN for direct document GETs (until Stage 3 brings xkey tagging to varnish-frontend).
+            // xkey purge covers proxied SPARQL CONSTRUCT/SELECT responses tagged by their backend (varnish-admin / varnish-end-user).
             URI frontendProxy = getSystem().getFrontendProxy();
             if (frontendProxy != null)
             {
                 if (log.isDebugEnabled()) log.debug("Purge ontology document with URI '{}' from frontend proxy cache", ontologyDocURI);
                 ban(frontendProxy, ontologyDocURI.toString(), false);
+                xkeyPurge(frontendProxy, ontologyURI);
             }
             URI adminBackendProxy = getSystem().getServiceContext(getApplication().getService()).getBackendProxy();
             if (adminBackendProxy != null)
             {
-                if (log.isDebugEnabled()) log.debug("Ban ontology with URI '{}' from backend proxy cache", ontologyURI);
-                ban(adminBackendProxy, ontologyURI);
-            }
-            // purge from end-user cache
-            if (frontendProxy != null)
-            {
-                if (log.isDebugEnabled()) log.debug("Purge ontology document with URI '{}' from frontend proxy cache", ontologyDocURI);
-                ban(frontendProxy, ontologyDocURI.toString(), false);
+                // URL-pattern BAN of the ontology URI is a no-op on the SPARQL proxy (its req.url namespace is /ds/?query=...,
+                // never containing the ontology URI as path), which is exactly why ontology reloads were getting stale CONSTRUCTs.
+                // xkey-purge of the same tag set by OntologyModelGetter's X-Xkey-Promote is what actually invalidates here.
+                if (log.isDebugEnabled()) log.debug("XKEY-PURGE ontology with URI '{}' from admin backend proxy cache", ontologyURI);
+                xkeyPurge(adminBackendProxy, ontologyURI);
             }
             URI endUserBackendProxy = getSystem().getServiceContext(endUserApp.getService()).getBackendProxy();
             if (endUserBackendProxy != null)
             {
-                if (log.isDebugEnabled()) log.debug("Ban ontology with URI '{}' from backend proxy cache", ontologyURI);
-                ban(endUserBackendProxy, ontologyURI);
+                // same reasoning as adminBackendProxy above. End-user proxy xkey-purge is no-op until Stage 2 lights up its VCL.
+                if (log.isDebugEnabled()) log.debug("XKEY-PURGE ontology with URI '{}' from end-user backend proxy cache", ontologyURI);
+                xkeyPurge(endUserBackendProxy, ontologyURI);
             }
             
             // !!! we need to reload the ontology model before returning a response, to make sure the next request already gets the new version !!!
@@ -164,6 +164,31 @@ public class ClearOntology
                 method("BAN", Response.class))
         {
             // Response automatically closed by try-with-resources
+        }
+    }
+
+    /**
+     * Surrogate-key purge: surgically evicts every cached object the proxy indexed with the given xkey tag.
+     * No URL parsing — xkey matches the tag byte-for-byte against {@code beresp.http.xkey} set in VCL.
+     *
+     * @param proxyURI proxy server URI
+     * @param tag xkey tag to purge (typically an absolute resource/graph URI)
+     */
+    public void xkeyPurge(URI proxyURI, String tag)
+    {
+        if (proxyURI == null) throw new IllegalArgumentException("Proxy URI cannot be null");
+        if (tag == null) throw new IllegalArgumentException("Tag cannot be null");
+
+        try (Response cr = getSystem().getClient().target(proxyURI).
+                request().
+                header("xkey-purge", tag).
+                method("XKEY-PURGE", Response.class))
+        {
+            if (log.isDebugEnabled()) log.debug("XKEY-PURGE on {} for tag '{}' returned status {}", proxyURI, tag, cr.getStatus());
+        }
+        catch (Exception ex)
+        {
+            if (log.isErrorEnabled()) log.error("XKEY-PURGE failed for tag: " + tag, ex);
         }
     }
     

--- a/src/main/java/com/atomgraph/linkeddatahub/server/util/OntologyModelGetter.java
+++ b/src/main/java/com/atomgraph/linkeddatahub/server/util/OntologyModelGetter.java
@@ -19,6 +19,9 @@ package com.atomgraph.linkeddatahub.server.util;
 import com.atomgraph.client.vocabulary.LDT;
 import com.atomgraph.linkeddatahub.apps.model.EndUserApplication;
 import com.atomgraph.server.exception.OntologyException;
+import jakarta.ws.rs.core.MultivaluedHashMap;
+import jakarta.ws.rs.core.MultivaluedMap;
+import jakarta.ws.rs.core.Response;
 import org.apache.jena.ontology.OntModelSpec;
 import org.apache.jena.query.ParameterizedSparqlString;
 import org.apache.jena.query.Query;
@@ -66,8 +69,19 @@ public class OntologyModelGetter implements org.apache.jena.rdf.model.ModelGette
         // attempt to load ontology model from the admin endpoint. TO-DO: is that necessary if ontologies terms are now stored in a single graph?
         ParameterizedSparqlString ontologyPss = new ParameterizedSparqlString(getOntologyQuery().toString());
         ontologyPss.setIri(LDT.ontology.getLocalName(), uri);
-        Model model = getSystem().getServiceContext(getApplication().getAdminApplication().getService()).getSPARQLClient().loadModel(ontologyPss.asQuery());
-        
+
+        // surrogate-key hint: tag the cached CONSTRUCT response in varnish-admin with the ontology graph URI
+        // so that ClearOntology's XKEY-PURGE for the same URI surgically evicts it
+        MultivaluedMap<String, Object> headers = new MultivaluedHashMap<>();
+        headers.putSingle("X-Xkey-Promote", uri);
+
+        Model model;
+        try (Response cr = getSystem().getServiceContext(getApplication().getAdminApplication().getService()).getSPARQLClient().
+                query(ontologyPss.asQuery(), Model.class, new MultivaluedHashMap<>(), headers))
+        {
+            model = cr.readEntity(Model.class);
+        }
+
         if (!model.isEmpty()) return model;
 
         // if SPARQL result model is empty, fallback to using FileManager

--- a/src/main/webapp/static/com/atomgraph/linkeddatahub/xsl/bootstrap/2.3.2/client/block/chart.xsl
+++ b/src/main/webapp/static/com/atomgraph/linkeddatahub/xsl/bootstrap/2.3.2/client/block/chart.xsl
@@ -652,7 +652,7 @@ exclude-result-prefixes="#all"
             <xsl:variable name="property-metadata" select="document($request-uri)" as="document-node()"/>
 
             <xsl:variable name="query-string" select="$constructor-query || ' VALUES $Type { ' || string-join(for $type in $types return '&lt;' || $type || '&gt;', ' ') || ' }'" as="xs:string"/>
-            <xsl:variable name="request-uri" select="ldh:href(ac:build-uri(resolve-uri('ns', ldt:base()), map{ 'query': $query-string, 'accept': 'application/sparql-results+xml' }), map{})" as="xs:anyURI"/>
+            <xsl:variable name="request-uri" select="ldh:href(ac:build-uri(resolve-uri('ns', ldt:base()), map{ 'query': $query-string, 'accept': 'application/sparql-results+xml', '_nc': ldh:nc() }), map{})" as="xs:anyURI"/>
             <xsl:variable name="constructors" select="if (exists($types)) then document($request-uri) else ()" as="document-node()?"/>
 
             <xsl:variable name="query-string" select="$constraint-query || ' VALUES $Type { ' || string-join(for $type in $types return '&lt;' || $type || '&gt;', ' ') || ' }'" as="xs:string"/>

--- a/src/main/webapp/static/com/atomgraph/linkeddatahub/xsl/bootstrap/2.3.2/client/constructor.xsl
+++ b/src/main/webapp/static/com/atomgraph/linkeddatahub/xsl/bootstrap/2.3.2/client/constructor.xsl
@@ -89,7 +89,7 @@ exclude-result-prefixes="#all"
         <ixsl:set-style name="cursor" select="'progress'" object="."/>
 
         <xsl:variable name="query-string" select="$constructor-query || ' VALUES $Type { &lt;' || $type || '&gt; }'" as="xs:string"/>
-        <xsl:variable name="results-uri" select="ac:build-uri(resolve-uri('ns', ldt:base()), map{ 'query': $query-string, '_nc': string(current-dateTime()) })" as="xs:anyURI"/>
+        <xsl:variable name="results-uri" select="ac:build-uri(resolve-uri('ns', ldt:base()), map{ 'query': $query-string, '_nc': ldh:nc() })" as="xs:anyURI"/>
         <xsl:variable name="request-uri" select="ldh:href($results-uri, map{})" as="xs:anyURI"/>
         <xsl:variable name="request" as="item()*">
             <ixsl:schedule-action http-request="map{ 'method': 'GET', 'href': $request-uri, 'headers': map{ 'Accept': 'application/sparql-results+xml' } }">

--- a/src/main/webapp/static/com/atomgraph/linkeddatahub/xsl/bootstrap/2.3.2/client/form.xsl
+++ b/src/main/webapp/static/com/atomgraph/linkeddatahub/xsl/bootstrap/2.3.2/client/form.xsl
@@ -332,7 +332,7 @@ WHERE
                     <xsl:variable name="property-metadata" select="document($request-uri)" as="document-node()"/>
 
                     <xsl:variable name="query-string" select="$constructor-query || ' VALUES $Type { ' || string-join(for $type in $types return '&lt;' || $type || '&gt;', ' ') || ' }'" as="xs:string"/>
-                    <xsl:variable name="request-uri" select="ldh:href(ac:build-uri(resolve-uri('ns', ldt:base()), map{ 'query': $query-string, 'accept': 'application/sparql-results+xml', '_nc': string(current-dateTime()) }), map{})" as="xs:anyURI"/>
+                    <xsl:variable name="request-uri" select="ldh:href(ac:build-uri(resolve-uri('ns', ldt:base()), map{ 'query': $query-string, 'accept': 'application/sparql-results+xml', '_nc': ldh:nc() }), map{})" as="xs:anyURI"/>
                     <xsl:variable name="constructors" select="if (exists($types)) then document($request-uri) else ()" as="document-node()?"/>
 
                     <xsl:variable name="query-string" select="$constraint-query || ' VALUES $Type { ' || string-join(for $type in $types return '&lt;' || $type || '&gt;', ' ') || ' }'" as="xs:string"/>
@@ -793,7 +793,7 @@ WHERE
             <xsl:variable name="property-metadata" select="document($request-uri)" as="document-node()"/>
 
             <xsl:variable name="query-string" select="$constructor-query || ' VALUES $Type { ' || string-join(for $type in $types return '&lt;' || $type || '&gt;', ' ') || ' }'" as="xs:string"/>
-            <xsl:variable name="request-uri" select="ldh:href(ac:build-uri(resolve-uri('ns', ldt:base()), map{ 'query': $query-string, 'accept': 'application/sparql-results+xml', '_nc': string(current-dateTime()) }), map{})" as="xs:anyURI"/>
+            <xsl:variable name="request-uri" select="ldh:href(ac:build-uri(resolve-uri('ns', ldt:base()), map{ 'query': $query-string, 'accept': 'application/sparql-results+xml', '_nc': ldh:nc() }), map{})" as="xs:anyURI"/>
             <xsl:variable name="constructors" select="if (exists($types)) then document($request-uri) else ()" as="document-node()?"/>
 
             <xsl:variable name="query-string" select="$constraint-query || ' VALUES $Type { ' || string-join(for $type in $types return '&lt;' || $type || '&gt;', ' ') || ' }'" as="xs:string"/>
@@ -907,7 +907,7 @@ WHERE
             <xsl:variable name="property-metadata" select="document($request-uri)" as="document-node()"/>
 
             <xsl:variable name="query-string" select="$constructor-query || ' VALUES $Type { ' || string-join(for $type in $types return '&lt;' || $type || '&gt;', ' ') || ' }'" as="xs:string"/>
-            <xsl:variable name="request-uri" select="ldh:href(ac:build-uri(resolve-uri('ns', ldt:base()), map{ 'query': $query-string, 'accept': 'application/sparql-results+xml', '_nc': string(current-dateTime()) }), map{})" as="xs:anyURI"/>
+            <xsl:variable name="request-uri" select="ldh:href(ac:build-uri(resolve-uri('ns', ldt:base()), map{ 'query': $query-string, 'accept': 'application/sparql-results+xml', '_nc': ldh:nc() }), map{})" as="xs:anyURI"/>
             <xsl:variable name="constructors" select="if (exists($types)) then document($request-uri) else ()" as="document-node()?"/>
 
             <xsl:variable name="query-string" select="$constraint-query || ' VALUES $Type { ' || string-join(for $type in $types return '&lt;' || $type || '&gt;', ' ') || ' }'" as="xs:string"/>
@@ -1173,7 +1173,7 @@ WHERE
                 <xsl:variable name="property-metadata" select="document($request-uri)" as="document-node()"/>
 
                 <xsl:variable name="query-string" select="$constructor-query || ' VALUES $Type { ' || string-join(for $type in $types return '&lt;' || $type || '&gt;', ' ') || ' }'" as="xs:string"/>
-                <xsl:variable name="request-uri" select="ldh:href(ac:build-uri(resolve-uri('ns', ldt:base()), map{ 'query': $query-string, 'accept': 'application/sparql-results+xml' }), map{})" as="xs:anyURI"/>
+                <xsl:variable name="request-uri" select="ldh:href(ac:build-uri(resolve-uri('ns', ldt:base()), map{ 'query': $query-string, 'accept': 'application/sparql-results+xml', '_nc': ldh:nc() }), map{})" as="xs:anyURI"/>
                 <xsl:variable name="constructors" select="if (exists($types)) then document($request-uri) else ()" as="document-node()?"/>
 
                 <xsl:variable name="query-string" select="$constraint-query || ' VALUES $Type { ' || string-join(for $type in $types return '&lt;' || $type || '&gt;', ' ') || ' }'" as="xs:string"/>

--- a/src/main/webapp/static/com/atomgraph/linkeddatahub/xsl/bootstrap/2.3.2/client/form.xsl
+++ b/src/main/webapp/static/com/atomgraph/linkeddatahub/xsl/bootstrap/2.3.2/client/form.xsl
@@ -332,7 +332,7 @@ WHERE
                     <xsl:variable name="property-metadata" select="document($request-uri)" as="document-node()"/>
 
                     <xsl:variable name="query-string" select="$constructor-query || ' VALUES $Type { ' || string-join(for $type in $types return '&lt;' || $type || '&gt;', ' ') || ' }'" as="xs:string"/>
-                    <xsl:variable name="request-uri" select="ldh:href(ac:build-uri(resolve-uri('ns', ldt:base()), map{ 'query': $query-string, 'accept': 'application/sparql-results+xml' }), map{})" as="xs:anyURI"/>
+                    <xsl:variable name="request-uri" select="ldh:href(ac:build-uri(resolve-uri('ns', ldt:base()), map{ 'query': $query-string, 'accept': 'application/sparql-results+xml', '_nc': string(current-dateTime()) }), map{})" as="xs:anyURI"/>
                     <xsl:variable name="constructors" select="if (exists($types)) then document($request-uri) else ()" as="document-node()?"/>
 
                     <xsl:variable name="query-string" select="$constraint-query || ' VALUES $Type { ' || string-join(for $type in $types return '&lt;' || $type || '&gt;', ' ') || ' }'" as="xs:string"/>
@@ -793,7 +793,7 @@ WHERE
             <xsl:variable name="property-metadata" select="document($request-uri)" as="document-node()"/>
 
             <xsl:variable name="query-string" select="$constructor-query || ' VALUES $Type { ' || string-join(for $type in $types return '&lt;' || $type || '&gt;', ' ') || ' }'" as="xs:string"/>
-            <xsl:variable name="request-uri" select="ldh:href(ac:build-uri(resolve-uri('ns', ldt:base()), map{ 'query': $query-string, 'accept': 'application/sparql-results+xml' }), map{})" as="xs:anyURI"/>
+            <xsl:variable name="request-uri" select="ldh:href(ac:build-uri(resolve-uri('ns', ldt:base()), map{ 'query': $query-string, 'accept': 'application/sparql-results+xml', '_nc': string(current-dateTime()) }), map{})" as="xs:anyURI"/>
             <xsl:variable name="constructors" select="if (exists($types)) then document($request-uri) else ()" as="document-node()?"/>
 
             <xsl:variable name="query-string" select="$constraint-query || ' VALUES $Type { ' || string-join(for $type in $types return '&lt;' || $type || '&gt;', ' ') || ' }'" as="xs:string"/>
@@ -907,7 +907,7 @@ WHERE
             <xsl:variable name="property-metadata" select="document($request-uri)" as="document-node()"/>
 
             <xsl:variable name="query-string" select="$constructor-query || ' VALUES $Type { ' || string-join(for $type in $types return '&lt;' || $type || '&gt;', ' ') || ' }'" as="xs:string"/>
-            <xsl:variable name="request-uri" select="ldh:href(ac:build-uri(resolve-uri('ns', ldt:base()), map{ 'query': $query-string, 'accept': 'application/sparql-results+xml' }), map{})" as="xs:anyURI"/>
+            <xsl:variable name="request-uri" select="ldh:href(ac:build-uri(resolve-uri('ns', ldt:base()), map{ 'query': $query-string, 'accept': 'application/sparql-results+xml', '_nc': string(current-dateTime()) }), map{})" as="xs:anyURI"/>
             <xsl:variable name="constructors" select="if (exists($types)) then document($request-uri) else ()" as="document-node()?"/>
 
             <xsl:variable name="query-string" select="$constraint-query || ' VALUES $Type { ' || string-join(for $type in $types return '&lt;' || $type || '&gt;', ' ') || ' }'" as="xs:string"/>

--- a/src/main/webapp/static/com/atomgraph/linkeddatahub/xsl/bootstrap/2.3.2/client/modal.xsl
+++ b/src/main/webapp/static/com/atomgraph/linkeddatahub/xsl/bootstrap/2.3.2/client/modal.xsl
@@ -1684,7 +1684,7 @@ LIMIT   10
             <xsl:variable name="property-metadata" select="document($request-uri)" as="document-node()"/>
 
             <xsl:variable name="query-string" select="$constructor-query || ' VALUES $Type { ' || string-join(for $type in $types return '&lt;' || $type || '&gt;', ' ') || ' }'" as="xs:string"/>
-            <xsl:variable name="request-uri" select="ldh:href(ac:build-uri(resolve-uri('ns', ldt:base()), map{ 'query': $query-string, 'accept': 'application/sparql-results+xml' }), map{})" as="xs:anyURI"/>
+            <xsl:variable name="request-uri" select="ldh:href(ac:build-uri(resolve-uri('ns', ldt:base()), map{ 'query': $query-string, 'accept': 'application/sparql-results+xml', '_nc': ldh:nc() }), map{})" as="xs:anyURI"/>
             <xsl:variable name="constructors" select="if (exists($types)) then document($request-uri) else ()" as="document-node()?"/>
 
             <xsl:variable name="query-string" select="$constraint-query || ' VALUES $Type { ' || string-join(for $type in $types return '&lt;' || $type || '&gt;', ' ') || ' }'" as="xs:string"/>

--- a/src/main/webapp/static/com/atomgraph/linkeddatahub/xsl/bootstrap/2.3.2/imports/default.xsl
+++ b/src/main/webapp/static/com/atomgraph/linkeddatahub/xsl/bootstrap/2.3.2/imports/default.xsl
@@ -233,12 +233,12 @@ exclude-result-prefixes="#all"
         <xsl:sequence select="map:merge((if (exists($mode)) then map{ 'mode': for $m in $mode return string($m) } else (), if ($forClass) then map{ 'forClass': string($forClass) } else ()))"/>
     </xsl:function>
 
-    <xsl:function name="ldh:query-result" as="document-node()" cache="yes">
+    <xsl:function name="ldh:query-result" as="document-node()">
         <xsl:param name="endpoint" as="xs:anyURI"/>
         <xsl:param name="query" as="xs:string"/>
         <xsl:variable name="results-uri" select="ac:build-uri($endpoint, map{ 'query': $query })" as="xs:anyURI"/>
         <xsl:variable name="request-uri" select="ldh:href($results-uri, map{})" as="xs:anyURI"/>
-        
+
         <xsl:sequence select="document($request-uri)"/>
     </xsl:function>
 
@@ -260,11 +260,31 @@ exclude-result-prefixes="#all"
         </xsl:choose>
     </xsl:function>
     
-    <xsl:function name="ldh:construct-forClass" as="document-node()" cache="yes">
+    <!-- Non-deterministic cache buster for client-side document() / ixsl:schedule-action URIs.
+         SaxonJS 3 treats the entire interactive page session as a single transformation, which makes
+         current-dateTime() (and any other deterministic XPath function) a constant for that session.
+         Concatenating it into a URL therefore produces the same URL on every call, the SaxonJS
+         document() pool returns the cached parse, and no fresh network fetch fires.
+         ixsl:call to JS Date.now() is non-deterministic by spec and produces a fresh millisecond
+         timestamp on every invocation. -->
+    <xsl:function name="ldh:nc" as="xs:string" use-when="system-property('xsl:product-name') = 'SaxonJS'">
+        <xsl:sequence select="string(ixsl:call(ixsl:get(ixsl:window(), 'Date'), 'now', []))"/>
+    </xsl:function>
+
+    <!-- SSR fallback: each server-side transformation is fresh, so current-dateTime() varies between
+         requests; no document-pool persistence to defeat. -->
+    <xsl:function name="ldh:nc" as="xs:string" use-when="system-property('xsl:product-name') = 'SAXON'">
+        <xsl:sequence select="string(current-dateTime())"/>
+    </xsl:function>
+
+    <xsl:function name="ldh:construct-forClass" as="document-node()">
         <xsl:param name="forClass" as="xs:anyURI+"/>
-        <xsl:variable name="results-uri" select="ac:build-uri(resolve-uri('ns', ldt:base()), map{ 'forClass': for $class in $forClass return string($class), 'accept': 'application/rdf+xml' })" as="xs:anyURI"/>
+        <!-- _nc makes each invocation a unique URI to defeat the SaxonJS document() pool, which would
+             otherwise return the parsed constructor doc cached at first call for the rest of the page session,
+             even after the constructor itself was edited and the in-memory ontology reloaded. -->
+        <xsl:variable name="results-uri" select="ac:build-uri(resolve-uri('ns', ldt:base()), map{ 'forClass': for $class in $forClass return string($class), 'accept': 'application/rdf+xml', '_nc': ldh:nc() })" as="xs:anyURI"/>
         <xsl:variable name="request-uri" select="ldh:href($results-uri, map{})" as="xs:anyURI"/>
-            
+
         <xsl:sequence select="document($request-uri)"/>
     </xsl:function>
     


### PR DESCRIPTION
Resolves a constructor-form staleness symptom: after adding a property to a constructor (e.g. `skos:prefLabel`) and reopening the Create form for that class, the form would still render against the pre-edit constructor until a full page reload. Three layers of fix, originally scoped to the first.

**varnish-admin surrogate-key invalidation.** URL-pattern BAN couldn't match cached SPARQL CONSTRUCT responses whose URL carried the affected URI only inside the opaque percent-encoded `?query=` blob, so ontology reloads after `admin/clear` were served stale CONSTRUCT responses (Age: 180), repopulating `OntDocumentManager` with old data. varnish-admin now imports `vmod_xkey`, exposes an `XKEY-PURGE` method in `vcl_recv`, and promotes `X-Xkey-Promote` outbound from the backend to `beresp.http.xkey` in `vcl_backend_response`. `OntologyModelGetter` tags its CONSTRUCT with the ontology URI via the headers-accepting `SPARQLClient.query()` overload, and `ClearOntology` fires `XKEY-PURGE` on the frontend / admin-backend / end-user-backend proxies, replacing the previous no-op `ban(backendProxy, ontologyURI)` calls (their `req.url` namespace is `/ds/?query=…`, never the ontology URI as a path). Hard `xkey.purge` rather than `softpurge` because the same request re-fetches immediately and grace serving would just hand back the stale copy. Stage 1 of a three-stage migration; varnish-frontend and varnish-end-user are still BAN-driven and out of scope here.

**SaxonJS document() pool tactical buster.** `ldh:construct-forClass` and the four sibling sync `document()` callers (type-metadata, constructors, constraints, shapes) bypass the network on repeat calls because SaxonJS pools document() results for the lifetime of the page session. `_nc=current-dateTime()` couldn't break the pool — XPath F&O makes `current-dateTime()` stable within a single transformation, and SaxonJS treats the entire interactive page session as one transformation. New `ldh:nc()` helper returns a fresh millisecond timestamp via `ixsl:call(Date, "now", [])` (non-deterministic) with a Saxon-EE fallback for SSR (`use-when` keeps `current-dateTime()` there, since each server request is its own transformation). Applied at all eight `_nc` sites. Tactical patch — the proper fix is the async refactor below.

**Async ixsl:promise refactor.** Replaces synchronous `document()` fetches at every constructor- and shape-related user-interaction entry point with async `ixsl:promise` chains following the established LDH convention (`rethread-response` / `handle-response` / `http-request-threaded` + load-X / set-X / terminal render pair). New reusable load/set pairs: `ldh:load-constructed-doc` / `ldh:set-constructed-doc` in `imports/default.xsl`, `ldh:load-constructors` / `ldh:set-constructors` and `ldh:load-shapes` / `ldh:set-shapes` in `client/form.xsl`. Per-caller terminal callbacks: `ldh:render-add-row-form`, `ldh:render-add-value`, `ldh:render-add-modal-form`, `ldh:render-row-form-violation`, `ldh:render-chart-row-form`, `ldh:render-typeahead-row-form`, `ldh:render-constructor-mode`, `ldh:render-signup-form`. Migrated chains: row-fluid add-constructor onclick, add-value onclick, type-typeahead onmousedown, modal action-bar add-constructor onclick, chart `btn-create-chart` onclick, `ldh:row-form-submit-violation` terminal, `constructor.xsl` `ldh:LoadConstructors` (off `ixsl:schedule-action`), the existing edit-form chain extended with constructors+shapes load/set, and `signup.xsl` `bs2:Row` — the latter uses a placeholder div + `xsl:result-document method="ixsl:replace-content"` because it's a render-time template, not an event handler. Dead constructor SELECT / shape DESCRIBE fetches deleted from `ldh:set-type-metadata` and `ldh:modal-form-submit-violation`. `ldh:render-add-row-form` switched from applying templates to the whole `\$constructed-doc` to applying to `\$resource` to avoid whitespace-text-node leakage (`xsl:strip-space` applies only to document()-loaded sources, not to `?body` from `ixsl:http-request`).

Two `ldh:construct-forClass` callers remain — `resource.xsl:1234` and the `document.xsl:1156,1158` sync `ldh:query-result()` calls — sitting in `xsl:param` defaults that need a calling-pipeline restructure deferred to a follow-up. The deprecated `ldh:construct-forClass` stays in `default.xsl` until those land.