### PR TITLE
Convert modal-form metadata fetches to async load/set pairs

### DIFF
--- a/src/main/webapp/static/com/atomgraph/linkeddatahub/xsl/bootstrap/2.3.2/client/block.xsl
+++ b/src/main/webapp/static/com/atomgraph/linkeddatahub/xsl/bootstrap/2.3.2/client/block.xsl
@@ -653,12 +653,15 @@ exclude-result-prefixes="#all"
     <xsl:function name="ldh:load-object-metadata" as="map(*)" ixsl:updating="yes">
         <xsl:param name="context" as="map(*)"/>
         <xsl:param name="response-key" as="xs:string"/>
-        <xsl:variable name="response" select="$context($response-key)" as="map(*)"/>
         <xsl:variable name="endpoint" select="$context('endpoint')" as="xs:anyURI"/>
+        <!-- prefer caller-supplied object-uris in context (form flows compute these from $resource or $body upstream); fall back to extracting from the named response (block flows) -->
         <xsl:variable name="object-uris" as="xs:string*" select="
-            if ($response?status = 200 and $response?media-type = 'application/rdf+xml')
-            then distinct-values($response?body/rdf:RDF/rdf:Description/*/@rdf:resource[not(key('resources', .))])
-            else ()"/>
+            if (map:contains($context, 'object-uris')) then $context('object-uris')
+            else
+                let $response := $context($response-key)
+                return if ($response?status = 200 and $response?media-type = 'application/rdf+xml')
+                       then distinct-values($response?body/rdf:RDF/rdf:Description/*/@rdf:resource[not(key('resources', .))])
+                       else ()"/>
         <xsl:variable name="query-string" select="$object-metadata-query || ' VALUES $this { ' || string-join(for $uri in $object-uris return '&lt;' || $uri || '&gt;', ' ') || ' }'" as="xs:string"/>
         <xsl:variable name="request" select="map{ 'method': 'POST', 'href': ldh:href($endpoint), 'media-type': 'application/sparql-query', 'body': $query-string, 'headers': map{ 'Accept': 'application/rdf+xml' } }" as="map(*)"/>
 
@@ -704,11 +707,14 @@ exclude-result-prefixes="#all"
     <xsl:function name="ldh:load-property-metadata" as="map(*)" ixsl:updating="yes">
         <xsl:param name="context" as="map(*)"/>
         <xsl:param name="response-key" as="xs:string"/>
-        <xsl:variable name="response" select="$context($response-key)" as="map(*)"/>
+        <!-- prefer caller-supplied property-uris in context (form flows compute these from $resource or $body upstream); fall back to extracting from the named response (block flows) -->
         <xsl:variable name="property-uris" as="xs:string*" select="
-            if ($response?status = 200 and $response?media-type = 'application/rdf+xml')
-            then distinct-values($response?body/rdf:RDF/rdf:Description/*/concat(namespace-uri(), local-name()))
-            else ()"/>
+            if (map:contains($context, 'property-uris')) then $context('property-uris')
+            else
+                let $response := $context($response-key)
+                return if ($response?status = 200 and $response?media-type = 'application/rdf+xml')
+                       then distinct-values($response?body/rdf:RDF/rdf:Description/*/concat(namespace-uri(), local-name()))
+                       else ()"/>
         <xsl:variable name="query-string" select="$property-metadata-query || ' VALUES $Type { ' || string-join(for $uri in $property-uris return '&lt;' || $uri || '&gt;', ' ') || ' }'" as="xs:string"/>
         <xsl:variable name="request" select="map{ 'method': 'POST', 'href': ldh:href(resolve-uri('ns', ldt:base())), 'media-type': 'application/sparql-query', 'body': $query-string, 'headers': map{ 'Accept': 'application/rdf+xml' } }" as="map(*)"/>
 

--- a/src/main/webapp/static/com/atomgraph/linkeddatahub/xsl/bootstrap/2.3.2/client/form.xsl
+++ b/src/main/webapp/static/com/atomgraph/linkeddatahub/xsl/bootstrap/2.3.2/client/form.xsl
@@ -186,11 +186,6 @@ WHERE
         <ixsl:set-attribute name="value" select="normalize-space(ixsl:get(., 'value'))"/>
     </xsl:template>
 
-    <!-- remove names of RDF/POST inputs with empty values -->
-    <xsl:template match="input[@name = ('ob', 'ou', 'ol')][not(ixsl:get(., 'value'))]" mode="ldh:FormPreSubmit" priority="2">
-        <ixsl:remove-attribute name="name"/>
-    </xsl:template>
-
     <!-- append timezone to the datetime-local values -->
     <xsl:template match="input[@type = 'datetime-local'][ixsl:get(., 'value')]" mode="ldh:FormPreSubmit" priority="1">
         <!-- set the input type back to 'text' because 'datetime-local' does not accept the timezoned value -->

--- a/src/main/webapp/static/com/atomgraph/linkeddatahub/xsl/bootstrap/2.3.2/client/form.xsl
+++ b/src/main/webapp/static/com/atomgraph/linkeddatahub/xsl/bootstrap/2.3.2/client/form.xsl
@@ -1366,8 +1366,6 @@ WHERE
                 <xsl:apply-templates select="id(@id, ixsl:page())" mode="ldh:RenderRowForm"/>
             </xsl:if>
         </xsl:for-each>
-
-        <ixsl:set-style name="cursor" select="'default'" object="ixsl:page()//body"/>
     </xsl:function>
 
     <xsl:template match="ul[contains-token(@class, 'dropdown-menu')][contains-token(@class, 'type-typeahead')]/li" mode="ixsl:onmousedown" priority="1">
@@ -1415,32 +1413,19 @@ WHERE
         }"/>
 
         <ixsl:promise select="ixsl:resolve($context) =>
-            ixsl:then(ldh:load-constructed-doc#1) =>
-            ixsl:then(ldh:http-request-threaded(?, 'constructed-doc-request', 'constructed-doc-response')) =>
-            ixsl:then(ldh:handle-response(?, 'constructed-doc-response')) =>
-            ixsl:then(ldh:set-constructed-doc#1) =>
-            ixsl:then(ldh:load-shapes#1) =>
-            ixsl:then(ldh:http-request-threaded(?, 'shapes-request', 'shapes-response')) =>
-            ixsl:then(ldh:handle-response(?, 'shapes-response')) =>
-            ixsl:then(ldh:set-shapes#1) =>
+            ixsl:then(ldh:fire-load-set-parallel(?, [
+              [ ldh:load-constructed-doc#1, 'constructed-doc-request', 'constructed-doc-response', ldh:set-constructed-doc#1 ],
+              [ ldh:load-shapes#1,          'shapes-request',          'shapes-response',          ldh:set-shapes#1 ]
+            ])) =>
             ixsl:then(ldh:set-typeahead-form-resource#1) =>
-            ixsl:then(ldh:load-constructors#1) =>
-            ixsl:then(ldh:http-request-threaded(?, 'constructors-request', 'constructors-response')) =>
-            ixsl:then(ldh:handle-response(?, 'constructors-response')) =>
-            ixsl:then(ldh:set-constructors#1) =>
-            ixsl:then(ldh:load-type-metadata#1) =>
-            ixsl:then(ldh:http-request-threaded(?, 'type-metadata-request', 'type-metadata-response')) =>
-            ixsl:then(ldh:handle-response(?, 'type-metadata-response')) =>
-            ixsl:then(ldh:set-type-metadata#1) =>
-            ixsl:then(ldh:load-property-metadata#1) =>
-            ixsl:then(ldh:http-request-threaded(?, 'property-metadata-request', 'property-metadata-response')) =>
-            ixsl:then(ldh:handle-response(?, 'property-metadata-response')) =>
-            ixsl:then(ldh:set-property-metadata#1) =>
-            ixsl:then(ldh:load-constraints#1) =>
-            ixsl:then(ldh:http-request-threaded(?, 'constraints-request', 'constraints-response')) =>
-            ixsl:then(ldh:handle-response(?, 'constraints-response')) =>
-            ixsl:then(ldh:set-constraints#1) =>
-            ixsl:then(ldh:render-typeahead-row-form#1)"
+            ixsl:then(ldh:fire-load-set-parallel(?, [
+              [ ldh:load-constructors#1,      'constructors-request',      'constructors-response',      ldh:set-constructors#1 ],
+              [ ldh:load-type-metadata#1,     'type-metadata-request',     'type-metadata-response',     ldh:set-type-metadata#1 ],
+              [ ldh:load-property-metadata#1, 'property-metadata-request', 'property-metadata-response', ldh:set-property-metadata#1 ],
+              [ ldh:load-constraints#1,       'constraints-request',       'constraints-response',       ldh:set-constraints#1 ]
+            ])) =>
+            ixsl:then(ldh:render-typeahead-row-form#1) =>
+            ixsl:finally(ldh:reset-cursor#0)"
             on-failure="ldh:promise-failure#1"/>
     </xsl:template>
     

--- a/src/main/webapp/static/com/atomgraph/linkeddatahub/xsl/bootstrap/2.3.2/client/form.xsl
+++ b/src/main/webapp/static/com/atomgraph/linkeddatahub/xsl/bootstrap/2.3.2/client/form.xsl
@@ -185,12 +185,12 @@ WHERE
     <xsl:template match="input[@name = ('ob', 'ou')][ixsl:get(., 'value')]" mode="ldh:FormPreSubmit" priority="1">
         <ixsl:set-attribute name="value" select="normalize-space(ixsl:get(., 'value'))"/>
     </xsl:template>
-    
+
     <!-- remove names of RDF/POST inputs with empty values -->
     <xsl:template match="input[@name = ('ob', 'ou', 'ol')][not(ixsl:get(., 'value'))]" mode="ldh:FormPreSubmit" priority="2">
         <ixsl:remove-attribute name="name"/>
     </xsl:template>
-    
+
     <!-- append timezone to the datetime-local values -->
     <xsl:template match="input[@type = 'datetime-local'][ixsl:get(., 'value')]" mode="ldh:FormPreSubmit" priority="1">
         <!-- set the input type back to 'text' because 'datetime-local' does not accept the timezoned value -->
@@ -262,23 +262,17 @@ WHERE
             'block': $block,
             'about': $about
           }"/>
+        <!-- ldh:fetch-and-load-edited-resource bakes a GET-style type-metadata-request directly, so the type-metadata pair uses an identity load-fn rather than ldh:load-type-metadata (which would build a different POST-style request). -->
         <ixsl:promise select="
-          ixsl:http-request($context('request'))
-            => ixsl:then(ldh:rethread-response($context, ?))
-            => ixsl:then(ldh:handle-response#1)
-            => ixsl:then(ldh:load-edited-resource#1)
-            => ixsl:then(ldh:http-request-threaded(?, 'type-metadata-request', 'type-metadata-response'))
-            => ixsl:then(ldh:handle-response(?, 'type-metadata-response'))
-            => ixsl:then(ldh:set-type-metadata#1)
-            => ixsl:then(ldh:load-constructors#1)
-            => ixsl:then(ldh:http-request-threaded(?, 'constructors-request', 'constructors-response'))
-            => ixsl:then(ldh:handle-response(?, 'constructors-response'))
-            => ixsl:then(ldh:set-constructors#1)
-            => ixsl:then(ldh:load-shapes#1)
-            => ixsl:then(ldh:http-request-threaded(?, 'shapes-request', 'shapes-response'))
-            => ixsl:then(ldh:handle-response(?, 'shapes-response'))
-            => ixsl:then(ldh:set-shapes#1)
+          ixsl:resolve($context)
+            => ixsl:then(ldh:fetch-and-load-edited-resource#1)
+            => ixsl:then(ldh:fire-load-set-parallel(?, [
+                 [ function($ctx as map(*)) as map(*) { $ctx }, 'type-metadata-request', 'type-metadata-response', ldh:set-type-metadata#1 ],
+                 [ ldh:load-constructors#1,                     'constructors-request',  'constructors-response',  ldh:set-constructors#1 ],
+                 [ ldh:load-shapes#1,                           'shapes-request',        'shapes-response',        ldh:set-shapes#1 ]
+               ]))
             => ixsl:then(ldh:render-row-form#1)
+            => ixsl:finally(ldh:reset-cursor#0)
         " on-failure="ldh:promise-failure#1"/>
     </xsl:template>
 
@@ -553,10 +547,8 @@ WHERE
 
         <!-- initialize event listeners -->
         <xsl:apply-templates select="$block" mode="ldh:RenderRowForm"/>
-
-        <ixsl:set-style name="cursor" select="'default'" object="ixsl:page()//body"/>
     </xsl:function>
-    
+
     <xsl:function name="ldh:render-form" as="item()*" ixsl:updating="yes">
         <xsl:param name="context" as="map(*)"/>
         <xsl:variable name="block" select="$context('block')" as="element()"/>
@@ -719,7 +711,7 @@ WHERE
     </xsl:template>
 
     <!-- submit instance update row-form using PATCH -->
-    
+
     <xsl:template match="div[contains-token(@class, 'block')]//form[contains-token(@class, 'form-horizontal')][upper-case(@method) = 'PATCH']" mode="ixsl:onsubmit" priority="1">
         <xsl:param name="block" select="ancestor::div[contains-token(@class, 'block')][1]" as="element()"/>
         <xsl:sequence select="ixsl:call(ixsl:event(), 'preventDefault', [])"/>
@@ -737,7 +729,7 @@ WHERE
         <xsl:apply-templates select="." mode="ldh:FormPreSubmit"/>
 
         <xsl:variable name="elements" select=".//input | .//textarea | .//select" as="element()*"/>
-        <xsl:variable name="triples" select="ldh:parse-rdf-post($elements)" as="element()*"/>        
+        <xsl:variable name="triples" select="ldh:parse-rdf-post($elements)" as="element()*"/>
         <!-- canonicalize XML in rdf:XMLLiterals -->
         <xsl:variable name="triples" as="element()*">
             <xsl:apply-templates select="$triples" mode="ldh:CanonicalizeXML"/>
@@ -971,32 +963,18 @@ WHERE
             }
         ), map{ 'duplicates': 'use-last' })"/>
 
+        <!-- $new-context is built synchronously above; types/property-uris/object-uris populated from the violation response body. No pre-baked type-metadata-request here, so the type-metadata pair uses the normal ldh:load-type-metadata. -->
         <ixsl:promise select="ixsl:resolve($new-context) =>
-            ixsl:then(ldh:load-constructors#1) =>
-            ixsl:then(ldh:http-request-threaded(?, 'constructors-request', 'constructors-response')) =>
-            ixsl:then(ldh:handle-response(?, 'constructors-response')) =>
-            ixsl:then(ldh:set-constructors#1) =>
-            ixsl:then(ldh:load-shapes#1) =>
-            ixsl:then(ldh:http-request-threaded(?, 'shapes-request', 'shapes-response')) =>
-            ixsl:then(ldh:handle-response(?, 'shapes-response')) =>
-            ixsl:then(ldh:set-shapes#1) =>
-            ixsl:then(ldh:load-type-metadata#1) =>
-            ixsl:then(ldh:http-request-threaded(?, 'type-metadata-request', 'type-metadata-response')) =>
-            ixsl:then(ldh:handle-response(?, 'type-metadata-response')) =>
-            ixsl:then(ldh:set-type-metadata#1) =>
-            ixsl:then(ldh:load-property-metadata#1) =>
-            ixsl:then(ldh:http-request-threaded(?, 'property-metadata-request', 'property-metadata-response')) =>
-            ixsl:then(ldh:handle-response(?, 'property-metadata-response')) =>
-            ixsl:then(ldh:set-property-metadata#1) =>
-            ixsl:then(ldh:load-constraints#1) =>
-            ixsl:then(ldh:http-request-threaded(?, 'constraints-request', 'constraints-response')) =>
-            ixsl:then(ldh:handle-response(?, 'constraints-response')) =>
-            ixsl:then(ldh:set-constraints#1) =>
-            ixsl:then(ldh:load-object-metadata#1) =>
-            ixsl:then(ldh:http-request-threaded(?, 'metadata-request', 'metadata-response')) =>
-            ixsl:then(ldh:handle-response(?, 'metadata-response')) =>
-            ixsl:then(ldh:set-object-metadata#1) =>
-            ixsl:then(ldh:render-row-form-violation#1)"
+            ixsl:then(ldh:fire-load-set-parallel(?, [
+              [ ldh:load-constructors#1,      'constructors-request',      'constructors-response',      ldh:set-constructors#1 ],
+              [ ldh:load-shapes#1,            'shapes-request',            'shapes-response',            ldh:set-shapes#1 ],
+              [ ldh:load-type-metadata#1,     'type-metadata-request',     'type-metadata-response',     ldh:set-type-metadata#1 ],
+              [ ldh:load-property-metadata#1, 'property-metadata-request', 'property-metadata-response', ldh:set-property-metadata#1 ],
+              [ ldh:load-constraints#1,       'constraints-request',       'constraints-response',       ldh:set-constraints#1 ],
+              [ ldh:load-object-metadata#1,   'metadata-request',          'metadata-response',          ldh:set-object-metadata#1 ]
+            ])) =>
+            ixsl:then(ldh:render-row-form-violation#1) =>
+            ixsl:finally(ldh:reset-cursor#0)"
             on-failure="ldh:promise-failure#1"/>
     </xsl:function>
 
@@ -1040,8 +1018,6 @@ WHERE
         <xsl:for-each select="id($block/@id, ixsl:page())">
             <xsl:apply-templates select="." mode="ldh:RenderRowForm"/>
         </xsl:for-each>
-
-        <ixsl:set-style name="cursor" select="'default'" object="ixsl:page()//body"/>
     </xsl:function>
 
     <xsl:function name="ldh:replace-content" as="map(*)" ixsl:updating="yes">

--- a/src/main/webapp/static/com/atomgraph/linkeddatahub/xsl/bootstrap/2.3.2/client/form.xsl
+++ b/src/main/webapp/static/com/atomgraph/linkeddatahub/xsl/bootstrap/2.3.2/client/form.xsl
@@ -282,6 +282,42 @@ WHERE
         " on-failure="ldh:promise-failure#1"/>
     </xsl:template>
 
+    <!-- Async type-metadata fetch pair (DESCRIBE against /ns for type URIs). Reads context('types'),
+         stores parsed RDF/XML at context('type-metadata'). Used by chains that have types in context
+         without going through ldh:load-edited-resource (which builds its own type-metadata-request). -->
+    <xsl:function name="ldh:load-type-metadata" as="map(*)" ixsl:updating="yes">
+        <xsl:param name="context" as="map(*)"/>
+        <xsl:variable name="types" select="$context('types')" as="xs:anyURI*"/>
+        <xsl:variable name="query-string" select="'DESCRIBE $Type VALUES $Type { ' || string-join(for $t in $types return '&lt;' || $t || '&gt;', ' ') || ' }'" as="xs:string"/>
+        <xsl:variable name="request" select="map{ 'method': 'POST', 'href': ldh:href(resolve-uri('ns', ldt:base())), 'media-type': 'application/sparql-query', 'body': $query-string, 'headers': map{ 'Accept': 'application/rdf+xml' } }" as="map(*)"/>
+        <xsl:sequence select="map:merge(($context, map{ 'type-metadata-request': $request }))"/>
+    </xsl:function>
+
+    <!-- Async constraint-query fetch pair (SPARQL SELECT against /ns?query= for ?Type spin:constraint ?constraint).
+         Reads context('types'), stores parsed sparql-results at context('constraints'). -->
+    <xsl:function name="ldh:load-constraints" as="map(*)" ixsl:updating="yes">
+        <xsl:param name="context" as="map(*)"/>
+        <xsl:variable name="types" select="$context('types')" as="xs:anyURI*"/>
+        <xsl:variable name="query-string" select="$constraint-query || ' VALUES $Type { ' || string-join(for $t in $types return '&lt;' || $t || '&gt;', ' ') || ' }'" as="xs:string"/>
+        <xsl:variable name="request" select="map{ 'method': 'POST', 'href': ldh:href(resolve-uri('ns', ldt:base())), 'media-type': 'application/sparql-query', 'body': $query-string, 'headers': map{ 'Accept': 'application/sparql-results+xml' } }" as="map(*)"/>
+        <xsl:sequence select="map:merge(($context, map{ 'constraints-request': $request }))"/>
+    </xsl:function>
+
+    <xsl:function name="ldh:set-constraints" as="map(*)" ixsl:updating="yes">
+        <xsl:param name="context" as="map(*)"/>
+        <xsl:variable name="response" select="$context('constraints-response')" as="map(*)"/>
+        <xsl:for-each select="$response">
+            <xsl:choose>
+                <xsl:when test="?status = 200 and ?media-type = 'application/sparql-results+xml'">
+                    <xsl:sequence select="map:merge(($context, map{ 'constraints': ?body }))"/>
+                </xsl:when>
+                <xsl:otherwise>
+                    <xsl:sequence select="$context"/>
+                </xsl:otherwise>
+            </xsl:choose>
+        </xsl:for-each>
+    </xsl:function>
+
     <xsl:function name="ldh:load-edited-resource" as="map(*)" ixsl:updating="yes">
         <xsl:param name="context" as="map(*)"/>
         <xsl:variable name="response" select="$context('response')" as="map(*)"/>
@@ -306,11 +342,16 @@ WHERE
                         <xsl:variable name="results-uri" select="ac:build-uri(resolve-uri('ns', ldt:base()), map{ 'query': $query-string, 'accept': 'application/rdf+xml' })" as="xs:anyURI"/>
                         <xsl:variable name="request-uri" select="ldh:href($results-uri, map{})" as="xs:anyURI"/>
                         <xsl:variable name="http-request" select="map{ 'method': 'GET', 'href': $request-uri, 'headers': map{ 'Accept': 'application/rdf+xml' } }" as="map(*)"/>
+                        <!-- 'document' = raw response body; the renderer handles per-Description suppression via ldh:DocumentForm match templates. 'action' defaults to the response document's URL if the caller didn't set it. property-uris/object-uris seed the downstream ldh:load-property-metadata / ldh:load-object-metadata steps. -->
                         <xsl:sequence select="map:merge(($context, map{
                           'type-metadata-request': $http-request,
                           'resource': $resource,
-                          'types': $types
-                        }))"/>
+                          'types': $types,
+                          'property-uris': distinct-values($resource/*/concat(namespace-uri(), local-name())),
+                          'object-uris': distinct-values($resource/*/@rdf:resource[not(key('resources', .))]),
+                          'document': .,
+                          'action': if (map:contains($context, 'action')) then $context('action') else ldh:href(ac:absolute-path(ldh:base-uri(.)), map{})
+                        }), map{ 'duplicates': 'use-last' })"/>
                     </xsl:for-each>
                 </xsl:when>
                 <!-- error response -->
@@ -331,34 +372,8 @@ WHERE
         <xsl:for-each select="$response">
             <xsl:choose>
                 <xsl:when test="?status = 200 and ?media-type = 'application/rdf+xml'">
-                    <xsl:variable name="type-metadata" select="?body" as="document-node()?"/>
-
-                    <!-- TO-DO: refactor remaining synchronous document() calls (property-metadata, constraints, object-metadata) into load/set pairs.
-                         The constructors SELECT and the SHACL shapes DESCRIBE were previously done here synchronously — they're
-                         now async ldh:load-constructors / ldh:set-constructors and ldh:load-shapes / ldh:set-shapes steps in the
-                         calling promise chain. -->
-                    <xsl:variable name="property-uris" select="distinct-values($resource/*/concat(namespace-uri(), local-name()))" as="xs:string*"/>
-                    <xsl:variable name="query-string" select="'DESCRIBE $Type VALUES $Type { ' || string-join(for $uri in $property-uris return '&lt;' || $uri || '&gt;', ' ') || ' }'" as="xs:string"/>
-                    <xsl:variable name="request-uri" select="ldh:href(ac:build-uri(resolve-uri('ns', ldt:base()), map{ 'query': $query-string, 'accept': 'application/rdf+xml' }), map{})" as="xs:anyURI"/>
-                    <xsl:variable name="property-metadata" select="document($request-uri)" as="document-node()"/>
-
-                    <xsl:variable name="query-string" select="$constraint-query || ' VALUES $Type { ' || string-join(for $type in $types return '&lt;' || $type || '&gt;', ' ') || ' }'" as="xs:string"/>
-                    <xsl:variable name="request-uri" select="ldh:href(ac:build-uri(resolve-uri('ns', ldt:base()), map{ 'query': $query-string, 'accept': 'application/sparql-results+xml' }), map{})" as="xs:anyURI"/>
-                    <xsl:variable name="constraints" select="if (exists($types)) then document($request-uri) else ()" as="document-node()?"/>
-
-                    <xsl:variable name="object-uris" select="distinct-values($resource/*/@rdf:resource[not(key('resources', .))])" as="xs:string*"/>
-                    <xsl:variable name="query-string" select="$object-metadata-query || ' VALUES $this { ' || string-join(for $uri in $object-uris return '&lt;' || $uri || '&gt;', ' ') || ' }'" as="xs:string"/>
-                    <xsl:variable name="request-uri" select="ldh:href(ac:build-uri(resolve-uri('sparql', ldt:base()), map{ 'query': $query-string, 'accept': 'application/rdf+xml' }), map{})" as="xs:anyURI"/>
-                    <xsl:variable name="object-metadata" select="if (doc-available($request-uri)) then document($request-uri) else ()" as="document-node()?"/>
-
-                    <xsl:sequence select="map:merge(($context, map{
-                        'type-metadata': $type-metadata,
-                        'property-metadata': $property-metadata,
-                        'constraints': $constraints,
-                        'object-metadata': $object-metadata
-                    }))"/>
+                    <xsl:sequence select="map:merge(($context, map{ 'type-metadata': ?body }))"/>
                 </xsl:when>
-                <!-- error response -->
                 <xsl:otherwise>
                     <xsl:sequence select="error(QName('&ldh;', 'ldh:type-metadata-response-error'), 'Could not load type metadata', $response)"/>
                 </xsl:otherwise>
@@ -366,23 +381,6 @@ WHERE
         </xsl:for-each>
     </xsl:function>
     
-    <xsl:function name="ldh:wrap-into-document" as="map(*)" ixsl:updating="yes">
-        <xsl:param name="context" as="map(*)"/>
-        <xsl:variable name="resource" select="$context('resource')" as="element()"/>
-
-        <xsl:variable name="document" as="document-node()">
-            <xsl:document>
-                <rdf:RDF>
-                    <xsl:sequence select="$resource"/>
-                </rdf:RDF>
-            </xsl:document>
-        </xsl:variable>
-        <xsl:sequence select="map:merge(($context, map{
-            'document': $document,
-            'action': if (map:contains($context, 'action')) then $context('action') else ldh:href(ac:absolute-path(ldh:base-uri($document)), map{})
-        }), map{ 'duplicates': 'use-last' })"/>
-    </xsl:function>
-
     <!-- Async constructor-fetch pair (the SPARQL SELECT against /ns?query= for ?Type spin:constructor ?constructor).
          Reads context('types'), stores parsed sparql-results at context('constructors'). -->
     <xsl:function name="ldh:load-constructors" as="map(*)" ixsl:updating="yes">
@@ -522,7 +520,7 @@ WHERE
         <xsl:variable name="block" select="$context('block')" as="element()"/>
         <xsl:variable name="resource" select="$context('resource')" as="element()"/>
         <xsl:variable name="type-metadata" select="$context('type-metadata')" as="document-node()?"/>
-        <xsl:variable name="property-metadata" select="$context('property-metadata')" as="document-node()"/>
+        <xsl:variable name="property-metadata" select="$context('property-metadata')" as="document-node()?"/>
         <xsl:variable name="constructors" select="$context('constructors')" as="document-node()?"/>
         <xsl:variable name="constraints" select="$context('constraints')" as="document-node()?"/>
         <xsl:variable name="shapes" select="$context('shapes')" as="document-node()"/>
@@ -563,35 +561,9 @@ WHERE
         <xsl:param name="context" as="map(*)"/>
         <xsl:variable name="block" select="$context('block')" as="element()"/>
         <xsl:variable name="document" select="$context('document')" as="document-node()"/>
-        <xsl:variable name="type-metadata" select="$context('type-metadata')" as="document-node()?"/>
-        <xsl:variable name="property-metadata" select="$context('property-metadata')" as="document-node()"/>
-        <xsl:variable name="constructors" select="$context('constructors')" as="document-node()?"/>
-        <xsl:variable name="constraints" select="$context('constraints')" as="document-node()?"/>
-        <xsl:variable name="shapes" select="$context('shapes')" as="document-node()"/>
-        <xsl:variable name="object-metadata" select="$context('object-metadata')" as="document-node()?"/>
-        <xsl:variable name="method" select="$context('method')" as="xs:string"/>
-        <xsl:variable name="action" select="$context('action')" as="xs:anyURI"/>
-        <xsl:variable name="required" select="$context('required')" as="function(element()) as xs:boolean"/>
 
         <xsl:for-each select="$block">
-            <xsl:variable name="form" as="node()*">
-                <xsl:apply-templates select="$document" mode="bs2:Form"> <!-- document level template -->
-                    <xsl:with-param name="about" select="()"/> <!-- don't set @about on the container until after the resource is saved -->
-                    <xsl:with-param name="method" select="$method"/>
-                    <xsl:with-param name="action" select="$action" tunnel="yes"/>
-                    <xsl:with-param name="form-actions-class" select="'form-actions modal-footer'"/>
-                    <xsl:with-param name="classes" select="()"/>
-                    <xsl:with-param name="type-metadata" select="$type-metadata" tunnel="yes"/>
-                    <xsl:with-param name="property-metadata" select="$property-metadata" tunnel="yes"/>
-<!--                    <xsl:with-param name="constructor" select="$constructed-doc" tunnel="yes"/>-->
-                    <xsl:with-param name="constructors" select="()" tunnel="yes"/> <!-- can be empty because modal form is only used to create Container/Item instances -->
-                    <xsl:with-param name="constraints" select="$constraints" tunnel="yes"/>
-                    <xsl:with-param name="shapes" select="()" tunnel="yes"/> <!-- there will be no shapes as modal form is only used to create Container/Item instances -->
-                    <xsl:with-param name="base-uri" select="ac:absolute-path(ldh:base-uri(.))" tunnel="yes"/> <!-- ac:absolute-path(ldh:base-uri(.)) is empty on constructed documents -->
-                    <xsl:with-param name="required" select="$required" tunnel="yes"/>
-                    <!-- <xsl:sort select="ac:label(.)"/> -->
-                </xsl:apply-templates>
-            </xsl:variable>
+            <xsl:variable name="form" select="ldh:render-document-form($document, $context)" as="element()*"/>
 
             <xsl:result-document href="?." method="ixsl:replace-content">
                 <xsl:copy-of select="$form"/>
@@ -603,7 +575,53 @@ WHERE
 
         <ixsl:set-style name="cursor" select="'default'" object="ixsl:page()//body"/>
     </xsl:function>
-    
+
+    <!-- ldh:DocumentForm: form-flavor mode that reuses the bs2:Form shell but replaces its body with a match-template-driven Description iteration. Only the Description at @rdf:about = $about is rendered as a fieldset; everything else in the response graph is suppressed declaratively. Used by both the initial document-edit/settings/add-instance render paths and their constraint-violation re-render paths. -->
+    <xsl:template match="rdf:RDF" mode="ldh:DocumentForm">
+        <xsl:param name="method" select="'post'" as="xs:string"/>
+        <xsl:param name="form-actions-class" select="'form-actions modal-footer'" as="xs:string?"/>
+        <!-- tunnel params (about, action, base-uri, required, constructors, constraints,
+             shapes, type-metadata, property-metadata, object-metadata) propagate through
+             to bs2:Form and to the per-Description templates automatically -->
+        <xsl:call-template name="bs2:Form">
+            <xsl:with-param name="method" select="$method"/>
+            <xsl:with-param name="form-actions-class" select="$form-actions-class"/>
+            <xsl:with-param name="body" as="node()*">
+                <xsl:apply-templates mode="bs2:Exception"/>
+                <xsl:apply-templates mode="#current"/>
+            </xsl:with-param>
+        </xsl:call-template>
+    </xsl:template>
+
+    <!-- per-Description dispatch: keep the editable subject, suppress every other Description in the response graph. The discriminator $about is a tunnel param because XSLT 3.0 patterns cannot reference template-local params; the keep-or-suppress test lives in the body via xsl:if. -->
+    <xsl:template match="*" mode="ldh:DocumentForm">
+        <xsl:param name="about" as="xs:anyURI" tunnel="yes"/>
+        <xsl:if test="@rdf:about = $about">
+            <xsl:apply-templates select="." mode="bs2:Form">
+                <xsl:with-param name="required" select="true()" tunnel="yes"/>
+            </xsl:apply-templates>
+        </xsl:if>
+    </xsl:template>
+
+    <!-- thin dispatcher: function-item invoked by the initial-render and violation handlers via ldh:render-document-form($body, $ctx). Named (not an inline XPath function literal) because xsl:apply-templates is an XSLT instruction. base-uri falls back to the editable subject URI when the caller hasn't set it, so bs2:Form's xs:anyURI typecheck doesn't see an empty value when the body is a freshly constructed doc with no associated URI. -->
+    <xsl:function name="ldh:render-document-form" as="element()*">
+        <xsl:param name="body" as="document-node()"/>
+        <xsl:param name="ctx"  as="map(*)"/>
+        <xsl:apply-templates select="$body" mode="ldh:DocumentForm">
+            <xsl:with-param name="about"             select="$ctx('about')"             tunnel="yes"/>
+            <xsl:with-param name="method"            select="$ctx('method')"/>
+            <xsl:with-param name="action"            select="$ctx('action')"            tunnel="yes"/>
+            <xsl:with-param name="base-uri"          select="if (map:contains($ctx, 'base-uri')) then $ctx('base-uri') else $ctx('about')" tunnel="yes"/>
+            <xsl:with-param name="type-metadata"     select="$ctx('type-metadata')"     tunnel="yes"/>
+            <xsl:with-param name="property-metadata" select="$ctx('property-metadata')" tunnel="yes"/>
+            <xsl:with-param name="constructors"      select="$ctx('constructors')"      tunnel="yes"/>
+            <xsl:with-param name="constraints"       select="$ctx('constraints')"       tunnel="yes"/>
+            <xsl:with-param name="shapes"            select="$ctx('shapes')"            tunnel="yes"/>
+            <xsl:with-param name="object-metadata"   select="$ctx('object-metadata')"   tunnel="yes"/>
+            <xsl:with-param name="required"          select="$ctx('required')"          tunnel="yes"/>
+        </xsl:apply-templates>
+    </xsl:function>
+
     <!-- TO-DO: unify -->
     <xsl:template match="div[ancestor::div[contains-token(@class, 'block')]]//button[contains-token(@class, 'btn-cancel')][not(contains-token(@class, 'disabled'))]" mode="ixsl:onclick">
         <xsl:sequence select="ixsl:call(ixsl:event(), 'preventDefault', [])"/>
@@ -679,10 +697,12 @@ WHERE
             <xsl:otherwise>
                 <!-- If-Match header checks preconditions, i.e. that the graph has not been modified in the meanwhile -->
                 <xsl:variable name="request" select="map{ 'method': $method, 'href': $request-uri, 'media-type': 'application/rdf+xml', 'body': $request-body, 'headers': map{ 'If-Match': $etag, 'Accept': $accept } }" as="map(*)"/>
+                <!-- 'about' = the resource URL being submitted to; the wrapping block carries it on @about uniformly (btn-edit / btn-app-settings / Container-Item creation modals all set it). $doc-uri is the page URL and can't be used for this -->
                 <xsl:variable name="context" as="map(*)" select="
                   map{
                     'request': $request,
                     'doc-uri': $doc-uri,
+                    'about': xs:anyURI($block/@about),
                     'block': $block,
                     'form': $form,
                     'resources': $resources
@@ -944,7 +964,10 @@ WHERE
             $context,
             map{
                 'body': $body,
-                'types': $types
+                'types': $types,
+                'endpoint': sd:endpoint(),
+                'property-uris': distinct-values($body/rdf:RDF/*[not(@rdf:about = $doc-uri)]/*/concat(namespace-uri(), local-name())),
+                'object-uris': distinct-values($body/rdf:RDF/*/*/@rdf:resource[not(key('resources', .))])
             }
         ), map{ 'duplicates': 'use-last' })"/>
 
@@ -957,15 +980,29 @@ WHERE
             ixsl:then(ldh:http-request-threaded(?, 'shapes-request', 'shapes-response')) =>
             ixsl:then(ldh:handle-response(?, 'shapes-response')) =>
             ixsl:then(ldh:set-shapes#1) =>
+            ixsl:then(ldh:load-type-metadata#1) =>
+            ixsl:then(ldh:http-request-threaded(?, 'type-metadata-request', 'type-metadata-response')) =>
+            ixsl:then(ldh:handle-response(?, 'type-metadata-response')) =>
+            ixsl:then(ldh:set-type-metadata#1) =>
+            ixsl:then(ldh:load-property-metadata#1) =>
+            ixsl:then(ldh:http-request-threaded(?, 'property-metadata-request', 'property-metadata-response')) =>
+            ixsl:then(ldh:handle-response(?, 'property-metadata-response')) =>
+            ixsl:then(ldh:set-property-metadata#1) =>
+            ixsl:then(ldh:load-constraints#1) =>
+            ixsl:then(ldh:http-request-threaded(?, 'constraints-request', 'constraints-response')) =>
+            ixsl:then(ldh:handle-response(?, 'constraints-response')) =>
+            ixsl:then(ldh:set-constraints#1) =>
+            ixsl:then(ldh:load-object-metadata#1) =>
+            ixsl:then(ldh:http-request-threaded(?, 'metadata-request', 'metadata-response')) =>
+            ixsl:then(ldh:handle-response(?, 'metadata-response')) =>
+            ixsl:then(ldh:set-object-metadata#1) =>
             ixsl:then(ldh:render-row-form-violation#1)"
             on-failure="ldh:promise-failure#1"/>
     </xsl:function>
 
     <!-- Terminal callback for the row-form-submit-violation promise chain. Renders the form with
          violation feedback by applying bs2:RowForm to the response body and replacing block content.
-         Reads context('shapes') and context('constructors') (async-fetched upstream); the remaining
-         sync fetches (type-metadata, property-metadata, constraints, object-metadata) are scope for a
-         follow-up phase. -->
+         All metadata is fetched async by the upstream chain steps; this function just reads from context. -->
     <xsl:function name="ldh:render-row-form-violation" as="item()*" ixsl:updating="yes">
         <xsl:param name="context" as="map(*)"/>
         <xsl:variable name="doc-uri" select="$context('doc-uri')" as="xs:anyURI"/>
@@ -975,25 +1012,10 @@ WHERE
         <xsl:variable name="types" select="$context('types')" as="xs:anyURI*"/>
         <xsl:variable name="constructors" select="$context('constructors')" as="document-node()?"/>
         <xsl:variable name="shapes" select="$context('shapes')" as="document-node()?"/>
-
-        <!-- TO-DO: refactor remaining synchronous document() calls (type-metadata, property-metadata, constraints, object-metadata) into load/set pairs -->
-        <xsl:variable name="query-string" select="'DESCRIBE $Type VALUES $Type { ' || string-join(for $type in $types return '&lt;' || $type || '&gt;', ' ') || ' }'" as="xs:string"/>
-        <xsl:variable name="request-uri" select="ldh:href(ac:build-uri(resolve-uri('ns', ldt:base()), map{ 'query': $query-string, 'accept': 'application/rdf+xml' }), map{})" as="xs:anyURI"/>
-        <xsl:variable name="type-metadata" select="if (exists($types)) then document($request-uri) else ()" as="document-node()?"/>
-
-        <xsl:variable name="property-uris" select="distinct-values($body/rdf:RDF/*[not(@rdf:about = $doc-uri)]/*/concat(namespace-uri(), local-name()))" as="xs:string*"/>
-        <xsl:variable name="query-string" select="'DESCRIBE $Type VALUES $Type { ' || string-join(for $uri in $property-uris return '&lt;' || $uri || '&gt;', ' ') || ' }'" as="xs:string"/>
-        <xsl:variable name="request-uri" select="ldh:href(ac:build-uri(resolve-uri('ns', ldt:base()), map{ 'query': $query-string, 'accept': 'application/rdf+xml' }), map{})" as="xs:anyURI"/>
-        <xsl:variable name="property-metadata" select="document($request-uri)" as="document-node()"/>
-
-        <xsl:variable name="query-string" select="$constraint-query || ' VALUES $Type { ' || string-join(for $type in $types return '&lt;' || $type || '&gt;', ' ') || ' }'" as="xs:string"/>
-        <xsl:variable name="request-uri" select="ldh:href(ac:build-uri(resolve-uri('ns', ldt:base()), map{ 'query': $query-string, 'accept': 'application/sparql-results+xml' }), map{})" as="xs:anyURI"/>
-        <xsl:variable name="constraints" select="if (exists($types)) then document($request-uri) else ()" as="document-node()?"/>
-
-        <xsl:variable name="object-uris" select="distinct-values($body/rdf:RDF/*/*/@rdf:resource[not(key('resources', .))])" as="xs:string*"/>
-        <xsl:variable name="query-string" select="$object-metadata-query || ' VALUES $this { ' || string-join(for $uri in $object-uris return '&lt;' || $uri || '&gt;', ' ') || ' }'" as="xs:string"/>
-        <xsl:variable name="request-uri" select="ldh:href(ac:build-uri(resolve-uri('sparql', ldt:base()), map{ 'query': $query-string, 'accept': 'application/rdf+xml' }), map{})" as="xs:anyURI"/>
-        <xsl:variable name="object-metadata" select="if (doc-available($request-uri)) then document($request-uri) else ()" as="document-node()?"/>
+        <xsl:variable name="type-metadata" select="$context('type-metadata')" as="document-node()?"/>
+        <xsl:variable name="property-metadata" select="$context('property-metadata')" as="document-node()?"/>
+        <xsl:variable name="constraints" select="$context('constraints')" as="document-node()?"/>
+        <xsl:variable name="object-metadata" select="$context('object-metadata')" as="document-node()?"/>
 
         <xsl:variable name="row-form" as="node()*">
             <!-- filter out the current document which might be in the constraint violation response attached by an rdf:_N property to a block resource -->
@@ -1292,7 +1314,8 @@ WHERE
             'constructed-doc': $merged-doc,
             'shapes': $shapes,
             'resource': $resource,
-            'types': $types
+            'types': $types,
+            'property-uris': distinct-values($resource/*/concat(namespace-uri(), local-name()))
         }), map{ 'duplicates': 'use-last' })"/>
     </xsl:function>
 
@@ -1307,26 +1330,15 @@ WHERE
         <xsl:variable name="constructed-doc" select="$context('constructed-doc')" as="document-node()"/>
         <xsl:variable name="resource" select="$context('resource')" as="element()"/>
         <xsl:variable name="types" select="$context('types')" as="xs:anyURI*"/>
+        <xsl:variable name="type-metadata" select="$context('type-metadata')" as="document-node()?"/>
+        <xsl:variable name="property-metadata" select="$context('property-metadata')" as="document-node()?"/>
+        <xsl:variable name="constraints" select="$context('constraints')" as="document-node()?"/>
         <xsl:variable name="constructors" select="$context('constructors')" as="document-node()?"/>
         <xsl:variable name="shapes" select="$context('shapes')" as="document-node()?"/>
         <xsl:variable name="classes" select="()" as="element()*"/>
 
         <xsl:for-each select="$fieldset">
             <xsl:variable name="new-fieldset" as="element()*">
-                <!-- TO-DO: refactor remaining synchronous document() calls (type-metadata, property-metadata, constraints) into load/set pairs -->
-                <xsl:variable name="query-string" select="'DESCRIBE $Type VALUES $Type { ' || string-join(for $type in $types return '&lt;' || $type || '&gt;', ' ') || ' }'" as="xs:string"/>
-                <xsl:variable name="request-uri" select="ldh:href(ac:build-uri(resolve-uri('ns', ldt:base()), map{ 'query': $query-string, 'accept': 'application/rdf+xml' }), map{})" as="xs:anyURI"/>
-                <xsl:variable name="type-metadata" select="if (exists($types)) then document($request-uri) else ()" as="document-node()?"/>
-
-                <xsl:variable name="property-uris" select="distinct-values($resource/*/concat(namespace-uri(), local-name()))" as="xs:string*"/>
-                <xsl:variable name="query-string" select="'DESCRIBE $Type VALUES $Type { ' || string-join(for $uri in $property-uris return '&lt;' || $uri || '&gt;', ' ') || ' }'" as="xs:string"/>
-                <xsl:variable name="request-uri" select="ldh:href(ac:build-uri(resolve-uri('ns', ldt:base()), map{ 'query': $query-string, 'accept': 'application/rdf+xml' }), map{})" as="xs:anyURI"/>
-                <xsl:variable name="property-metadata" select="document($request-uri)" as="document-node()"/>
-
-                <xsl:variable name="query-string" select="$constraint-query || ' VALUES $Type { ' || string-join(for $type in $types return '&lt;' || $type || '&gt;', ' ') || ' }'" as="xs:string"/>
-                <xsl:variable name="request-uri" select="ldh:href(ac:build-uri(resolve-uri('ns', ldt:base()), map{ 'query': $query-string, 'accept': 'application/sparql-results+xml' }), map{})" as="xs:anyURI"/>
-                <xsl:variable name="constraints" select="if (exists($types)) then document($request-uri) else ()" as="document-node()?"/>
-
                 <xsl:apply-templates select="$resource" mode="bs2:Form">
                     <xsl:with-param name="method" select="'post'"/>
                     <xsl:with-param name="action" select="ldh:href($doc-uri)" as="xs:anyURI" tunnel="yes"/>
@@ -1416,6 +1428,18 @@ WHERE
             ixsl:then(ldh:http-request-threaded(?, 'constructors-request', 'constructors-response')) =>
             ixsl:then(ldh:handle-response(?, 'constructors-response')) =>
             ixsl:then(ldh:set-constructors#1) =>
+            ixsl:then(ldh:load-type-metadata#1) =>
+            ixsl:then(ldh:http-request-threaded(?, 'type-metadata-request', 'type-metadata-response')) =>
+            ixsl:then(ldh:handle-response(?, 'type-metadata-response')) =>
+            ixsl:then(ldh:set-type-metadata#1) =>
+            ixsl:then(ldh:load-property-metadata#1) =>
+            ixsl:then(ldh:http-request-threaded(?, 'property-metadata-request', 'property-metadata-response')) =>
+            ixsl:then(ldh:handle-response(?, 'property-metadata-response')) =>
+            ixsl:then(ldh:set-property-metadata#1) =>
+            ixsl:then(ldh:load-constraints#1) =>
+            ixsl:then(ldh:http-request-threaded(?, 'constraints-request', 'constraints-response')) =>
+            ixsl:then(ldh:handle-response(?, 'constraints-response')) =>
+            ixsl:then(ldh:set-constraints#1) =>
             ixsl:then(ldh:render-typeahead-row-form#1)"
             on-failure="ldh:promise-failure#1"/>
     </xsl:template>

--- a/src/main/webapp/static/com/atomgraph/linkeddatahub/xsl/bootstrap/2.3.2/client/functions.xsl
+++ b/src/main/webapp/static/com/atomgraph/linkeddatahub/xsl/bootstrap/2.3.2/client/functions.xsl
@@ -589,6 +589,40 @@ exclude-result-prefixes="#all"
         </xsl:for-each>
     </xsl:function>
 
+    <!-- Parallel load/set pair runner. $pairs is a single array whose members are 4-element arrays [load-fn, request-key, response-key, set-fn]; load-fn is a pure context-transformer that populates context($request-key). The helper folds every load-fn over $context (collecting all request specs), fans out one http-request → rethread → handle → set per pair via ixsl:all, then merges all per-branch contexts back into one. ixsl:all is fail-fast — first rejected branch propagates through on-failure of the enclosing chain. -->
+    <xsl:function name="ldh:fire-load-set-parallel" as="item()*" ixsl:updating="yes">
+        <xsl:param name="context" as="map(*)"/>
+        <xsl:param name="pairs" as="array(*)"/>
+
+        <xsl:variable name="ctx-with-requests" as="map(*)" select="
+          array:fold-left($pairs, $context, function($ctx as item()*, $pair as item()*) as item()* { $pair?1($ctx) })
+        "/>
+
+        <xsl:variable name="promises" as="array(*)" select="
+          array {
+            for $pair in $pairs?* return
+              ixsl:http-request($ctx-with-requests($pair?2))
+                => ixsl:then(ldh:rethread-response($ctx-with-requests, ?, $pair?3))
+                => ixsl:then(ldh:handle-response(?, $pair?3))
+                => ixsl:then($pair?4)
+          }
+        "/>
+
+        <xsl:sequence select="
+          ixsl:all($promises)
+            => ixsl:then(function($results as item()*) as item()* {
+                 array:fold-left($results, $ctx-with-requests, function($acc as item()*, $r as item()*) as item()* {
+                   map:merge(($acc, $r), map{ 'duplicates': 'use-last' })
+                 })
+               })
+        "/>
+    </xsl:function>
+
+    <!-- Promise-chain cleanup callback for ixsl:finally — resets the body cursor. ixsl:finally requires a 0-arg handler and ignores its return value (the original promise outcome flows through to on-failure / on-completion). Idempotent with ldh:promise-failure's own cursor reset, so chains that use both don't conflict. -->
+    <xsl:function name="ldh:reset-cursor" ixsl:updating="yes">
+        <ixsl:set-style name="cursor" select="'default'" object="ixsl:page()//body"/>
+    </xsl:function>
+
     <xsl:function name="ldh:promise-failure" ixsl:updating="yes">
         <xsl:param name="error" as="map(*)"/>
 

--- a/src/main/webapp/static/com/atomgraph/linkeddatahub/xsl/bootstrap/2.3.2/client/functions.xsl
+++ b/src/main/webapp/static/com/atomgraph/linkeddatahub/xsl/bootstrap/2.3.2/client/functions.xsl
@@ -623,6 +623,18 @@ exclude-result-prefixes="#all"
         <ixsl:set-style name="cursor" select="'default'" object="ixsl:page()//body"/>
     </xsl:function>
 
+    <!-- Composes the seed shape shared by chains whose initial GET is against the edited resource: http-request → rethread → handle → load-edited-resource. After this resolves, context has types/property-uris/object-uris populated and a GET-style type-metadata-request pre-baked, so downstream parallel pairs should use an identity load-fn for type-metadata (otherwise ldh:load-type-metadata would overwrite the request with its POST variant). -->
+    <xsl:function name="ldh:fetch-and-load-edited-resource" as="item()*" ixsl:updating="yes">
+        <xsl:param name="context" as="map(*)"/>
+
+        <xsl:sequence select="
+          ixsl:http-request($context('request'))
+            => ixsl:then(ldh:rethread-response($context, ?))
+            => ixsl:then(ldh:handle-response#1)
+            => ixsl:then(ldh:load-edited-resource#1)
+        "/>
+    </xsl:function>
+
     <xsl:function name="ldh:promise-failure" ixsl:updating="yes">
         <xsl:param name="error" as="map(*)"/>
 

--- a/src/main/webapp/static/com/atomgraph/linkeddatahub/xsl/bootstrap/2.3.2/client/modal.xsl
+++ b/src/main/webapp/static/com/atomgraph/linkeddatahub/xsl/bootstrap/2.3.2/client/modal.xsl
@@ -732,6 +732,20 @@ LIMIT   10
          Reads context('constructed-doc') as the async-fetched SPIN-construction; the remaining
          sync document() calls for type-metadata/property-metadata/constraints are scope for a
          follow-up refactor. -->
+    <!-- Promise-chain step: after ldh:set-constructed-doc, extract the new resource (by $forClass) and compute the inputs the downstream type-metadata / property-metadata / constraints async pairs need. Pure-XSLT (no I/O). -->
+    <xsl:function name="ldh:set-add-modal-form-resource" as="map(*)" ixsl:updating="yes">
+        <xsl:param name="context" as="map(*)"/>
+        <xsl:variable name="constructed-doc" select="$context('constructed-doc')" as="document-node()"/>
+        <xsl:variable name="forClass" select="$context('forClass')" as="xs:anyURI"/>
+        <xsl:variable name="resource" select="key('resources-by-type', $forClass, $constructed-doc)[not(key('predicates-by-object', @rdf:nodeID))]" as="element()"/>
+        <xsl:variable name="types" select="distinct-values($resource/rdf:type/@rdf:resource)" as="xs:anyURI*"/>
+        <xsl:sequence select="map:merge(($context, map{
+            'resource': $resource,
+            'types': $types,
+            'property-uris': distinct-values($resource/*/concat(namespace-uri(), local-name()))
+        }), map{ 'duplicates': 'use-last' })"/>
+    </xsl:function>
+
     <xsl:function name="ldh:render-add-modal-form" as="item()*" ixsl:updating="yes">
         <xsl:param name="context" as="map(*)"/>
         <xsl:variable name="content-body" select="$context('content-body')" as="element()"/>
@@ -739,26 +753,13 @@ LIMIT   10
         <xsl:variable name="doc-uri" select="$context('doc-uri')" as="xs:anyURI"/>
         <xsl:variable name="base-uri" select="$context('base-uri')" as="xs:anyURI"/>
         <xsl:variable name="constructed-doc" select="$context('constructed-doc')" as="document-node()"/>
+        <xsl:variable name="type-metadata" select="$context('type-metadata')" as="document-node()?"/>
+        <xsl:variable name="property-metadata" select="$context('property-metadata')" as="document-node()?"/>
+        <xsl:variable name="constraints" select="$context('constraints')" as="document-node()?"/>
         <xsl:variable name="classes" select="()" as="element()*"/>
 
         <xsl:for-each select="$content-body">
-            <xsl:variable name="resource" select="key('resources-by-type', $forClass, $constructed-doc)[not(key('predicates-by-object', @rdf:nodeID))]" as="element()"/>
             <xsl:variable name="form" as="element()*">
-                <!-- TO-DO: refactor remaining synchronous document() calls (type-metadata, property-metadata, constraints) into load/set pairs -->
-                <xsl:variable name="types" select="distinct-values($resource/rdf:type/@rdf:resource)" as="xs:anyURI*"/>
-                <xsl:variable name="query-string" select="'DESCRIBE $Type VALUES $Type { ' || string-join(for $type in $types return '&lt;' || $type || '&gt;', ' ') || ' }'" as="xs:string"/>
-                <xsl:variable name="request-uri" select="ldh:href(ac:build-uri(resolve-uri('ns', ldt:base()), map{ 'query': $query-string, 'accept': 'application/rdf+xml' }), map{})" as="xs:anyURI"/>
-                <xsl:variable name="type-metadata" select="if (exists($types)) then document($request-uri) else ()" as="document-node()?"/>
-
-                <xsl:variable name="property-uris" select="distinct-values($resource/*/concat(namespace-uri(), local-name()))" as="xs:string*"/>
-                <xsl:variable name="query-string" select="'DESCRIBE $Type VALUES $Type { ' || string-join(for $uri in $property-uris return '&lt;' || $uri || '&gt;', ' ') || ' }'" as="xs:string"/>
-                <xsl:variable name="request-uri" select="ldh:href(ac:build-uri(resolve-uri('ns', ldt:base()), map{ 'query': $query-string, 'accept': 'application/rdf+xml' }), map{})" as="xs:anyURI"/>
-                <xsl:variable name="property-metadata" select="document($request-uri)" as="document-node()"/>
-
-                <xsl:variable name="query-string" select="$constraint-query || ' VALUES $Type { ' || string-join(for $type in $types return '&lt;' || $type || '&gt;', ' ') || ' }'" as="xs:string"/>
-                <xsl:variable name="request-uri" select="ldh:href(ac:build-uri(resolve-uri('ns', ldt:base()), map{ 'query': $query-string, 'accept': 'application/sparql-results+xml' }), map{})" as="xs:anyURI"/>
-                <xsl:variable name="constraints" select="if (exists($types)) then document($request-uri) else ()" as="document-node()?"/>
-
                 <xsl:apply-templates select="$constructed-doc" mode="bs2:Form">
                     <xsl:with-param name="about" select="()"/>
                     <xsl:with-param name="method" select="'put'"/>
@@ -777,7 +778,7 @@ LIMIT   10
             </xsl:variable>
 
             <xsl:result-document href="?." method="ixsl:append-content">
-                <div class="modal modal-constructor fade in" typeof="{$forClass}"> <!-- $forClass used by ldh:ResourceUpdated in case of 4xx response -->
+                <div class="modal modal-constructor fade in" about="{$doc-uri}" typeof="{$forClass}"> <!-- @about identifies the new resource URL (uniform with edit/settings modals so submit handlers can read $block/@about without a fallback); $forClass used by ldh:ResourceUpdated in case of 4xx response -->
                     <div class="modal-header">
                         <button type="button" class="close">&#215;</button>
 
@@ -823,6 +824,19 @@ LIMIT   10
             ixsl:then(ldh:http-request-threaded(?, 'constructed-doc-request', 'constructed-doc-response')) =>
             ixsl:then(ldh:handle-response(?, 'constructed-doc-response')) =>
             ixsl:then(ldh:set-constructed-doc#1) =>
+            ixsl:then(ldh:set-add-modal-form-resource#1) =>
+            ixsl:then(ldh:load-type-metadata#1) =>
+            ixsl:then(ldh:http-request-threaded(?, 'type-metadata-request', 'type-metadata-response')) =>
+            ixsl:then(ldh:handle-response(?, 'type-metadata-response')) =>
+            ixsl:then(ldh:set-type-metadata#1) =>
+            ixsl:then(ldh:load-property-metadata#1) =>
+            ixsl:then(ldh:http-request-threaded(?, 'property-metadata-request', 'property-metadata-response')) =>
+            ixsl:then(ldh:handle-response(?, 'property-metadata-response')) =>
+            ixsl:then(ldh:set-property-metadata#1) =>
+            ixsl:then(ldh:load-constraints#1) =>
+            ixsl:then(ldh:http-request-threaded(?, 'constraints-request', 'constraints-response')) =>
+            ixsl:then(ldh:handle-response(?, 'constraints-response')) =>
+            ixsl:then(ldh:set-constraints#1) =>
             ixsl:then(ldh:render-add-modal-form#1)"
             on-failure="ldh:promise-failure#1"/>
     </xsl:template>
@@ -869,6 +883,7 @@ LIMIT   10
             'block': $block,
             'about': $about,
             'method': $method,
+            'endpoint': sd:endpoint(),
             'required': function($r as element()) as xs:boolean { $r/rdf:type/@rdf:resource = ('&dh;Container', '&dh;Item') }
           }"/>
         <ixsl:promise select="
@@ -879,7 +894,18 @@ LIMIT   10
             => ixsl:then(ldh:http-request-threaded(?, 'type-metadata-request', 'type-metadata-response'))
             => ixsl:then(ldh:handle-response(?, 'type-metadata-response'))
             => ixsl:then(ldh:set-type-metadata#1)
-            => ixsl:then(ldh:wrap-into-document#1)
+            => ixsl:then(ldh:load-property-metadata#1)
+            => ixsl:then(ldh:http-request-threaded(?, 'property-metadata-request', 'property-metadata-response'))
+            => ixsl:then(ldh:handle-response(?, 'property-metadata-response'))
+            => ixsl:then(ldh:set-property-metadata#1)
+            => ixsl:then(ldh:load-constraints#1)
+            => ixsl:then(ldh:http-request-threaded(?, 'constraints-request', 'constraints-response'))
+            => ixsl:then(ldh:handle-response(?, 'constraints-response'))
+            => ixsl:then(ldh:set-constraints#1)
+            => ixsl:then(ldh:load-object-metadata#1)
+            => ixsl:then(ldh:http-request-threaded(?, 'metadata-request', 'metadata-response'))
+            => ixsl:then(ldh:handle-response(?, 'metadata-response'))
+            => ixsl:then(ldh:set-object-metadata#1)
             => ixsl:then(ldh:render-form#1)
         " on-failure="ldh:promise-failure#1"/>
     </xsl:template>
@@ -987,10 +1013,12 @@ LIMIT   10
         <xsl:variable name="request-uri" select="ldh:href($action, map{})" as="xs:anyURI"/>
         <!-- If-Match header checks preconditions, i.e. that the graph has not been modified in the meanwhile -->
         <xsl:variable name="request" select="map{ 'method': $method, 'href': $request-uri, 'media-type': 'application/sparql-update', 'body': $update-string, 'headers': map{ 'If-Match': $etag, 'Accept': 'application/rdf+xml', 'Cache-Control': 'no-cache' } }" as="map(*)"/>
+        <!-- 'about' = the resource URL being submitted to; the wrapping block carries it on @about uniformly (btn-edit / btn-app-settings / Container-Item creation modals all set it). $doc-uri is the page URL and can't be used for this -->
         <xsl:variable name="context" as="map(*)" select="
           map{
             'request': $request,
             'doc-uri': ac:absolute-path(ldh:base-uri(.)),
+            'about': xs:anyURI($block/@about),
             'block': $block,
             'form': $form,
             'resources': $resources
@@ -1077,6 +1105,7 @@ LIMIT   10
             'about': lapp:application(),
             'method': $method,
             'action': $settings-uri,
+            'endpoint': sd:endpoint(),
             'required': function($r as element()) as xs:boolean { true() }
           }"/>
         <ixsl:promise select="
@@ -1087,7 +1116,18 @@ LIMIT   10
             => ixsl:then(ldh:http-request-threaded(?, 'type-metadata-request', 'type-metadata-response'))
             => ixsl:then(ldh:handle-response(?, 'type-metadata-response'))
             => ixsl:then(ldh:set-type-metadata#1)
-            => ixsl:then(ldh:wrap-into-document#1)
+            => ixsl:then(ldh:load-property-metadata#1)
+            => ixsl:then(ldh:http-request-threaded(?, 'property-metadata-request', 'property-metadata-response'))
+            => ixsl:then(ldh:handle-response(?, 'property-metadata-response'))
+            => ixsl:then(ldh:set-property-metadata#1)
+            => ixsl:then(ldh:load-constraints#1)
+            => ixsl:then(ldh:http-request-threaded(?, 'constraints-request', 'constraints-response'))
+            => ixsl:then(ldh:handle-response(?, 'constraints-response'))
+            => ixsl:then(ldh:set-constraints#1)
+            => ixsl:then(ldh:load-object-metadata#1)
+            => ixsl:then(ldh:http-request-threaded(?, 'metadata-request', 'metadata-response'))
+            => ixsl:then(ldh:handle-response(?, 'metadata-response'))
+            => ixsl:then(ldh:set-object-metadata#1)
             => ixsl:then(ldh:render-form#1)
         " on-failure="ldh:promise-failure#1"/>
     </xsl:template>
@@ -1710,87 +1750,89 @@ LIMIT   10
         </xsl:choose>
     </xsl:function>
 
+    <!-- Kicks off the async metadata-fetch chain for the constraint-violation re-render of a modal form (Container/Item creation and document edit). $context carries response/about/block/form from the form submit handler — $about is the resource discriminator (set by the submit handler from $block/@about or $form/@action). Harvest types/property-uris from the edited resource; object-uris from the whole body. Terminates in ldh:render-modal-form-violation. -->
     <xsl:function name="ldh:modal-form-submit-violation" ixsl:updating="yes">
         <xsl:param name="context" as="map(*)"/>
         <xsl:variable name="response" select="$context('response')" as="map(*)"/>
-        <xsl:variable name="doc-uri" select="$context('doc-uri')" as="xs:anyURI"/>
-        <xsl:variable name="block" select="$context('block')" as="element()"/>
-        <xsl:variable name="form" select="$context('form')" as="element()?"/>
-        
+        <xsl:variable name="about" select="$context('about')" as="xs:anyURI"/>
+
         <xsl:message>ldh:modal-form-submit-violation</xsl:message>
 
-        <xsl:for-each select="$response">
-            <xsl:variable name="body" select="?body" as="document-node()"/>
-            <!-- TO-DO: refactor to use asynchronous HTTP requests -->
-            <!-- inverse $types expression compared to ldh:row-form-submit-violation -->
-            <xsl:variable name="types" select="distinct-values($body/rdf:RDF/*[@rdf:about = $doc-uri]/rdf:type/@rdf:resource)" as="xs:anyURI*"/>
-            <xsl:variable name="query-string" select="'DESCRIBE $Type VALUES $Type { ' || string-join(for $type in $types return '&lt;' || $type || '&gt;', ' ') || ' }'" as="xs:string"/>
-            <xsl:variable name="request-uri" select="ldh:href(ac:build-uri(resolve-uri('ns', ldt:base()), map{ 'query': $query-string, 'accept': 'application/rdf+xml' }), map{})" as="xs:anyURI"/>
-            <xsl:variable name="type-metadata" select="if (exists($types)) then document($request-uri) else ()" as="document-node()?"/>
+        <xsl:variable name="body" select="$response?body" as="document-node()"/>
+        <!-- inverse $types expression compared to ldh:row-form-submit-violation: types come from the *edited* resource, not from the violation-attached ones -->
+        <xsl:variable name="types" select="distinct-values($body/rdf:RDF/*[@rdf:about = $about]/rdf:type/@rdf:resource)" as="xs:anyURI*"/>
 
-            <xsl:variable name="property-uris" select="distinct-values($body/rdf:RDF/*[not(@rdf:about = $doc-uri)]/*/concat(namespace-uri(), local-name()))" as="xs:string*"/>
-            <xsl:variable name="query-string" select="'DESCRIBE $Type VALUES $Type { ' || string-join(for $uri in $property-uris return '&lt;' || $uri || '&gt;', ' ') || ' }'" as="xs:string"/>
-            <xsl:variable name="request-uri" select="ldh:href(ac:build-uri(resolve-uri('ns', ldt:base()), map{ 'query': $query-string, 'accept': 'application/rdf+xml' }), map{})" as="xs:anyURI"/>
-            <xsl:variable name="property-metadata" select="document($request-uri)" as="document-node()"/>
+        <xsl:variable name="new-context" as="map(*)" select="map:merge((
+            $context,
+            map{
+                'body': $body,
+                'types': $types,
+                'endpoint': sd:endpoint(),
+                'property-uris': distinct-values($body/rdf:RDF/*[not(@rdf:about = $about)]/*/concat(namespace-uri(), local-name())),
+                'object-uris': distinct-values($body/rdf:RDF/*/*/@rdf:resource[not(key('resources', .))])
+            }
+        ), map{ 'duplicates': 'use-last' })"/>
 
-            <!-- $constructors fetch removed: the modal form is only used for Container/Item instances and the bs2:Form tunnel param is hard-coded to () below -->
+        <ixsl:promise select="ixsl:resolve($new-context) =>
+            ixsl:then(ldh:load-type-metadata#1) =>
+            ixsl:then(ldh:http-request-threaded(?, 'type-metadata-request', 'type-metadata-response')) =>
+            ixsl:then(ldh:handle-response(?, 'type-metadata-response')) =>
+            ixsl:then(ldh:set-type-metadata#1) =>
+            ixsl:then(ldh:load-property-metadata#1) =>
+            ixsl:then(ldh:http-request-threaded(?, 'property-metadata-request', 'property-metadata-response')) =>
+            ixsl:then(ldh:handle-response(?, 'property-metadata-response')) =>
+            ixsl:then(ldh:set-property-metadata#1) =>
+            ixsl:then(ldh:load-constraints#1) =>
+            ixsl:then(ldh:http-request-threaded(?, 'constraints-request', 'constraints-response')) =>
+            ixsl:then(ldh:handle-response(?, 'constraints-response')) =>
+            ixsl:then(ldh:set-constraints#1) =>
+            ixsl:then(ldh:load-object-metadata#1) =>
+            ixsl:then(ldh:http-request-threaded(?, 'metadata-request', 'metadata-response')) =>
+            ixsl:then(ldh:handle-response(?, 'metadata-response')) =>
+            ixsl:then(ldh:set-object-metadata#1) =>
+            ixsl:then(ldh:render-modal-form-violation#1)"
+            on-failure="ldh:promise-failure#1"/>
+    </xsl:function>
 
-            <xsl:variable name="query-string" select="$constraint-query || ' VALUES $Type { ' || string-join(for $type in $types return '&lt;' || $type || '&gt;', ' ') || ' }'" as="xs:string"/>
-            <xsl:variable name="request-uri" select="ldh:href(ac:build-uri(resolve-uri('ns', ldt:base()), map{ 'query': $query-string, 'accept': 'application/sparql-results+xml' }), map{})" as="xs:anyURI"/>
-            <xsl:variable name="constraints" select="if (exists($types)) then document($request-uri) else ()" as="document-node()?"/>
+    <!-- Terminal callback for the modal-form-submit-violation chain. All metadata is in $context from the upstream chain steps. constructors and shapes stay () because the modal form is only used for Container/Item instances. -->
+    <xsl:function name="ldh:render-modal-form-violation" as="item()*" ixsl:updating="yes">
+        <xsl:param name="context" as="map(*)"/>
+        <xsl:variable name="body" select="$context('body')" as="document-node()"/>
+        <xsl:variable name="block" select="$context('block')" as="element()"/>
+        <xsl:variable name="form" select="$context('form')" as="element()?"/>
 
-            <!-- $shapes fetch removed: the modal form is only used for Container/Item instances and the bs2:Form tunnel param is hard-coded to () below -->
+        <xsl:variable name="render-ctx" as="map(*)" select="map:merge(($context, map{
+            'method':            string($form/@method),
+            'action':            xs:anyURI(string($form/@action)),
+            'base-uri':          ac:absolute-path(ldh:base-uri($body)),
+            'constructors':      (),
+            'shapes':            (),
+            'required':          function($r as element()) as xs:boolean { $r/rdf:type/@rdf:resource = ('&dh;Container', '&dh;Item') }
+        }), map{ 'duplicates': 'use-last' })"/>
+        <xsl:variable name="rendered" select="ldh:render-document-form($body, $render-ctx)" as="element()*"/>
 
-            <xsl:variable name="object-uris" select="distinct-values($body/rdf:RDF/*/*/@rdf:resource[not(key('resources', .))])" as="xs:string*"/>
-            <xsl:variable name="query-string" select="$object-metadata-query || ' VALUES $this { ' || string-join(for $uri in $object-uris return '&lt;' || $uri || '&gt;', ' ') || ' }'" as="xs:string"/>
-            <xsl:variable name="request-uri" select="ldh:href(ac:build-uri(resolve-uri('sparql', ldt:base()), map{ 'query': $query-string, 'accept': 'application/rdf+xml' }), map{})" as="xs:anyURI"/>
-            <xsl:variable name="object-metadata" select="if (doc-available($request-uri)) then document($request-uri) else ()" as="document-node()?"/>
+        <xsl:for-each select="$block">
+            <xsl:result-document href="?." method="ixsl:replace-content">
+                <div class="modal-header">
+                    <button type="button" class="close">&#215;</button>
 
-            <xsl:variable name="form" as="element()*">
-                <xsl:for-each select="$body">
-                    <xsl:apply-templates select="." mode="bs2:Form"> <!-- document level template -->
-                        <xsl:with-param name="about" select="()"/> <!-- don't set @about on the container until after the resource is saved -->
-                        <xsl:with-param name="method" select="$form/@method"/>
-                        <xsl:with-param name="action" select="$form/@action" as="xs:anyURI" tunnel="yes"/>
-                        <xsl:with-param name="form-actions-class" select="'form-actions modal-footer'" as="xs:string?"/>
-                        <xsl:with-param name="classes" select="()"/>
-                        <xsl:with-param name="type-metadata" select="$type-metadata" tunnel="yes"/>
-                        <xsl:with-param name="property-metadata" select="$property-metadata" tunnel="yes"/>
-                        <xsl:with-param name="constructors" select="()" tunnel="yes"/> <!-- can be empty because modal form is only used to create Container/Item instances -->
-                        <xsl:with-param name="constraints" select="$constraints" tunnel="yes"/>
-                        <xsl:with-param name="shapes" select="()" tunnel="yes"/> <!-- there will be no shapes as modal form is only used to create Container/Item instances -->
-                        <xsl:with-param name="base-uri" select="ac:absolute-path(ldh:base-uri(.))" tunnel="yes"/> <!-- ac:absolute-path(ldh:base-uri(.)) is empty on constructed documents -->
-                        <xsl:with-param name="required" select="function($r as element()) as xs:boolean { $r/rdf:type/@rdf:resource = ('&dh;Container', '&dh;Item') }" tunnel="yes"/>
-                        <!-- <xsl:sort select="ac:label(.)"/> -->
-                    </xsl:apply-templates>
-                </xsl:for-each>
-            </xsl:variable>
+                    <legend>
+                        <!-- <xsl:value-of select="$legend-label"/> -->
+                    </legend>
+                </div>
 
-            <xsl:for-each select="$block">
-                <xsl:result-document href="?." method="ixsl:replace-content">
-                    <div class="modal-header">
-                        <button type="button" class="close">&#215;</button>
-
-                        <legend>
-                            <!-- <xsl:value-of select="$legend-label"/> -->
-                        </legend>
-                    </div>
-
-                    <div class="modal-body">
-                        <xsl:copy-of select="$form"/>
-                    </div>
-                </xsl:result-document>
-            </xsl:for-each>
-
-        <!-- cannot be in $form context because it contains old DOM (pre-ixsl:replace-content) -->
-            <xsl:for-each select="id($form/@id, ixsl:page())">
-                <xsl:apply-templates select="." mode="ldh:RenderRowForm"/>
-            </xsl:for-each>
-
-            <ixsl:set-style name="cursor" select="'default'" object="ixsl:page()//body"/>            
+                <div class="modal-body">
+                    <xsl:copy-of select="$rendered"/>
+                </div>
+            </xsl:result-document>
         </xsl:for-each>
-        
-        <xsl:sequence select="$context"/>
+
+        <!-- cannot be in $rendered context because it contains old DOM (pre-ixsl:replace-content) -->
+        <xsl:for-each select="id($rendered/@id, ixsl:page())">
+            <xsl:apply-templates select="." mode="ldh:RenderRowForm"/>
+        </xsl:for-each>
+
+        <ixsl:set-style name="cursor" select="'default'" object="ixsl:page()//body"/>
     </xsl:function>
     
 </xsl:stylesheet>

--- a/src/main/webapp/static/com/atomgraph/linkeddatahub/xsl/bootstrap/2.3.2/client/modal.xsl
+++ b/src/main/webapp/static/com/atomgraph/linkeddatahub/xsl/bootstrap/2.3.2/client/modal.xsl
@@ -877,27 +877,18 @@ LIMIT   10
             'endpoint': sd:endpoint(),
             'required': function($r as element()) as xs:boolean { $r/rdf:type/@rdf:resource = ('&dh;Container', '&dh;Item') }
           }"/>
+        <!-- Same structure as the app-settings chain below: ldh:fetch-and-load-edited-resource bakes a GET-style type-metadata-request, so the type-metadata pair uses an identity load-fn. ldh:render-form has its own cursor reset (shared with app-settings); the finally here is the backstop for the failure-on-parallel path. -->
         <ixsl:promise select="
-          ixsl:http-request($context('request'))
-            => ixsl:then(ldh:rethread-response($context, ?))
-            => ixsl:then(ldh:handle-response#1)
-            => ixsl:then(ldh:load-edited-resource#1)
-            => ixsl:then(ldh:http-request-threaded(?, 'type-metadata-request', 'type-metadata-response'))
-            => ixsl:then(ldh:handle-response(?, 'type-metadata-response'))
-            => ixsl:then(ldh:set-type-metadata#1)
-            => ixsl:then(ldh:load-property-metadata#1)
-            => ixsl:then(ldh:http-request-threaded(?, 'property-metadata-request', 'property-metadata-response'))
-            => ixsl:then(ldh:handle-response(?, 'property-metadata-response'))
-            => ixsl:then(ldh:set-property-metadata#1)
-            => ixsl:then(ldh:load-constraints#1)
-            => ixsl:then(ldh:http-request-threaded(?, 'constraints-request', 'constraints-response'))
-            => ixsl:then(ldh:handle-response(?, 'constraints-response'))
-            => ixsl:then(ldh:set-constraints#1)
-            => ixsl:then(ldh:load-object-metadata#1)
-            => ixsl:then(ldh:http-request-threaded(?, 'metadata-request', 'metadata-response'))
-            => ixsl:then(ldh:handle-response(?, 'metadata-response'))
-            => ixsl:then(ldh:set-object-metadata#1)
+          ixsl:resolve($context)
+            => ixsl:then(ldh:fetch-and-load-edited-resource#1)
+            => ixsl:then(ldh:fire-load-set-parallel(?, [
+                 [ function($ctx as map(*)) as map(*) { $ctx }, 'type-metadata-request',     'type-metadata-response',     ldh:set-type-metadata#1 ],
+                 [ ldh:load-property-metadata#1,                'property-metadata-request', 'property-metadata-response', ldh:set-property-metadata#1 ],
+                 [ ldh:load-constraints#1,                      'constraints-request',       'constraints-response',       ldh:set-constraints#1 ],
+                 [ ldh:load-object-metadata#1,                  'metadata-request',          'metadata-response',          ldh:set-object-metadata#1 ]
+               ]))
             => ixsl:then(ldh:render-form#1)
+            => ixsl:finally(ldh:reset-cursor#0)
         " on-failure="ldh:promise-failure#1"/>
     </xsl:template>
 
@@ -1099,12 +1090,10 @@ LIMIT   10
             'endpoint': sd:endpoint(),
             'required': function($r as element()) as xs:boolean { true() }
           }"/>
-        <!-- seed phase: load-edited-resource bakes a GET-style type-metadata-request directly, so the type-metadata pair below uses an identity load-fn rather than ldh:load-type-metadata (which would build a different POST-style request). ldh:render-form has its own cursor reset; ixsl:finally here is for the failure-on-parallel path before the render gets to run. -->
+        <!-- ldh:fetch-and-load-edited-resource bakes a GET-style type-metadata-request into context, so the type-metadata pair uses an identity load-fn rather than ldh:load-type-metadata (which would build a different POST-style request). ldh:render-form has its own cursor reset (shared with btn-edit modal); the finally here is the backstop for the failure-on-parallel path. -->
         <ixsl:promise select="
-          ixsl:http-request($context('request'))
-            => ixsl:then(ldh:rethread-response($context, ?))
-            => ixsl:then(ldh:handle-response#1)
-            => ixsl:then(ldh:load-edited-resource#1)
+          ixsl:resolve($context)
+            => ixsl:then(ldh:fetch-and-load-edited-resource#1)
             => ixsl:then(ldh:fire-load-set-parallel(?, [
                  [ function($ctx as map(*)) as map(*) { $ctx }, 'type-metadata-request',     'type-metadata-response',     ldh:set-type-metadata#1 ],
                  [ ldh:load-property-metadata#1,                'property-metadata-request', 'property-metadata-response', ldh:set-property-metadata#1 ],
@@ -1762,24 +1751,16 @@ LIMIT   10
             }
         ), map{ 'duplicates': 'use-last' })"/>
 
+        <!-- $new-context is built synchronously above; types/property-uris/object-uris populated from the violation response body. No pre-baked type-metadata-request here, so the type-metadata pair uses the normal ldh:load-type-metadata. -->
         <ixsl:promise select="ixsl:resolve($new-context) =>
-            ixsl:then(ldh:load-type-metadata#1) =>
-            ixsl:then(ldh:http-request-threaded(?, 'type-metadata-request', 'type-metadata-response')) =>
-            ixsl:then(ldh:handle-response(?, 'type-metadata-response')) =>
-            ixsl:then(ldh:set-type-metadata#1) =>
-            ixsl:then(ldh:load-property-metadata#1) =>
-            ixsl:then(ldh:http-request-threaded(?, 'property-metadata-request', 'property-metadata-response')) =>
-            ixsl:then(ldh:handle-response(?, 'property-metadata-response')) =>
-            ixsl:then(ldh:set-property-metadata#1) =>
-            ixsl:then(ldh:load-constraints#1) =>
-            ixsl:then(ldh:http-request-threaded(?, 'constraints-request', 'constraints-response')) =>
-            ixsl:then(ldh:handle-response(?, 'constraints-response')) =>
-            ixsl:then(ldh:set-constraints#1) =>
-            ixsl:then(ldh:load-object-metadata#1) =>
-            ixsl:then(ldh:http-request-threaded(?, 'metadata-request', 'metadata-response')) =>
-            ixsl:then(ldh:handle-response(?, 'metadata-response')) =>
-            ixsl:then(ldh:set-object-metadata#1) =>
-            ixsl:then(ldh:render-modal-form-violation#1)"
+            ixsl:then(ldh:fire-load-set-parallel(?, [
+              [ ldh:load-type-metadata#1,     'type-metadata-request',     'type-metadata-response',     ldh:set-type-metadata#1 ],
+              [ ldh:load-property-metadata#1, 'property-metadata-request', 'property-metadata-response', ldh:set-property-metadata#1 ],
+              [ ldh:load-constraints#1,       'constraints-request',       'constraints-response',       ldh:set-constraints#1 ],
+              [ ldh:load-object-metadata#1,   'metadata-request',          'metadata-response',          ldh:set-object-metadata#1 ]
+            ])) =>
+            ixsl:then(ldh:render-modal-form-violation#1) =>
+            ixsl:finally(ldh:reset-cursor#0)"
             on-failure="ldh:promise-failure#1"/>
     </xsl:function>
 
@@ -1820,8 +1801,6 @@ LIMIT   10
         <xsl:for-each select="id($rendered/@id, ixsl:page())">
             <xsl:apply-templates select="." mode="ldh:RenderRowForm"/>
         </xsl:for-each>
-
-        <ixsl:set-style name="cursor" select="'default'" object="ixsl:page()//body"/>
     </xsl:function>
-    
+
 </xsl:stylesheet>

--- a/src/main/webapp/static/com/atomgraph/linkeddatahub/xsl/bootstrap/2.3.2/client/modal.xsl
+++ b/src/main/webapp/static/com/atomgraph/linkeddatahub/xsl/bootstrap/2.3.2/client/modal.xsl
@@ -1360,6 +1360,7 @@ LIMIT   10
         <xsl:param name="slug" select="ixsl:get(., 'value')" as="xs:string?"/>
         <xsl:param name="rdf-post-subj-input" select="preceding-sibling::input[@name = 'su']" as="element()"/>
         <xsl:param name="form" select="ancestor::form" as="element()?"/>
+        <xsl:param name="modal" select="ancestor::div[contains-token(@class, 'modal-constructor')]" as="element()?"/>
         <!-- URL-encode the slug value, resolve it against base URI and add trailing slash -->
         <xsl:param name="new-uri" select="ac:absolute-path(ldh:base-uri(.)) || encode-for-uri($slug) || '/'" as="xs:string"/>
 
@@ -1367,6 +1368,10 @@ LIMIT   10
         <ixsl:set-attribute name="value" select="$new-uri" object="$rdf-post-subj-input"/>
         <!-- also set it as the new form action value -->
         <ixsl:set-attribute name="action" select="$new-uri" object="$form"/>
+        <!-- keep the modal wrapper @about in sync so the submit handler's $block/@about discriminator matches the resource the form will PUT to -->
+        <xsl:if test="exists($modal)">
+            <ixsl:set-attribute name="about" select="$new-uri" object="$modal"/>
+        </xsl:if>
     </xsl:template>
     
     <!-- CALLBACKS -->

--- a/src/main/webapp/static/com/atomgraph/linkeddatahub/xsl/bootstrap/2.3.2/client/modal.xsl
+++ b/src/main/webapp/static/com/atomgraph/linkeddatahub/xsl/bootstrap/2.3.2/client/modal.xsl
@@ -796,8 +796,6 @@ LIMIT   10
                 <xsl:apply-templates select="id($form/@id, ixsl:page())" mode="ldh:RenderRowForm"/>
             </xsl:if>
         </xsl:for-each>
-
-        <ixsl:set-style name="cursor" select="'default'" object="ixsl:page()//body"/>
     </xsl:function>
 
     <!-- shows new SPIN-constructed document as a modal form -->
@@ -820,24 +818,17 @@ LIMIT   10
         }"/>
 
         <ixsl:promise select="ixsl:resolve($context) =>
-            ixsl:then(ldh:load-constructed-doc#1) =>
-            ixsl:then(ldh:http-request-threaded(?, 'constructed-doc-request', 'constructed-doc-response')) =>
-            ixsl:then(ldh:handle-response(?, 'constructed-doc-response')) =>
-            ixsl:then(ldh:set-constructed-doc#1) =>
+            ixsl:then(ldh:fire-load-set-parallel(?, [
+              [ ldh:load-constructed-doc#1, 'constructed-doc-request', 'constructed-doc-response', ldh:set-constructed-doc#1 ]
+            ])) =>
             ixsl:then(ldh:set-add-modal-form-resource#1) =>
-            ixsl:then(ldh:load-type-metadata#1) =>
-            ixsl:then(ldh:http-request-threaded(?, 'type-metadata-request', 'type-metadata-response')) =>
-            ixsl:then(ldh:handle-response(?, 'type-metadata-response')) =>
-            ixsl:then(ldh:set-type-metadata#1) =>
-            ixsl:then(ldh:load-property-metadata#1) =>
-            ixsl:then(ldh:http-request-threaded(?, 'property-metadata-request', 'property-metadata-response')) =>
-            ixsl:then(ldh:handle-response(?, 'property-metadata-response')) =>
-            ixsl:then(ldh:set-property-metadata#1) =>
-            ixsl:then(ldh:load-constraints#1) =>
-            ixsl:then(ldh:http-request-threaded(?, 'constraints-request', 'constraints-response')) =>
-            ixsl:then(ldh:handle-response(?, 'constraints-response')) =>
-            ixsl:then(ldh:set-constraints#1) =>
-            ixsl:then(ldh:render-add-modal-form#1)"
+            ixsl:then(ldh:fire-load-set-parallel(?, [
+              [ ldh:load-type-metadata#1,     'type-metadata-request',     'type-metadata-response',     ldh:set-type-metadata#1 ],
+              [ ldh:load-property-metadata#1, 'property-metadata-request', 'property-metadata-response', ldh:set-property-metadata#1 ],
+              [ ldh:load-constraints#1,       'constraints-request',       'constraints-response',       ldh:set-constraints#1 ]
+            ])) =>
+            ixsl:then(ldh:render-add-modal-form#1) =>
+            ixsl:finally(ldh:reset-cursor#0)"
             on-failure="ldh:promise-failure#1"/>
     </xsl:template>
     
@@ -1108,27 +1099,20 @@ LIMIT   10
             'endpoint': sd:endpoint(),
             'required': function($r as element()) as xs:boolean { true() }
           }"/>
+        <!-- seed phase: load-edited-resource bakes a GET-style type-metadata-request directly, so the type-metadata pair below uses an identity load-fn rather than ldh:load-type-metadata (which would build a different POST-style request). ldh:render-form has its own cursor reset; ixsl:finally here is for the failure-on-parallel path before the render gets to run. -->
         <ixsl:promise select="
           ixsl:http-request($context('request'))
             => ixsl:then(ldh:rethread-response($context, ?))
             => ixsl:then(ldh:handle-response#1)
             => ixsl:then(ldh:load-edited-resource#1)
-            => ixsl:then(ldh:http-request-threaded(?, 'type-metadata-request', 'type-metadata-response'))
-            => ixsl:then(ldh:handle-response(?, 'type-metadata-response'))
-            => ixsl:then(ldh:set-type-metadata#1)
-            => ixsl:then(ldh:load-property-metadata#1)
-            => ixsl:then(ldh:http-request-threaded(?, 'property-metadata-request', 'property-metadata-response'))
-            => ixsl:then(ldh:handle-response(?, 'property-metadata-response'))
-            => ixsl:then(ldh:set-property-metadata#1)
-            => ixsl:then(ldh:load-constraints#1)
-            => ixsl:then(ldh:http-request-threaded(?, 'constraints-request', 'constraints-response'))
-            => ixsl:then(ldh:handle-response(?, 'constraints-response'))
-            => ixsl:then(ldh:set-constraints#1)
-            => ixsl:then(ldh:load-object-metadata#1)
-            => ixsl:then(ldh:http-request-threaded(?, 'metadata-request', 'metadata-response'))
-            => ixsl:then(ldh:handle-response(?, 'metadata-response'))
-            => ixsl:then(ldh:set-object-metadata#1)
+            => ixsl:then(ldh:fire-load-set-parallel(?, [
+                 [ function($ctx as map(*)) as map(*) { $ctx }, 'type-metadata-request',     'type-metadata-response',     ldh:set-type-metadata#1 ],
+                 [ ldh:load-property-metadata#1,                'property-metadata-request', 'property-metadata-response', ldh:set-property-metadata#1 ],
+                 [ ldh:load-constraints#1,                      'constraints-request',       'constraints-response',       ldh:set-constraints#1 ],
+                 [ ldh:load-object-metadata#1,                  'metadata-request',          'metadata-response',          ldh:set-object-metadata#1 ]
+               ]))
             => ixsl:then(ldh:render-form#1)
+            => ixsl:finally(ldh:reset-cursor#0)
         " on-failure="ldh:promise-failure#1"/>
     </xsl:template>
 

--- a/src/main/webapp/static/com/atomgraph/linkeddatahub/xsl/bootstrap/2.3.2/document.xsl
+++ b/src/main/webapp/static/com/atomgraph/linkeddatahub/xsl/bootstrap/2.3.2/document.xsl
@@ -1140,7 +1140,7 @@ extension-element-prefixes="ixsl"
     
     <!-- ROW FORM -->
     
-    <xsl:template match="rdf:RDF" mode="bs2:Form">
+    <xsl:template match="rdf:RDF" mode="bs2:Form" name="bs2:Form">
         <xsl:param name="method" select="'post'" as="xs:string"/>
         <xsl:param name="base-uri" select="ldh:base-uri(.)" as="xs:anyURI" tunnel="yes"/>
         <xsl:param name="action" select="ldh:href(ac:absolute-path($base-uri))" as="xs:anyURI" tunnel="yes"/>
@@ -1164,27 +1164,8 @@ extension-element-prefixes="ixsl"
         <xsl:param name="property-metadata" select="if (exists($property-uris)) then ldh:send-request(resolve-uri('ns', ldt:base()), 'POST', 'application/sparql-query', 'DESCRIBE $Type' || ' VALUES $Type { ' || string-join(for $uri in $property-uris return '&lt;' || $uri || '&gt;', ' ') || ' }', map{ 'Accept': 'application/rdf+xml' }) else ()" as="document-node()?" tunnel="yes"/>
         <xsl:param name="object-uris" select="rdf:Description/*/@rdf:resource[not(key('resources', .))]" as="xs:anyURI*"/>
         <xsl:param name="object-metadata" select="if (exists($object-uris)) then ldh:send-request(resolve-uri('ns', ldt:base()), 'POST', 'application/sparql-query', $object-metadata-query || ' VALUES $this { ' || string-join(for $uri in $object-uris return '&lt;' || $uri || '&gt;', ' ') || ' }', map{ 'Accept': 'application/rdf+xml' }) else ()" as="document-node()?" tunnel="yes"/>
-
-        <form method="{$method}" action="{$action}">
-            <xsl:if test="$id">
-                <xsl:attribute name="id" select="$id"/>
-            </xsl:if>
-            <xsl:if test="$class">
-                <xsl:attribute name="class" select="$class"/>
-            </xsl:if>
-            <xsl:if test="$accept-charset">
-                <xsl:attribute name="accept-charset" select="$accept-charset"/>
-            </xsl:if>
-            <xsl:if test="$enctype">
-                <xsl:attribute name="enctype" select="$enctype"/>
-            </xsl:if>
-
-            <xsl:comment>This form uses RDF/POST encoding: https://atomgraph.github.io/RDF-POST/</xsl:comment>
-            <xsl:call-template name="xhtml:Input">
-                <xsl:with-param name="name" select="'rdf'"/>
-                <xsl:with-param name="type" select="'hidden'"/>
-            </xsl:call-template>
-            
+        <!-- inner form content; default is the exception alerts + primary/non-primary Description iteration. Override via xsl:with-param name="body" to substitute a different body (e.g. ldh:DocumentForm mode for declarative suppression) while reusing the form shell. -->
+        <xsl:param name="body" as="node()*">
             <xsl:apply-templates mode="bs2:Exception"/>
 
             <xsl:variable name="abs-base-uri" select="ac:absolute-path(ldh:base-uri(.))" as="xs:anyURI"/>
@@ -1213,6 +1194,29 @@ extension-element-prefixes="ixsl"
                     <xsl:with-param name="required" select="$required(.)" tunnel="yes"/>
                 </xsl:apply-templates>
             </xsl:for-each>
+        </xsl:param>
+
+        <form method="{$method}" action="{$action}">
+            <xsl:if test="$id">
+                <xsl:attribute name="id" select="$id"/>
+            </xsl:if>
+            <xsl:if test="$class">
+                <xsl:attribute name="class" select="$class"/>
+            </xsl:if>
+            <xsl:if test="$accept-charset">
+                <xsl:attribute name="accept-charset" select="$accept-charset"/>
+            </xsl:if>
+            <xsl:if test="$enctype">
+                <xsl:attribute name="enctype" select="$enctype"/>
+            </xsl:if>
+
+            <xsl:comment>This form uses RDF/POST encoding: https://atomgraph.github.io/RDF-POST/</xsl:comment>
+            <xsl:call-template name="xhtml:Input">
+                <xsl:with-param name="name" select="'rdf'"/>
+                <xsl:with-param name="type" select="'hidden'"/>
+            </xsl:call-template>
+
+            <xsl:sequence select="$body"/>
 
             <div class="{$form-actions-class}">
                 <button type="submit" class="btn btn-primary'">

--- a/src/main/webapp/static/com/atomgraph/linkeddatahub/xsl/bootstrap/2.3.2/imports/default.xsl
+++ b/src/main/webapp/static/com/atomgraph/linkeddatahub/xsl/bootstrap/2.3.2/imports/default.xsl
@@ -639,8 +639,8 @@ exclude-result-prefixes="#all"
 
     <!-- FORM CONTROL -->
     
-    <!-- change constructed blank node input to URI input -->
-    <xsl:template match="*[rdf:type/@rdf:resource = ('&dh;Container', '&dh;Item')]/@rdf:nodeID" mode="bs2:FormControl" priority="1">
+    <!-- Container/Item subject input: slug-style UI (base URI + editable slug + trailing /). Matches both @rdf:nodeID (initial SPIN-constructed creation: resource is a blank node) and @rdf:about (constraint-violation re-render: response body carries the submitted URI). Same body works for both because $action carries the resource URL in either case. -->
+    <xsl:template match="*[rdf:type/@rdf:resource = ('&dh;Container', '&dh;Item')]/@rdf:about | *[rdf:type/@rdf:resource = ('&dh;Container', '&dh;Item')]/@rdf:nodeID" mode="bs2:FormControl" priority="1">
         <xsl:param name="type" select="'text'" as="xs:string"/>
         <xsl:param name="id" select="generate-id()" as="xs:string"/>
         <xsl:param name="class" select="'subject-slug input-xxlarge'" as="xs:string?"/>

--- a/src/main/webapp/static/com/atomgraph/linkeddatahub/xsl/bootstrap/2.3.2/layout.xsl
+++ b/src/main/webapp/static/com/atomgraph/linkeddatahub/xsl/bootstrap/2.3.2/layout.xsl
@@ -949,7 +949,7 @@ exclude-result-prefixes="#all">
                         </button>
                     </li>
                     <li>
-                        <a href="{replace(string(lapp:origin()), '^(https?://)', '$1admin.')}" target="_blank">
+                        <a href="{replace(string(lapp:origin()), '^(https?://)', '$1admin.')}" class="external" target="_blank">
                             <xsl:value-of>
                                 <xsl:apply-templates select="key('resources', 'administration', document('translations.rdf'))" mode="ac:label"/>
                             </xsl:value-of>


### PR DESCRIPTION
The five modal/typeahead form rendering paths each fetched type-metadata, property-metadata, constraints, and object-metadata synchronously via document() inside their terminal render functions, blocking the UI thread on 3-4 sequential round-trips per render.

Promote each fetch to an async load/set pair invoked as steps in the existing ixsl:promise chains:
- ldh:load-type-metadata / ldh:set-type-metadata (set-type-metadata stripped of its sync work, now just extracts response body)
- ldh:load-constraints / ldh:set-constraints (new pair)
- Reuse the existing ldh:load-property-metadata and ldh:load-object-metadata in client/block.xsl, extended to accept pre-computed URIs from context (backward-compatible)

Each of the five chains (btn-edit, btn-app-settings, add-constructor, typeahead-row-form, row-form-submit-violation) is extended with the new load/set steps before its terminal render function. The render functions are correspondingly stripped of sync work and now just read metadata from context.

ldh:modal-form-submit-violation was sync; converted to start a promise chain and terminate in a new ldh:render-modal-form-violation.

To uniformly identify the resource being edited across all three modal flows in the submit-violation re-render path, the Container/Item creation modal now also carries @about on its wrapper div (the new resource URL), matching btn-edit and btn-app-settings. The submit handlers read $block/@about directly without a fallback.