### PR TITLE
Emit CTRF JSON from HTTP tests and render as GHA Job Summary

### DIFF
--- a/.github/workflows/http-tests.yml
+++ b/.github/workflows/http-tests.yml
@@ -54,6 +54,19 @@ jobs:
         run: ./run.sh "$PWD/ssl/owner/cert.pem" "${{ secrets.HTTP_TEST_OWNER_CERT_PASSWORD }}" "$PWD/ssl/secretary/cert.pem" "${{ secrets.HTTP_TEST_SECRETARY_CERT_PASSWORD }}"
         shell: bash
         working-directory: http-tests
+      - name: Generate test summary
+        if: always()
+        run: python3 scripts/generate_test_summary.py http-tests/out http-tests/out/report.md
+      - name: Write job summary
+        if: always() && hashFiles('http-tests/out/report.md') != ''
+        run: cat http-tests/out/report.md >> "$GITHUB_STEP_SUMMARY"
+      - name: Upload test results
+        if: always() && hashFiles('http-tests/out/**') != ''
+        uses: actions/upload-artifact@v4
+        with:
+          name: test-results
+          path: http-tests/out/
+          if-no-files-found: ignore
       - name: Dump container logs on failure
         if: failure()
         run: docker compose --env-file ./http-tests/.env logs --no-color

--- a/.gitignore
+++ b/.gitignore
@@ -12,5 +12,6 @@
 /http-tests/ssl
 /http-tests/datasets
 /http-tests/uploads
+/http-tests/out
 /fuseki
 .claude/scheduled_tasks.lock

--- a/http-tests/run.sh
+++ b/http-tests/run.sh
@@ -37,25 +37,133 @@ export STATUS_INTERNAL_SERVER_ERROR=500
 export STATUS_NOT_IMPLEMENTED=501
 export STATUS_BAD_GATEWAY=502
 
+# Millisecond epoch. Uses GNU date when available, otherwise falls back to Python.
+_ms_probe=$(date +%s%3N 2>/dev/null)
+if [[ "$_ms_probe" == *N ]] || [ -z "$_ms_probe" ]; then
+    function now_ms() { python3 -c 'import time; print(int(time.time()*1000))'; }
+else
+    function now_ms() { date +%s%3N; }
+fi
+unset _ms_probe
+
+# Escape a string for embedding inside a JSON string literal.
+function json_escape()
+{
+    local s="$1"
+    s="${s//\\/\\\\}"
+    s="${s//\"/\\\"}"
+    s="${s//	/\\t}"
+    # Strip carriage returns, then encode newlines.
+    s="${s//$'\r'/}"
+    s="${s//$'\n'/\\n}"
+    # Strip remaining control characters (anything below 0x20) - they would break JSON.
+    s="$(printf '%s' "$s" | LC_ALL=C tr -d '\000-\037')"
+    printf '%s' "$s"
+}
+
 function run_tests()
 {
+    local suite_name="$1"
+    shift
+
     local error_count=0
+    local suite_start_ms suite_end_ms
+    suite_start_ms=$(now_ms)
+
+    local results_file=""
+    if [ -n "$TEST_RESULTS_DIR" ]; then
+        mkdir -p "$TEST_RESULTS_DIR"
+        results_file="$TEST_RESULTS_DIR/${suite_name}.ctrf.json"
+        : > "$results_file.tests"
+    fi
+
+    local tests_total=0 tests_passed=0 tests_failed=0
+
     for script_pathname in "$@"
     do
         echo -n "$script_pathname";
+        local script_filename script_directory
         script_filename=$(basename "$script_pathname")
         script_directory=$(dirname "$script_pathname")
+
+        local log_file
+        log_file=$(mktemp)
+        local t_start_ms t_end_ms duration_ms exit_code
+        t_start_ms=$(now_ms)
         ( cd "$script_directory" || exit;
             bash -e "$script_filename";
-        )
-        if [[ $? == "0" ]]
+        ) > "$log_file" 2>&1
+        exit_code=$?
+        t_end_ms=$(now_ms)
+        duration_ms=$(( t_end_ms - t_start_ms ))
+
+        local status
+        if [[ $exit_code == "0" ]]
         then
             echo "   ok"
+            status="passed"
+            (( tests_passed += 1 ))
         else
             echo "   failed";
-            (( error_count += 1))
+            status="failed"
+            (( tests_failed += 1 ))
+            (( error_count += 1 ))
+            # Echo the captured output so CI logs still show the failure.
+            cat "$log_file"
         fi
+        (( tests_total += 1 ))
+
+        if [ -n "$results_file" ]; then
+            local message=""
+            if [ "$status" = "failed" ]; then
+                # Keep the last ~4 KiB of captured output for the report.
+                message=$(tail -c 4096 "$log_file")
+            fi
+            local rel_name="${script_pathname#./}"
+            {
+                printf '    {'
+                printf '"name":"%s",' "$(json_escape "$rel_name")"
+                printf '"status":"%s",' "$status"
+                printf '"duration":%s,' "$duration_ms"
+                printf '"suite":"%s"' "$(json_escape "$suite_name")"
+                if [ -n "$message" ]; then
+                    printf ',"message":"%s"' "$(json_escape "$message")"
+                fi
+                printf '}\n'
+            } >> "$results_file.tests"
+        fi
+
+        rm -f "$log_file"
     done
+
+    suite_end_ms=$(now_ms)
+
+    if [ -n "$results_file" ]; then
+        {
+            printf '{\n'
+            printf '  "results": {\n'
+            printf '    "tool": {"name": "http-tests-run.sh"},\n'
+            printf '    "summary": {\n'
+            printf '      "tests": %s,\n' "$tests_total"
+            printf '      "passed": %s,\n' "$tests_passed"
+            printf '      "failed": %s,\n' "$tests_failed"
+            printf '      "pending": 0,\n'
+            printf '      "skipped": 0,\n'
+            printf '      "other": 0,\n'
+            printf '      "suites": 1,\n'
+            printf '      "start": %s,\n' "$suite_start_ms"
+            printf '      "stop": %s\n' "$suite_end_ms"
+            printf '    },\n'
+            printf '    "tests": [\n'
+            # Join the per-test JSON object lines with commas.
+            awk 'NR>1 {printf ",\n"} {printf "%s", $0}' "$results_file.tests"
+            printf '\n    ]\n'
+            printf '  }\n'
+            printf '}\n'
+        } > "$results_file"
+        rm -f "$results_file.tests"
+    fi
+
     return $error_count
 }
 
@@ -107,6 +215,8 @@ export -f initialize_dataset
 export -f purge_cache
 
 export HTTP_TEST_ROOT="$PWD"
+export TEST_RESULTS_DIR="${TEST_RESULTS_DIR:-$HTTP_TEST_ROOT/out}"
+mkdir -p "$TEST_RESULTS_DIR"
 export END_USER_ENDPOINT_URL="http://localhost:3031/ds/"
 export ADMIN_ENDPOINT_URL="http://localhost:3030/ds/"
 export END_USER_BASE_URL="https://localhost:4443/"
@@ -124,7 +234,7 @@ export AGENT_CERT_PWD="changeit"
 
 start_time=$(date +%s)
 
-run_tests "signup.sh"
+run_tests "signup" "signup.sh"
 (( error_count += $? ))
 
 export AGENT_URI="$(webid-uri.sh "$AGENT_CERT_FILE")"
@@ -138,23 +248,23 @@ download_dataset "$ADMIN_ENDPOINT_URL" > "$TMP_ADMIN_DATASET"
 
 ### Other tests ###
 
-run_tests $(find ./add/ -type f -name '*.sh')
+run_tests "add" $(find ./add/ -type f -name '*.sh')
 (( error_count += $? ))
-run_tests $(find ./admin/ -type f -name '*.sh')
+run_tests "admin" $(find ./admin/ -type f -name '*.sh')
 (( error_count += $? ))
-run_tests $(find ./dataspaces/ -type f -name '*.sh')
+run_tests "dataspaces" $(find ./dataspaces/ -type f -name '*.sh')
 (( error_count += $? ))
-run_tests $(find ./access/ -type f -name '*.sh')
+run_tests "access" $(find ./access/ -type f -name '*.sh')
 (( error_count += $? ))
-run_tests $(find ./imports/ -type f -name '*.sh')
+run_tests "imports" $(find ./imports/ -type f -name '*.sh')
 (( error_count += $? ))
-run_tests $(find ./document-hierarchy/ -type f -name '*.sh')
+run_tests "document-hierarchy" $(find ./document-hierarchy/ -type f -name '*.sh')
 (( error_count += $? ))
-run_tests $(find ./misc/ -type f -name '*.sh')
+run_tests "misc" $(find ./misc/ -type f -name '*.sh')
 (( error_count += $? ))
-run_tests $(find ./proxy/ -type f -name '*.sh')
+run_tests "proxy" $(find ./proxy/ -type f -name '*.sh')
 (( error_count += $? ))
-run_tests $(find ./sparql-protocol/ -type f -name '*.sh')
+run_tests "sparql-protocol" $(find ./sparql-protocol/ -type f -name '*.sh')
 (( error_count += $? ))
 
 end_time=$(date +%s)

--- a/scripts/generate_test_summary.py
+++ b/scripts/generate_test_summary.py
@@ -1,0 +1,223 @@
+#!/usr/bin/env python3
+"""Aggregate CTRF JSON test results into a GitHub-Flavored Markdown report.
+
+Usage: generate_test_summary.py <input_dir> <output_md> [<template>]
+
+Reads every *.ctrf.json file from <input_dir>, aggregates totals, and renders
+templates/test-summary.md.hbs (or the supplied template) to <output_md>.
+The template uses a small Handlebars-subset: {{var}}, {{#if k}}…{{/if}},
+{{^if k}}…{{/if}}, {{#each list}}…{{/each}}. No external dependencies.
+"""
+import json
+import re
+import sys
+from pathlib import Path
+
+
+def human_duration(ms: int) -> str:
+    if ms < 1000:
+        return f"{ms} ms"
+    seconds = ms / 1000.0
+    if seconds < 60:
+        return f"{seconds:.1f} s"
+    minutes, sec = divmod(int(seconds), 60)
+    return f"{minutes}m {sec}s"
+
+
+def status_icon(status: str) -> str:
+    return {"passed": "✅", "failed": "❌", "skipped": "⚠️", "pending": "⏸️"}.get(status, "❔")
+
+
+def load_suites(input_dir: Path) -> list[dict]:
+    suites = []
+    for path in sorted(input_dir.glob("*.ctrf.json")):
+        try:
+            doc = json.loads(path.read_text())
+        except (json.JSONDecodeError, OSError) as exc:
+            print(f"warning: skipping {path}: {exc}", file=sys.stderr)
+            continue
+        results = doc.get("results", {})
+        summary = results.get("summary", {})
+        tests = results.get("tests", [])
+        name = path.stem.removesuffix(".ctrf")
+        duration_ms = int(summary.get("stop", 0)) - int(summary.get("start", 0))
+        if duration_ms < 0:
+            duration_ms = sum(int(t.get("duration", 0)) for t in tests)
+        tests_view = [
+            {
+                "name": t.get("name", "?"),
+                "status": t.get("status", "other"),
+                "status_icon": status_icon(t.get("status", "other")),
+                "duration_ms": int(t.get("duration", 0)),
+                "duration_human": human_duration(int(t.get("duration", 0))),
+                "message": t.get("message", ""),
+            }
+            for t in tests
+        ]
+        failed_tests = [t for t in tests_view if t["status"] == "failed"]
+        passed = int(summary.get("passed", sum(1 for t in tests if t.get("status") == "passed")))
+        failed = int(summary.get("failed", len(failed_tests)))
+        total = int(summary.get("tests", len(tests)))
+        suites.append({
+            "name": name,
+            "tests": total,
+            "passed": passed,
+            "failed": failed,
+            "skipped": int(summary.get("skipped", 0)),
+            "duration_human": human_duration(duration_ms),
+            "status_icon": status_icon("failed" if failed else "passed"),
+            "has_failures": failed > 0,
+            "tests_list": tests_view,
+            "failed_tests": failed_tests,
+        })
+    return suites
+
+
+def build_context(suites: list[dict]) -> dict:
+    tests = sum(s["tests"] for s in suites)
+    passed = sum(s["passed"] for s in suites)
+    failed = sum(s["failed"] for s in suites)
+    skipped = sum(s["skipped"] for s in suites)
+    duration_ms = sum(t["duration_ms"] for s in suites for t in s["tests_list"])
+    return {
+        "suites": len(suites),
+        "tests": tests,
+        "passed": passed,
+        "failed": failed,
+        "skipped": skipped,
+        "duration_human": human_duration(duration_ms),
+        "has_failures": failed > 0,
+        "suites_list": suites,
+    }
+
+
+# Mini-Handlebars renderer. Supports {{var}}, {{#each x}}…{{/each}},
+# {{#if x}}…{{/if}}, {{^if x}}…{{/if}}. No nested expressions in conditions —
+# the value is looked up as-is in the current context stack.
+_TAG = re.compile(r"\{\{\s*([#/^]?)\s*(if|each)?\s*([\w.-]+)?\s*\}\}")
+
+
+def _lookup(stack: list[dict], key: str):
+    if key == ".":
+        return stack[-1]
+    for ctx in reversed(stack):
+        if isinstance(ctx, dict) and key in ctx:
+            return ctx[key]
+    return ""
+
+
+def _parse(template: str) -> list:
+    """Tokenise the template into a list of nodes.
+
+    Nodes:
+      ("text", str)
+      ("var", key)
+      ("block", "each"|"if"|"unless", key, [children])
+    """
+    tokens = []
+    pos = 0
+    for m in _TAG.finditer(template):
+        if m.start() > pos:
+            tokens.append(("text", template[pos:m.start()]))
+        prefix, kind, key = m.group(1), m.group(2), m.group(3)
+        if prefix == "#":
+            tokens.append(("open", kind, key))
+        elif prefix == "/":
+            tokens.append(("close", kind or "", key))
+        elif prefix == "^":
+            tokens.append(("open", "unless", key))
+        else:
+            tokens.append(("var", key))
+        pos = m.end()
+    if pos < len(template):
+        tokens.append(("text", template[pos:]))
+
+    # Build tree from token list.
+    def build(idx):
+        nodes = []
+        while idx < len(tokens):
+            tok = tokens[idx]
+            if tok[0] == "text":
+                nodes.append(("text", tok[1]))
+                idx += 1
+            elif tok[0] == "var":
+                nodes.append(("var", tok[1]))
+                idx += 1
+            elif tok[0] == "open":
+                children, idx = build(idx + 1)
+                nodes.append(("block", tok[1], tok[2], children))
+            elif tok[0] == "close":
+                return nodes, idx + 1
+            else:
+                idx += 1
+        return nodes, idx
+
+    tree, _ = build(0)
+    return tree
+
+
+def _render(nodes: list, stack: list[dict]) -> str:
+    out = []
+    for node in nodes:
+        if node[0] == "text":
+            out.append(node[1])
+        elif node[0] == "var":
+            val = _lookup(stack, node[1])
+            out.append(str(val))
+        elif node[0] == "block":
+            _, kind, key, children = node
+            val = _lookup(stack, key)
+            if kind == "if":
+                if val:
+                    out.append(_render(children, stack))
+            elif kind == "unless":
+                if not val:
+                    out.append(_render(children, stack))
+            elif kind == "each":
+                if isinstance(val, list):
+                    for item in val:
+                        out.append(_render(children, stack + [item if isinstance(item, dict) else {".": item}]))
+    return "".join(out)
+
+
+_STANDALONE_TAG = re.compile(r"(?m)^[ \t]*(\{\{[#/^][^}]+\}\})[ \t]*\n")
+
+
+def render(template: str, context: dict) -> str:
+    # Standalone block tags (alone on a line) consume their trailing newline,
+    # so tables and lists render cleanly without blank rows.
+    template = _STANDALONE_TAG.sub(r"\1", template)
+    tree = _parse(template)
+    body = _render(tree, [context])
+    # Collapse runs of 3+ blank lines that arise from blocks with no body.
+    return re.sub(r"\n{3,}", "\n\n", body)
+
+
+def main(argv: list[str]) -> int:
+    if len(argv) < 3:
+        print(__doc__, file=sys.stderr)
+        return 2
+    input_dir = Path(argv[1])
+    output_md = Path(argv[2])
+    template_path = Path(argv[3]) if len(argv) > 3 else Path(__file__).parent / "templates" / "test-summary.md.hbs"
+
+    if not input_dir.is_dir():
+        print(f"warning: input dir not found: {input_dir}", file=sys.stderr)
+        suites = []
+    else:
+        suites = load_suites(input_dir)
+
+    if not suites:
+        output_md.parent.mkdir(parents=True, exist_ok=True)
+        output_md.write_text("## HTTP-tests summary\n\n⚠️ No test results found.\n")
+        return 0
+
+    context = build_context(suites)
+    template = template_path.read_text()
+    output_md.parent.mkdir(parents=True, exist_ok=True)
+    output_md.write_text(render(template, context))
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv))

--- a/scripts/templates/test-summary.md.hbs
+++ b/scripts/templates/test-summary.md.hbs
@@ -1,0 +1,30 @@
+## HTTP-tests summary
+
+{{#if has_failures}}❌ **{{failed}} failed**, {{passed}} passed{{/if}}{{^if has_failures}}✅ **All {{passed}} tests passed**{{/if}} — {{tests}} total in {{duration_human}}
+
+| Suites | Tests | ✅ Passed | ❌ Failed | ⚠️ Skipped |
+| --- | --- | --- | --- | --- |
+| {{suites}} | {{tests}} | {{passed}} | {{failed}} | {{skipped}} |
+
+{{#each suites_list}}
+### {{status_icon}} {{name}} — {{passed}}/{{tests}} passed ({{duration_human}})
+
+| Test | Status | Duration |
+| --- | --- | --- |
+{{#each tests_list}}
+| `{{name}}` | {{status_icon}} {{status}} | {{duration_human}} |
+{{/each}}
+
+{{#if has_failures}}
+{{#each failed_tests}}
+<details><summary>❌ <code>{{name}}</code></summary>
+
+```
+{{message}}
+```
+
+</details>
+
+{{/each}}
+{{/if}}
+{{/each}}


### PR DESCRIPTION
run.sh now writes one CTRF result file per suite to http-tests/out/. A new scripts/generate_test_summary.py aggregates them into a Markdown report (Handlebars-subset template) appended to $GITHUB_STEP_SUMMARY, with raw results uploaded as an artifact.