### PR TITLE
Consolidate label rendering on per-vocab templates, retire $ldt:lang

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -169,13 +169,13 @@
         <dependency>
             <groupId>${project.groupId}</groupId>
             <artifactId>client</artifactId>
-            <version>5.0.2</version>
+            <version>5.0.3-SNAPSHOT</version>
             <classifier>classes</classifier>
         </dependency>
         <dependency>
             <groupId>${project.groupId}</groupId>
             <artifactId>client</artifactId>
-            <version>5.0.2</version>
+            <version>5.0.3-SNAPSHOT</version>
             <type>war</type>
         </dependency>
         <dependency>

--- a/src/main/webapp/static/com/atomgraph/linkeddatahub/xsl/bootstrap/2.3.2/client/admin/signup.xsl
+++ b/src/main/webapp/static/com/atomgraph/linkeddatahub/xsl/bootstrap/2.3.2/client/admin/signup.xsl
@@ -173,7 +173,7 @@ exclude-result-prefixes="#all">
             
             <xsl:variable name="selected" select="." as="xs:anyURI"/>
             <xsl:for-each select="document(resolve-uri('static/com/atomgraph/linkeddatahub/xsl/bootstrap/2.3.2/admin/countries.rdf', lapp:origin()))/rdf:RDF/*[@rdf:about]">
-                <xsl:sort select="ac:label(.)" lang="{$ldt:lang}"/>
+                <xsl:sort select="ac:label(.)" lang="{$ac:lang}"/>
                 <xsl:apply-templates select="." mode="xhtml:Option">
                     <xsl:with-param name="selected" select="@rdf:about = $selected"/>
                 </xsl:apply-templates>

--- a/src/main/webapp/static/com/atomgraph/linkeddatahub/xsl/bootstrap/2.3.2/client/block/chart.xsl
+++ b/src/main/webapp/static/com/atomgraph/linkeddatahub/xsl/bootstrap/2.3.2/client/block/chart.xsl
@@ -183,8 +183,7 @@ exclude-result-prefixes="#all"
                     </option>
 
                     <xsl:for-each-group select="$results/rdf:RDF/*/*" group-by="concat(namespace-uri(), local-name())">
-                        <xsl:sort select="ac:property-label(.)" order="ascending" lang="{$ldt:lang}" use-when="system-property('xsl:product-name') = 'SAXON'"/>
-                        <xsl:sort select="ac:property-label(.)" order="ascending" use-when="system-property('xsl:product-name') eq 'SaxonJS'"/>
+                        <xsl:sort select="ac:property-label(.)" order="ascending" lang="{$ac:lang}"/>
 
                         <option value="{current-grouping-key()}">
                             <xsl:if test="$category = current-grouping-key()">
@@ -202,8 +201,7 @@ exclude-result-prefixes="#all"
             <xsl:for-each select="$container//select[contains-token(@class, 'chart-series')]">
                 <xsl:result-document href="?." method="ixsl:replace-content">
                     <xsl:for-each-group select="$results/rdf:RDF/*/*" group-by="concat(namespace-uri(), local-name())">
-                        <xsl:sort select="ac:property-label(.)" order="ascending" lang="{$ldt:lang}" use-when="system-property('xsl:product-name') = 'SAXON'"/>
-                        <xsl:sort select="ac:property-label(.)" order="ascending" use-when="system-property('xsl:product-name') eq 'SaxonJS'"/>
+                        <xsl:sort select="ac:property-label(.)" order="ascending" lang="{$ac:lang}"/>
 
                         <option value="{current-grouping-key()}">
                             <xsl:if test="$series = current-grouping-key()">

--- a/src/main/webapp/static/com/atomgraph/linkeddatahub/xsl/bootstrap/2.3.2/client/block/view.xsl
+++ b/src/main/webapp/static/com/atomgraph/linkeddatahub/xsl/bootstrap/2.3.2/client/block/view.xsl
@@ -2095,7 +2095,7 @@ exclude-result-prefixes="#all"
                 <!-- sort the existing <li> items together with the new item -->
                 <xsl:perform-sort select="($existing-items, $new-item)">
                     <!-- sort by the link text content (property label) -->
-                    <xsl:sort select="a/text()" lang="{$ldt:lang}"/>
+                    <xsl:sort select="a/text()" lang="{$ac:lang}"/>
                 </xsl:perform-sort>
             </xsl:variable>
 
@@ -2243,7 +2243,7 @@ exclude-result-prefixes="#all"
                     <!-- sort by count in a hidden input first -->
                     <xsl:sort select="xs:integer(input[@name = 'count']/@value)" order="descending"/>
                     <!-- sort by the link text content (value label) -->
-                    <xsl:sort select="a/text()" lang="{$ldt:lang}"/>
+                    <xsl:sort select="a/text()" lang="{$ac:lang}"/>
                 </xsl:perform-sort>
             </xsl:variable>
 

--- a/src/main/webapp/static/com/atomgraph/linkeddatahub/xsl/bootstrap/2.3.2/client/functions.xsl
+++ b/src/main/webapp/static/com/atomgraph/linkeddatahub/xsl/bootstrap/2.3.2/client/functions.xsl
@@ -45,6 +45,11 @@ exclude-result-prefixes="#all"
         <xsl:sequence select="if (ldh:query-params()?uri) then xs:anyURI(ldh:query-params()?uri) else ()"/>
     </xsl:function>
 
+    <!-- overrides the Web-Client stub; server-side ac:uuid() is the com.atomgraph.client.writer.function.UUID extension function -->
+    <xsl:function name="ac:uuid" as="xs:string">
+        <xsl:value-of select="ixsl:call(ixsl:window(), 'generateUUID', [])"/>
+    </xsl:function>
+
     <!-- ldh:query-params is defined once in imports/default.xsl and works in both contexts via ldh:request-uri -->
 
     <xsl:function name="ldh:base-uri" as="xs:anyURI">

--- a/src/main/webapp/static/com/atomgraph/linkeddatahub/xsl/bootstrap/2.3.2/client/navigation.xsl
+++ b/src/main/webapp/static/com/atomgraph/linkeddatahub/xsl/bootstrap/2.3.2/client/navigation.xsl
@@ -679,7 +679,7 @@ ORDER BY DESC(?created)
                         <xsl:result-document href="?." method="ixsl:append-content">
                             <ul class="well well-small nav nav-list">
                                 <xsl:apply-templates select="$results/rdf:RDF/rdf:Description[not(@rdf:about = $doc-uri)]" mode="xhtml:ListItem">
-                                    <xsl:sort select="ac:label(.)" order="ascending" lang="{$ldt:lang}"/>
+                                    <xsl:sort select="ac:label(.)" order="ascending" lang="{$ac:lang}"/>
                                     <xsl:with-param name="mode" select="ldh:query-params()?mode[1]" tunnel="yes"/> <!-- TO-DO: support multiple modes -->
                                     <xsl:with-param name="render-id" select="false()" tunnel="yes"/>
                                 </xsl:apply-templates>

--- a/src/main/webapp/static/com/atomgraph/linkeddatahub/xsl/bootstrap/2.3.2/document.xsl
+++ b/src/main/webapp/static/com/atomgraph/linkeddatahub/xsl/bootstrap/2.3.2/document.xsl
@@ -717,8 +717,7 @@ extension-element-prefixes="ixsl"
         <xsl:param name="property-metadata" select="if (exists($property-uris)) then ldh:send-request(resolve-uri('ns', ldt:base()), 'POST', 'application/sparql-query', 'DESCRIBE $Type' || ' VALUES $Type { ' || string-join(for $uri in $property-uris return '&lt;' || $uri || '&gt;', ' ') || ' }', map{ 'Accept': 'application/rdf+xml' }) else ()" as="document-node()?" tunnel="yes"/>
         <xsl:param name="predicates" as="element()*">
             <xsl:for-each-group select="*/*" group-by="concat(namespace-uri(), local-name())">
-                <xsl:sort select="if ($property-metadata) then ac:property-label(., $property-metadata) else ac:property-label(.)" order="ascending" lang="{$ldt:lang}" use-when="system-property('xsl:product-name') = 'SAXON'"/>
-                <xsl:sort select="if ($property-metadata) then ac:property-label(., $property-metadata) else ac:property-label(.)" order="ascending" use-when="system-property('xsl:product-name') eq 'SaxonJS'"/>
+                <xsl:sort select="if ($property-metadata) then ac:property-label(., $property-metadata) else ac:property-label(.)" order="ascending" lang="{$ac:lang}"/>
 
                 <xsl:sequence select="current-group()[1]"/>
             </xsl:for-each-group>
@@ -877,8 +876,7 @@ extension-element-prefixes="ixsl"
                                 </option>
 
                                 <xsl:for-each-group select="*/*" group-by="concat(namespace-uri(), local-name())">
-                                    <xsl:sort select="ac:property-label(.)" order="ascending" lang="{$ldt:lang}" use-when="system-property('xsl:product-name') = 'SAXON'"/>
-                                    <xsl:sort select="ac:property-label(.)" order="ascending" use-when="system-property('xsl:product-name') eq 'SaxonJS'"/>
+                                    <xsl:sort select="ac:property-label(.)" order="ascending" lang="{$ac:lang}"/>
 
                                     <option value="{current-grouping-key()}">
                                         <xsl:if test="$category = current-grouping-key()">
@@ -896,8 +894,7 @@ extension-element-prefixes="ixsl"
                             <label for="{$series-id}">Series</label>
                             <select id="{$series-id}" name="ou" multiple="multiple" class="input-large chart-series">
                                 <xsl:for-each-group select="*/*" group-by="concat(namespace-uri(), local-name())">
-                                    <xsl:sort select="ac:property-label(.)" order="ascending" lang="{$ldt:lang}" use-when="system-property('xsl:product-name') = 'SAXON'"/>
-                                    <xsl:sort select="ac:property-label(.)" order="ascending" use-when="system-property('xsl:product-name') eq 'SaxonJS'"/>
+                                    <xsl:sort select="ac:property-label(.)" order="ascending" lang="{$ac:lang}"/>
 
                                     <option value="{current-grouping-key()}">
                                         <xsl:if test="$series = current-grouping-key()">

--- a/src/main/webapp/static/com/atomgraph/linkeddatahub/xsl/bootstrap/2.3.2/imports/ac.xsl
+++ b/src/main/webapp/static/com/atomgraph/linkeddatahub/xsl/bootstrap/2.3.2/imports/ac.xsl
@@ -43,7 +43,7 @@ exclude-result-prefixes="#all">
             </option>
             
             <xsl:for-each select="$modes[not(@rdf:about = '&ac;EditMode')]"> <!-- don't show EditMode -->
-                <xsl:sort select="ac:label(.)" lang="{$ldt:lang}"/>
+                <xsl:sort select="ac:label(.)" lang="{$ac:lang}"/>
                 <xsl:apply-templates select="." mode="xhtml:Option">
                     <xsl:with-param name="selected" select="@rdf:about = $value"/>
                 </xsl:apply-templates>

--- a/src/main/webapp/static/com/atomgraph/linkeddatahub/xsl/bootstrap/2.3.2/imports/acl.xsl
+++ b/src/main/webapp/static/com/atomgraph/linkeddatahub/xsl/bootstrap/2.3.2/imports/acl.xsl
@@ -43,7 +43,7 @@ exclude-result-prefixes="#all">
         <xsl:variable name="modes" select="key('resources-by-subclass', '&acl;Access', document(ac:document-uri('&acl;')))" as="element()*"/>
         <select name="ou" id="{generate-id()}" multiple="multiple" size="{count($modes)}">
             <xsl:for-each select="$modes">
-                <xsl:sort select="ac:label(.)" lang="{$ldt:lang}"/>
+                <xsl:sort select="ac:label(.)" lang="{$ac:lang}"/>
                 <xsl:apply-templates select="." mode="xhtml:Option">
                     <xsl:with-param name="selected" select="@rdf:about = $properties/@rdf:resource"/>
                 </xsl:apply-templates>

--- a/src/main/webapp/static/com/atomgraph/linkeddatahub/xsl/bootstrap/2.3.2/imports/default.xsl
+++ b/src/main/webapp/static/com/atomgraph/linkeddatahub/xsl/bootstrap/2.3.2/imports/default.xsl
@@ -767,8 +767,11 @@ exclude-result-prefixes="#all"
 
     <!-- PROPERTY LIST -->
 
-    <!-- suppress properties in a language other than $ldt:lang. TO-DO: move to Web-Client? -->
-    <xsl:template match="*[@rdf:about or @rdf:nodeID]/*[@xml:lang and not(lang($ldt:lang))]" mode="bs2:PropertyList"/>
+    <!-- suppress values in a language the user doesn't accept. TO-DO: move to Web-Client? -->
+    <xsl:template match="*[@rdf:about or @rdf:nodeID]/*[@xml:lang and not(some $lang in $ac:langs satisfies lang($lang))]" mode="bs2:PropertyList"/>
+
+    <!-- suppress values outranked by a more preferred language on the same property -->
+    <xsl:template match="*[@rdf:about or @rdf:nodeID]/*[@xml:lang][let $rank := (for $i in 1 to count($ac:langs) return $i[lang($ac:langs[$i])])[1] return exists(../*[node-name() = node-name(current())][some $i in 1 to $rank - 1 satisfies lang($ac:langs[$i])])]" mode="bs2:PropertyList"/>
 
     <!-- FORM CONTROL -->
     

--- a/src/main/webapp/static/com/atomgraph/linkeddatahub/xsl/bootstrap/2.3.2/imports/ldh.xsl
+++ b/src/main/webapp/static/com/atomgraph/linkeddatahub/xsl/bootstrap/2.3.2/imports/ldh.xsl
@@ -31,7 +31,7 @@ exclude-result-prefixes="#all">
         <xsl:variable name="chart-types" select="key('resources-by-subclass', '&ac;Chart', document(ac:document-uri('&ldh;')))" as="element()*"/>
         <select name="ou" id="{generate-id()}">
             <xsl:for-each select="$chart-types">
-                <xsl:sort select="ac:label(.)" lang="{$ldt:lang}"/>
+                <xsl:sort select="ac:label(.)" lang="{$ac:lang}"/>
                 <xsl:apply-templates select="." mode="xhtml:Option">
                     <xsl:with-param name="selected" select="@rdf:about = $value"/>
                 </xsl:apply-templates>

--- a/src/main/webapp/static/com/atomgraph/linkeddatahub/xsl/bootstrap/2.3.2/imports/sh.xsl
+++ b/src/main/webapp/static/com/atomgraph/linkeddatahub/xsl/bootstrap/2.3.2/imports/sh.xsl
@@ -18,7 +18,6 @@ limitations under the License.
     <!ENTITY ac     "https://w3id.org/atomgraph/client#">
     <!ENTITY rdf    "http://www.w3.org/1999/02/22-rdf-syntax-ns#">
     <!ENTITY sh     "http://www.w3.org/ns/shacl#">
-    <!ENTITY ldt    "https://www.w3.org/ns/ldt#">
 ]>
 <xsl:stylesheet version="3.0"
 xmlns="http://www.w3.org/1999/xhtml"
@@ -27,25 +26,22 @@ xmlns:xs="http://www.w3.org/2001/XMLSchema"
 xmlns:ac="&ac;"
 xmlns:rdf="&rdf;"
 xmlns:sh="&sh;"
-xmlns:ldt="&ldt;"
 exclude-result-prefixes="#all">
 
-    <xsl:param name="ldt:lang" select="'en'" as="xs:string"/>
-
-    <xsl:template match="*[$ldt:lang][sh:name[lang($ldt:lang)]/text()]" mode="ac:label" priority="1">
-        <xsl:sequence select="sh:name[lang($ldt:lang)]/text()"/>
-    </xsl:template>
-    
-    <xsl:template match="*[sh:name[not(@xml:lang)]/text()]" mode="ac:label">
-        <xsl:sequence select="sh:name[not(@xml:lang)]/text()"/>
+    <xsl:template match="*[sh:name[some $lang in $ac:langs satisfies lang($lang)]/text()]" mode="ac:label" priority="1">
+        <xsl:sequence select="(for $lang in $ac:langs return sh:name[lang($lang)])[1]/text()"/>
     </xsl:template>
 
-    <xsl:template match="*[$ldt:lang][sh:description[lang($ldt:lang)]/text()]" mode="ac:description" priority="1">
-        <xsl:sequence select="sh:description[lang($ldt:lang)]/text()"/>
+    <xsl:template match="*[sh:name/text()]" mode="ac:label">
+        <xsl:sequence select="(sh:name[not(@xml:lang)], sh:name)[1]/text()"/>
     </xsl:template>
-    
-    <xsl:template match="*[sh:description[not(@xml:lang)]/text()]" mode="ac:description">
-        <xsl:sequence select="sh:description[not(@xml:lang)]/text()"/>
+
+    <xsl:template match="*[sh:description[some $lang in $ac:langs satisfies lang($lang)]/text()]" mode="ac:description" priority="1">
+        <xsl:sequence select="(for $lang in $ac:langs return sh:description[lang($lang)])[1]/text()"/>
+    </xsl:template>
+
+    <xsl:template match="*[sh:description/text()]" mode="ac:description">
+        <xsl:sequence select="(sh:description[not(@xml:lang)], sh:description)[1]/text()"/>
     </xsl:template>
     
 </xsl:stylesheet>

--- a/src/main/webapp/static/com/atomgraph/linkeddatahub/xsl/bootstrap/2.3.2/layout.xsl
+++ b/src/main/webapp/static/com/atomgraph/linkeddatahub/xsl/bootstrap/2.3.2/layout.xsl
@@ -697,7 +697,7 @@ WHERE
                                     <xsl:value-of select="ac:label(key('resources', 'user-defined-apps', document('translations.rdf')))"/>
                                 </li>
                                 <xsl:for-each select="$user-defined-apps">
-                                    <xsl:sort select="ac:label(.)" order="ascending" lang="{$ldt:lang}"/>
+                                    <xsl:sort select="ac:label(.)" order="ascending" lang="{$ac:lang}"/>
                                     <li>
                                         <a href="{lapp:origin/@rdf:resource}/" title="{lapp:origin/@rdf:resource}">
                                             <xsl:apply-templates select="." mode="ac:label"/>
@@ -713,7 +713,7 @@ WHERE
                                     <xsl:value-of select="ac:label(key('resources', 'system-apps', document('translations.rdf')))"/>
                                 </li>
                                 <xsl:for-each select="$system-apps">
-                                    <xsl:sort select="ac:label(.)" order="ascending" lang="{$ldt:lang}"/>
+                                    <xsl:sort select="ac:label(.)" order="ascending" lang="{$ac:lang}"/>
                                     <li>
                                         <a href="{lapp:origin/@rdf:resource}/" title="{lapp:origin/@rdf:resource}">
                                             <xsl:apply-templates select="." mode="ac:label"/>
@@ -924,8 +924,8 @@ WHERE
                     <xsl:document>
                         <dl class="dl-horizontal">
                             <xsl:apply-templates select="$properties-original" mode="#current">
-                                <xsl:sort select="ac:property-label(., $property-metadata)" order="ascending" lang="{$ldt:lang}"/>
-                                <xsl:sort select="if (exists((text(), @rdf:resource, @rdf:nodeID))) then (if ($object-metadata) then ac:object-label((text(), @rdf:resource, @rdf:nodeID)[1], $object-metadata) else ac:object-label((text(), @rdf:resource, @rdf:nodeID)[1])) else ()" order="ascending" lang="{$ldt:lang}"/>
+                                <xsl:sort select="ac:property-label(., $property-metadata)" order="ascending" lang="{$ac:lang}"/>
+                                <xsl:sort select="if (exists((text(), @rdf:resource, @rdf:nodeID))) then (if ($object-metadata) then ac:object-label((text(), @rdf:resource, @rdf:nodeID)[1], $object-metadata) else ac:object-label((text(), @rdf:resource, @rdf:nodeID)[1])) else ()" order="ascending" lang="{$ac:lang}"/>
                                 <xsl:with-param name="property-metadata" select="$property-metadata" tunnel="yes"/>
                             </xsl:apply-templates>
                         </dl>
@@ -949,8 +949,8 @@ WHERE
                     <xsl:document>
                         <dl class="dl-horizontal">
                             <xsl:apply-templates select="$properties-local" mode="#current">
-                                <xsl:sort select="ac:property-label(., $property-metadata)" order="ascending" lang="{$ldt:lang}"/>
-                                <xsl:sort select="if (exists((text(), @rdf:resource, @rdf:nodeID))) then (if ($object-metadata) then ac:object-label((text(), @rdf:resource, @rdf:nodeID)[1], $object-metadata) else ac:object-label((text(), @rdf:resource, @rdf:nodeID)[1])) else ()" order="ascending" lang="{$ldt:lang}"/>
+                                <xsl:sort select="ac:property-label(., $property-metadata)" order="ascending" lang="{$ac:lang}"/>
+                                <xsl:sort select="if (exists((text(), @rdf:resource, @rdf:nodeID))) then (if ($object-metadata) then ac:object-label((text(), @rdf:resource, @rdf:nodeID)[1], $object-metadata) else ac:object-label((text(), @rdf:resource, @rdf:nodeID)[1])) else ()" order="ascending" lang="{$ac:lang}"/>
                                 <xsl:with-param name="property-metadata" select="$property-metadata" tunnel="yes"/>
                             </xsl:apply-templates>
                         </dl>
@@ -974,8 +974,8 @@ WHERE
                     <xsl:document>
                         <dl class="dl-horizontal">
                             <xsl:apply-templates select="$properties-common" mode="#current">
-                                <xsl:sort select="ac:property-label(., $property-metadata)" order="ascending" lang="{$ldt:lang}"/>
-                                <xsl:sort select="if (exists((text(), @rdf:resource, @rdf:nodeID))) then (if ($object-metadata) then ac:object-label((text(), @rdf:resource, @rdf:nodeID)[1], $object-metadata) else ac:object-label((text(), @rdf:resource, @rdf:nodeID)[1])) else ()" order="ascending" lang="{$ldt:lang}"/>
+                                <xsl:sort select="ac:property-label(., $property-metadata)" order="ascending" lang="{$ac:lang}"/>
+                                <xsl:sort select="if (exists((text(), @rdf:resource, @rdf:nodeID))) then (if ($object-metadata) then ac:object-label((text(), @rdf:resource, @rdf:nodeID)[1], $object-metadata) else ac:object-label((text(), @rdf:resource, @rdf:nodeID)[1])) else ()" order="ascending" lang="{$ac:lang}"/>
                                 <xsl:with-param name="property-metadata" select="$property-metadata" tunnel="yes"/>
                             </xsl:apply-templates>
                         </dl>

--- a/src/main/webapp/static/com/atomgraph/linkeddatahub/xsl/bootstrap/2.3.2/resource.xsl
+++ b/src/main/webapp/static/com/atomgraph/linkeddatahub/xsl/bootstrap/2.3.2/resource.xsl
@@ -760,8 +760,8 @@ extension-element-prefixes="ixsl"
             <xsl:document>
                 <dl class="dl-horizontal">
                     <xsl:apply-templates select="*" mode="#current">
-                        <xsl:sort select="if ($property-metadata) then ac:property-label(., $property-metadata) else ac:property-label(.)" order="ascending" lang="{$ldt:lang}"/>
-                        <xsl:sort select="if (exists((text(), @rdf:resource, @rdf:nodeID))) then (if ($object-metadata) then ac:object-label((text(), @rdf:resource, @rdf:nodeID)[1], $object-metadata) else ac:object-label((text(), @rdf:resource, @rdf:nodeID)[1])) else ()" order="ascending" lang="{$ldt:lang}"/>
+                        <xsl:sort select="if ($property-metadata) then ac:property-label(., $property-metadata) else ac:property-label(.)" order="ascending" lang="{$ac:lang}"/>
+                        <xsl:sort select="if (exists((text(), @rdf:resource, @rdf:nodeID))) then (if ($object-metadata) then ac:object-label((text(), @rdf:resource, @rdf:nodeID)[1], $object-metadata) else ac:object-label((text(), @rdf:resource, @rdf:nodeID)[1])) else ()" order="ascending" lang="{$ac:lang}"/>
                     </xsl:apply-templates>
                 </dl>
             </xsl:document>
@@ -834,7 +834,7 @@ extension-element-prefixes="ixsl"
                         </button>
                         <ul class="dropdown-menu">
                             <xsl:for-each select="$apps//*[@rdf:about][sd:endpoint/@rdf:resource]">
-                                <xsl:sort select="ac:label(.)" order="ascending" lang="{$ldt:lang}"/>
+                                <xsl:sort select="ac:label(.)" order="ascending" lang="{$ac:lang}"/>
                                 
                                 <li>
                                     <button class="btn btn-reconcile">
@@ -894,8 +894,7 @@ extension-element-prefixes="ixsl"
     <xsl:template match="*[@rdf:about or @rdf:nodeID][rdf:type/@rdf:resource]" mode="bs2:TypeList">
         <ul class="inline">
             <xsl:for-each select="rdf:type/@rdf:resource">
-                <xsl:sort select="ac:object-label(.)" order="ascending" lang="{$ldt:lang}" use-when="system-property('xsl:product-name') = 'SAXON'"/>
-                <xsl:sort select="ac:object-label(.)" order="ascending" use-when="system-property('xsl:product-name') eq 'SaxonJS'"/>
+                <xsl:sort select="ac:object-label(.)" order="ascending" lang="{$ac:lang}"/>
 
                 <!-- TO-DO: find a way to use only cached documents, otherwise this will execute a synchronous HTTP request which slows down the UI -->
                 <li>
@@ -1037,7 +1036,7 @@ extension-element-prefixes="ixsl"
                             <!-- apply on the "deepest" subclass and its subclasses -->
                             <!-- eliminate matches where a class is a subclass of itself (happens in inferenced ontology models) -->
                             <xsl:for-each-group select="$self-and-subclasses[let $about := @rdf:about return not($about = $self-and-subclasses[not(@rdf:about = $about)]/rdfs:subClassOf/@rdf:resource)]" group-by="@rdf:about">
-                                <xsl:sort select="ac:label(.)" order="ascending" lang="{$ldt:lang}"/>
+                                <xsl:sort select="ac:label(.)" order="ascending" lang="{$ac:lang}"/>
 
                                 <!-- won't traverse blank nodes, only URI resources -->
                                 <li>

--- a/src/main/webapp/static/com/atomgraph/linkeddatahub/xsl/client.xsl
+++ b/src/main/webapp/static/com/atomgraph/linkeddatahub/xsl/client.xsl
@@ -130,6 +130,7 @@ extension-element-prefixes="ixsl"
     <xsl:param name="ldt:ontology" as="xs:anyURI?"/> <!-- used in Web-Client TO-DO: remove -->
     <xsl:param name="acl:agent" as="xs:anyURI?"/>
     <xsl:param name="foaf:Agent" select="if ($acl:agent) then document(ac:document-uri($acl:agent)) else ()" as="document-node()?"/> <!-- should be in SaxonJS documentPool -->
+    <xsl:param name="ac:langs" select="for $lang in ixsl:get(ixsl:window(), 'navigator.languages') return tokenize($lang, '-')[1]" as="xs:string*"/> <!-- overrides the Web-Client default with the browser's ordered preference list -->
     <xsl:param name="ac:forClass" as="xs:anyURI?"/> <!-- used by Web-Client -->
     <xsl:param name="ac:query" select="ldh:query-params()?query" as="xs:string?"/>
     <xsl:param name="ac:googleMapsKey" select="''" as="xs:string"/>  <!-- cannot remove yet as it's used by container.xsl in Web-Client -->

--- a/src/main/webapp/static/com/atomgraph/linkeddatahub/xsl/client.xsl
+++ b/src/main/webapp/static/com/atomgraph/linkeddatahub/xsl/client.xsl
@@ -74,7 +74,15 @@ extension-element-prefixes="ixsl"
 
     <xsl:import href="../../../../com/atomgraph/client/xsl/functions.xsl"/>
     <xsl:import href="../../../../com/atomgraph/client/xsl/imports/default.xsl"/>
+    <xsl:import href="../../../../com/atomgraph/client/xsl/imports/dc.xsl"/>
+    <xsl:import href="../../../../com/atomgraph/client/xsl/imports/dct.xsl"/>
+    <xsl:import href="../../../../com/atomgraph/client/xsl/imports/doap.xsl"/>
+    <xsl:import href="../../../../com/atomgraph/client/xsl/imports/foaf.xsl"/>
     <xsl:import href="../../../../com/atomgraph/client/xsl/imports/rdf.xsl"/>
+    <xsl:import href="../../../../com/atomgraph/client/xsl/imports/rdfs.xsl"/>
+    <xsl:import href="../../../../com/atomgraph/client/xsl/imports/schema.xsl"/>
+    <xsl:import href="../../../../com/atomgraph/client/xsl/imports/sioc.xsl"/>
+    <xsl:import href="../../../../com/atomgraph/client/xsl/imports/skos.xsl"/>
     <xsl:import href="../../../../com/atomgraph/client/xsl/imports/sp.xsl"/>
     <xsl:import href="../../../../com/atomgraph/client/xsl/bootstrap/2.3.2/imports/default.xsl"/>
     <xsl:import href="bootstrap/2.3.2/imports/default.xsl"/>
@@ -122,7 +130,6 @@ extension-element-prefixes="ixsl"
     <xsl:param name="ldt:ontology" as="xs:anyURI?"/> <!-- used in Web-Client TO-DO: remove -->
     <xsl:param name="acl:agent" as="xs:anyURI?"/>
     <xsl:param name="foaf:Agent" select="if ($acl:agent) then document(ac:document-uri($acl:agent)) else ()" as="document-node()?"/> <!-- should be in SaxonJS documentPool -->
-    <xsl:param name="ac:lang" select="tokenize(ixsl:get(ixsl:get(ixsl:window(), 'navigator'), 'language'), '-')[1]" as="xs:string"/>
     <xsl:param name="ac:forClass" as="xs:anyURI?"/> <!-- used by Web-Client -->
     <xsl:param name="ac:query" select="ldh:query-params()?query" as="xs:string?"/>
     <xsl:param name="ac:googleMapsKey" select="''" as="xs:string"/>  <!-- cannot remove yet as it's used by container.xsl in Web-Client -->
@@ -240,7 +247,7 @@ WHERE
         <xsl:message>xsl:product-name: <xsl:value-of select="system-property('xsl:product-name')"/></xsl:message>
         <xsl:message>saxon:platform: <xsl:value-of select="system-property('saxon:platform')"/></xsl:message>
         <xsl:message>$ac:contextUri: <xsl:value-of select="$ac:contextUri"/></xsl:message>
-        <xsl:message>$ac:lang: <xsl:value-of select="$ac:lang"/></xsl:message>
+        <xsl:message>$ac:langs: <xsl:value-of select="$ac:langs" separator=" "/></xsl:message>
         <xsl:message>$acl:agent: <xsl:value-of select="$acl:agent"/></xsl:message>
         <xsl:message>ac:uri(): <xsl:value-of select="ac:uri()"/></xsl:message>
         <xsl:message>UTC offset: <xsl:value-of select="implicit-timezone()"/></xsl:message>
@@ -297,78 +304,6 @@ WHERE
     </xsl:template>
 
     <!-- TEMPLATES -->
-  
-    <!-- we don't want to include per-vocabulary stylesheets -->
-    
-    <xsl:template match="*[*][@rdf:about] | *[*][@rdf:nodeID]" mode="ac:label">
-        <xsl:choose>
-            <xsl:when test="skos:prefLabel[lang($ac:lang)]">
-                <xsl:sequence select="skos:prefLabel[lang($ac:lang)]/text()"/>
-            </xsl:when>
-            <xsl:when test="rdfs:label[lang($ac:lang)]">
-                <xsl:sequence select="rdfs:label[lang($ac:lang)]/text()"/>
-            </xsl:when>
-            <xsl:when test="dct:title[lang($ac:lang)]">
-                <xsl:sequence select="dct:title[lang($ac:lang)]/text()"/>
-            </xsl:when>
-            <xsl:when test="skos:prefLabel">
-                <xsl:sequence select="skos:prefLabel/text()"/>
-            </xsl:when>
-            <xsl:when test="rdfs:label">
-                <xsl:sequence select="rdfs:label/text()"/>
-            </xsl:when>
-            <xsl:when test="dct:title">
-                <xsl:sequence select="dct:title/text()"/>
-            </xsl:when>
-            <xsl:when test="foaf:name">
-                <xsl:sequence select="foaf:name/text()"/>
-            </xsl:when>
-            <xsl:when test="foaf:givenName and foaf:familyName">
-                <xsl:sequence select="concat(foaf:givenName, ' ', foaf:familyName)"/>
-            </xsl:when>
-            <xsl:when test="foaf:familyName">
-                <xsl:sequence select="foaf:familyName/text()"/>
-            </xsl:when>
-            <xsl:when test="foaf:nick">
-                <xsl:sequence select="foaf:nick/text()"/>
-            </xsl:when>
-            <xsl:when test="sioc:name">
-                <xsl:sequence select="sioc:name/text()"/>
-            </xsl:when>
-            <xsl:when test="schema1:name">
-                <xsl:sequence select="schema1:name/text()"/>
-            </xsl:when>
-            <xsl:when test="schema2:name">
-                <xsl:sequence select="schema2:name/text()"/>
-            </xsl:when>
-            <xsl:otherwise>
-                <xsl:next-match/>
-            </xsl:otherwise>
-        </xsl:choose>
-    </xsl:template>
-
-    <xsl:template match="*[*][@rdf:about] | *[*][@rdf:nodeID]" mode="ac:description">
-        <xsl:choose>
-            <xsl:when test="rdfs:comment[lang($ac:lang)]">
-                <xsl:sequence select="rdfs:comment[lang($ac:lang)]/text()"/>
-            </xsl:when>
-            <xsl:when test="dct:description[lang($ac:lang)]">
-                <xsl:sequence select="dct:description[lang($ac:lang)]/text()"/>
-            </xsl:when>
-            <xsl:when test="rdfs:comment">
-                <xsl:sequence select="rdfs:comment/text()"/>
-            </xsl:when>
-            <xsl:when test="dct:description">
-                <xsl:sequence select="dct:description/text()"/>
-            </xsl:when>
-            <xsl:when test="schema1:description">
-                <xsl:sequence select="schema1:description/text()"/>
-            </xsl:when>
-            <xsl:when test="schema2:description">
-                <xsl:sequence select="schema2:description/text()"/>
-            </xsl:when>
-        </xsl:choose>
-    </xsl:template>
 
     <xsl:template match="*[*][@rdf:about] | *[*][@rdf:nodeID]" mode="ac:image">
         <xsl:choose>


### PR DESCRIPTION
## Summary

Fixes duplicate bilingual widget headings (e.g. `BacklinksBacklinks`, `Related resultsResultados relacionados`) and makes the browser's ordered language preference govern label selection. Companion PR: AtomGraph/Web-Client#89 (requires `client` `5.0.3-SNAPSHOT`).

- `client.xsl` imports the Web-Client per-vocab stylesheets (same order as `internal-layout.xsl`, so CSR label precedence = SSR by construction) and drops the monolithic `ac:label`/`ac:description` override, whose unfiltered fallback emitted every language variant when the browser language matched neither `@en` nor `@es`.
- `$ac:langs` is overridden client-side from `navigator.languages` (SaxonJS marshals it as an XDM sequence); server-side the Web-Client writer passes the request's `Accept-Language`. Label selection is no longer capped by the `supportedLanguages` config — a `@lt` label wins for an `lt`-preferring user while `Content-Language` still negotiates against `en,es`.
- Property-value suppression in `bs2:PropertyList` negotiates per property over `$ac:langs` (two split templates with cheap match patterns): the best accepted language wins; values in unaccepted languages stay hidden as before.
- `sh.xsl` label/description templates migrated; all `xsl:sort` collations use `$ac:lang`; dual `use-when` sort pairs collapsed.
- Client-side `ac:uuid()` override added (`window.generateUUID`), completing the removal of `ixsl` from Web-Client.
- `$ldt:lang` is fully retired from this repo (0 references); it remains the SSR `Content-Language` carrier in Web-Client.

## Test plan

Verified in the browser against three preference configurations, all rendering single-language labels with SSR/CSR parity:

| `Accept-Language` | UI chrome | Data labels |
|---|---|---|
| `es,lt;q=0.9,en-US;q=0.8,en;q=0.7` | Spanish (`Registrarse`, `Resultados relacionados`) | Lithuanian |
| `lt,en-US;q=0.9,en;q=0.8` | English | Lithuanian |
| `en-US,en;q=0.9` | English | English where available, first-available fallback otherwise |

🤖 Generated with [Claude Code](https://claude.com/claude-code)