### PR TITLE
Pin graph-scoped queries via SPARQL Protocol dataset params

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,7 @@
 ## [Unreleased]
+### Added
+- HTTP tests pinning graph-scoped queries via SPARQL Protocol dataset parameters on `/sparql` (`default-graph-uri=<doc-uri>` scopes a query to one document's graph; overrides `FROM`; `GRAPH` patterns match nothing) — the read-side counterpart of graph-scoped `PATCH`, no server changes needed
+
 ### Changed
 - Application ontologies resolved as a native ontapi `owl:imports` union graph (cached per ontology URI), no RDFS inference — replaces the manually flattened, RDFS-materialized model
 - `Namespace` no-query GET serves the raw ontology graph from the shared repository instead of rebuilding one per request

--- a/http-tests/sparql-protocol/query/GET-sparql-default-graph-uri-from-override.sh
+++ b/http-tests/sparql-protocol/query/GET-sparql-default-graph-uri-from-override.sh
@@ -1,0 +1,54 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+initialize_dataset "$END_USER_BASE_URL" "$TMP_END_USER_DATASET" "$END_USER_ENDPOINT_URL"
+initialize_dataset "$ADMIN_BASE_URL" "$TMP_ADMIN_DATASET" "$ADMIN_ENDPOINT_URL"
+purge_cache "$END_USER_VARNISH_SERVICE"
+purge_cache "$ADMIN_VARNISH_SERVICE"
+purge_cache "$FRONTEND_VARNISH_SERVICE"
+
+# create two containers whose graphs hold distinct titles
+
+slug_one=$(uuidgen | tr '[:upper:]' '[:lower:]')
+slug_two=$(uuidgen | tr '[:upper:]' '[:lower:]')
+
+container_one=$(create-container.sh \
+  -f "$OWNER_CERT_FILE" \
+  -p "$OWNER_CERT_PWD" \
+  -b "$END_USER_BASE_URL" \
+  --title "Graph scope one" \
+  --slug "$slug_one" \
+  --parent "$END_USER_BASE_URL")
+
+container_two=$(create-container.sh \
+  -f "$OWNER_CERT_FILE" \
+  -p "$OWNER_CERT_PWD" \
+  -b "$END_USER_BASE_URL" \
+  --title "Graph scope two" \
+  --slug "$slug_two" \
+  --parent "$END_USER_BASE_URL")
+
+# the protocol dataset description overrides the query's FROM clause (SPARQL 1.1 Protocol):
+# FROM <container_two> in the query text loses to default-graph-uri=<container_one>
+
+result=$(curl -k -f -s -G \
+  -E "$OWNER_CERT_FILE":"$OWNER_CERT_PWD" \
+  -H "Accept: application/sparql-results+xml" \
+  "${END_USER_BASE_URL}sparql" \
+  --data-urlencode "query=SELECT ?title FROM <${container_two}> WHERE { ?s <http://purl.org/dc/terms/title> ?title }" \
+  --data-urlencode "default-graph-uri=${container_one}")
+
+echo "DEBUG: FROM: $container_two"
+echo "DEBUG: default-graph-uri: $container_one"
+echo "DEBUG: Got: $result"
+
+# the protocol-specified graph's title is visible
+
+echo "$result" | grep -q "Graph scope one" || { echo "DEBUG: expected 'Graph scope one' - protocol dataset should win over FROM"; exit 1; }
+
+# the FROM graph's title is not
+
+if echo "$result" | grep -q "Graph scope two"; then
+    echo "DEBUG: 'Graph scope two' visible - FROM clause overrode the protocol dataset"
+    exit 1
+fi

--- a/http-tests/sparql-protocol/query/GET-sparql-default-graph-uri-from-override.sh
+++ b/http-tests/sparql-protocol/query/GET-sparql-default-graph-uri-from-override.sh
@@ -38,17 +38,12 @@ result=$(curl -k -f -s -G \
   --data-urlencode "query=SELECT ?title FROM <${container_two}> WHERE { ?s <http://purl.org/dc/terms/title> ?title }" \
   --data-urlencode "default-graph-uri=${container_one}")
 
-echo "DEBUG: FROM: $container_two"
-echo "DEBUG: default-graph-uri: $container_one"
-echo "DEBUG: Got: $result"
-
 # the protocol-specified graph's title is visible
 
-echo "$result" | grep -q "Graph scope one" || { echo "DEBUG: expected 'Graph scope one' - protocol dataset should win over FROM"; exit 1; }
+echo "$result" | grep -q "Graph scope one"
 
 # the FROM graph's title is not
 
 if echo "$result" | grep -q "Graph scope two"; then
-    echo "DEBUG: 'Graph scope two' visible - FROM clause overrode the protocol dataset"
     exit 1
 fi

--- a/http-tests/sparql-protocol/query/GET-sparql-default-graph-uri-graph-pattern.sh
+++ b/http-tests/sparql-protocol/query/GET-sparql-default-graph-uri-graph-pattern.sh
@@ -30,13 +30,7 @@ control=$(curl -k -f -s -G \
 
 control_count=$(echo "$control" | grep -c "<result>" || true)
 
-echo "DEBUG: default-graph-uri: $container"
-echo "DEBUG: control result count: $control_count"
-
-if [ "$control_count" -eq 0 ]; then
-    echo "DEBUG: control query returned no results - scoped default graph unexpectedly empty"
-    exit 1
-fi
+[ "$control_count" -gt 0 ]
 
 # the protocol dataset contains no named graphs, so GRAPH patterns must match nothing
 
@@ -49,10 +43,4 @@ result=$(curl -k -f -s -G \
 
 result_count=$(echo "$result" | grep -c "<result>" || true)
 
-echo "DEBUG: Expected GRAPH-pattern result count: 0"
-echo "DEBUG: Got: $result_count"
-
-if [ "$result_count" -ne 0 ]; then
-    echo "DEBUG: GRAPH pattern escaped the default-graph-uri scope"
-    exit 1
-fi
+[ "$result_count" -eq 0 ]

--- a/http-tests/sparql-protocol/query/GET-sparql-default-graph-uri-graph-pattern.sh
+++ b/http-tests/sparql-protocol/query/GET-sparql-default-graph-uri-graph-pattern.sh
@@ -1,0 +1,58 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+initialize_dataset "$END_USER_BASE_URL" "$TMP_END_USER_DATASET" "$END_USER_ENDPOINT_URL"
+initialize_dataset "$ADMIN_BASE_URL" "$TMP_ADMIN_DATASET" "$ADMIN_ENDPOINT_URL"
+purge_cache "$END_USER_VARNISH_SERVICE"
+purge_cache "$ADMIN_VARNISH_SERVICE"
+purge_cache "$FRONTEND_VARNISH_SERVICE"
+
+# create a container whose graph holds a known title
+
+slug=$(uuidgen | tr '[:upper:]' '[:lower:]')
+
+container=$(create-container.sh \
+  -f "$OWNER_CERT_FILE" \
+  -p "$OWNER_CERT_PWD" \
+  -b "$END_USER_BASE_URL" \
+  --title "Graph scope one" \
+  --slug "$slug" \
+  --parent "$END_USER_BASE_URL")
+
+# control: the scoped default graph is non-empty
+
+control=$(curl -k -f -s -G \
+  -E "$OWNER_CERT_FILE":"$OWNER_CERT_PWD" \
+  -H "Accept: application/sparql-results+xml" \
+  "${END_USER_BASE_URL}sparql" \
+  --data-urlencode "query=SELECT * { ?s ?p ?o }" \
+  --data-urlencode "default-graph-uri=${container}")
+
+control_count=$(echo "$control" | grep -c "<result>" || true)
+
+echo "DEBUG: default-graph-uri: $container"
+echo "DEBUG: control result count: $control_count"
+
+if [ "$control_count" -eq 0 ]; then
+    echo "DEBUG: control query returned no results - scoped default graph unexpectedly empty"
+    exit 1
+fi
+
+# the protocol dataset contains no named graphs, so GRAPH patterns must match nothing
+
+result=$(curl -k -f -s -G \
+  -E "$OWNER_CERT_FILE":"$OWNER_CERT_PWD" \
+  -H "Accept: application/sparql-results+xml" \
+  "${END_USER_BASE_URL}sparql" \
+  --data-urlencode "query=SELECT * { GRAPH ?g { ?s ?p ?o } }" \
+  --data-urlencode "default-graph-uri=${container}")
+
+result_count=$(echo "$result" | grep -c "<result>" || true)
+
+echo "DEBUG: Expected GRAPH-pattern result count: 0"
+echo "DEBUG: Got: $result_count"
+
+if [ "$result_count" -ne 0 ]; then
+    echo "DEBUG: GRAPH pattern escaped the default-graph-uri scope"
+    exit 1
+fi

--- a/http-tests/sparql-protocol/query/GET-sparql-default-graph-uri.sh
+++ b/http-tests/sparql-protocol/query/GET-sparql-default-graph-uri.sh
@@ -1,0 +1,52 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+initialize_dataset "$END_USER_BASE_URL" "$TMP_END_USER_DATASET" "$END_USER_ENDPOINT_URL"
+initialize_dataset "$ADMIN_BASE_URL" "$TMP_ADMIN_DATASET" "$ADMIN_ENDPOINT_URL"
+purge_cache "$END_USER_VARNISH_SERVICE"
+purge_cache "$ADMIN_VARNISH_SERVICE"
+purge_cache "$FRONTEND_VARNISH_SERVICE"
+
+# create two containers whose graphs hold distinct titles
+
+slug_one=$(uuidgen | tr '[:upper:]' '[:lower:]')
+slug_two=$(uuidgen | tr '[:upper:]' '[:lower:]')
+
+container_one=$(create-container.sh \
+  -f "$OWNER_CERT_FILE" \
+  -p "$OWNER_CERT_PWD" \
+  -b "$END_USER_BASE_URL" \
+  --title "Graph scope one" \
+  --slug "$slug_one" \
+  --parent "$END_USER_BASE_URL")
+
+container_two=$(create-container.sh \
+  -f "$OWNER_CERT_FILE" \
+  -p "$OWNER_CERT_PWD" \
+  -b "$END_USER_BASE_URL" \
+  --title "Graph scope two" \
+  --slug "$slug_two" \
+  --parent "$END_USER_BASE_URL")
+
+# SPARQL Protocol dataset specification: default-graph-uri scopes the query to a single document graph
+
+result=$(curl -k -f -s -G \
+  -E "$OWNER_CERT_FILE":"$OWNER_CERT_PWD" \
+  -H "Accept: application/sparql-results+xml" \
+  "${END_USER_BASE_URL}sparql" \
+  --data-urlencode "query=SELECT ?title { ?s <http://purl.org/dc/terms/title> ?title }" \
+  --data-urlencode "default-graph-uri=${container_one}")
+
+echo "DEBUG: default-graph-uri: $container_one"
+echo "DEBUG: Got: $result"
+
+# the scoped graph's title is visible
+
+echo "$result" | grep -q "Graph scope one" || { echo "DEBUG: expected 'Graph scope one' in scoped results"; exit 1; }
+
+# the other document's graph is invisible
+
+if echo "$result" | grep -q "Graph scope two"; then
+    echo "DEBUG: 'Graph scope two' leaked into results scoped to $container_one"
+    exit 1
+fi

--- a/http-tests/sparql-protocol/query/GET-sparql-default-graph-uri.sh
+++ b/http-tests/sparql-protocol/query/GET-sparql-default-graph-uri.sh
@@ -37,16 +37,12 @@ result=$(curl -k -f -s -G \
   --data-urlencode "query=SELECT ?title { ?s <http://purl.org/dc/terms/title> ?title }" \
   --data-urlencode "default-graph-uri=${container_one}")
 
-echo "DEBUG: default-graph-uri: $container_one"
-echo "DEBUG: Got: $result"
-
 # the scoped graph's title is visible
 
-echo "$result" | grep -q "Graph scope one" || { echo "DEBUG: expected 'Graph scope one' in scoped results"; exit 1; }
+echo "$result" | grep -q "Graph scope one"
 
 # the other document's graph is invisible
 
 if echo "$result" | grep -q "Graph scope two"; then
-    echo "DEBUG: 'Graph scope two' leaked into results scoped to $container_one"
     exit 1
 fi

--- a/http-tests/sparql-protocol/query/POST-sparql-default-graph-uri.sh
+++ b/http-tests/sparql-protocol/query/POST-sparql-default-graph-uri.sh
@@ -1,0 +1,56 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+initialize_dataset "$END_USER_BASE_URL" "$TMP_END_USER_DATASET" "$END_USER_ENDPOINT_URL"
+initialize_dataset "$ADMIN_BASE_URL" "$TMP_ADMIN_DATASET" "$ADMIN_ENDPOINT_URL"
+purge_cache "$END_USER_VARNISH_SERVICE"
+purge_cache "$ADMIN_VARNISH_SERVICE"
+purge_cache "$FRONTEND_VARNISH_SERVICE"
+
+# create two containers whose graphs hold distinct titles
+
+slug_one=$(uuidgen | tr '[:upper:]' '[:lower:]')
+slug_two=$(uuidgen | tr '[:upper:]' '[:lower:]')
+
+container_one=$(create-container.sh \
+  -f "$OWNER_CERT_FILE" \
+  -p "$OWNER_CERT_PWD" \
+  -b "$END_USER_BASE_URL" \
+  --title "Graph scope one" \
+  --slug "$slug_one" \
+  --parent "$END_USER_BASE_URL")
+
+container_two=$(create-container.sh \
+  -f "$OWNER_CERT_FILE" \
+  -p "$OWNER_CERT_PWD" \
+  -b "$END_USER_BASE_URL" \
+  --title "Graph scope two" \
+  --slug "$slug_two" \
+  --parent "$END_USER_BASE_URL")
+
+# query via POST directly (application/sparql-query): dataset params go in the request URI query string.
+# The container URI is built from a lowercase UUID slug, so only ':' and '/' need percent-encoding.
+
+container_one_enc="${container_one//:/%3A}"
+container_one_enc="${container_one_enc//\//%2F}"
+
+result=$(curl -k -f -s -X POST \
+  -E "$OWNER_CERT_FILE":"$OWNER_CERT_PWD" \
+  -H "Accept: application/sparql-results+xml" \
+  -H "Content-Type: application/sparql-query" \
+  "${END_USER_BASE_URL}sparql?default-graph-uri=${container_one_enc}" \
+  --data-binary "SELECT ?title { ?s <http://purl.org/dc/terms/title> ?title }")
+
+echo "DEBUG: default-graph-uri: $container_one"
+echo "DEBUG: Got: $result"
+
+# the scoped graph's title is visible
+
+echo "$result" | grep -q "Graph scope one" || { echo "DEBUG: expected 'Graph scope one' in scoped results"; exit 1; }
+
+# the other document's graph is invisible
+
+if echo "$result" | grep -q "Graph scope two"; then
+    echo "DEBUG: 'Graph scope two' leaked into results scoped to $container_one"
+    exit 1
+fi

--- a/http-tests/sparql-protocol/query/POST-sparql-default-graph-uri.sh
+++ b/http-tests/sparql-protocol/query/POST-sparql-default-graph-uri.sh
@@ -41,16 +41,12 @@ result=$(curl -k -f -s -X POST \
   "${END_USER_BASE_URL}sparql?default-graph-uri=${container_one_enc}" \
   --data-binary "SELECT ?title { ?s <http://purl.org/dc/terms/title> ?title }")
 
-echo "DEBUG: default-graph-uri: $container_one"
-echo "DEBUG: Got: $result"
-
 # the scoped graph's title is visible
 
-echo "$result" | grep -q "Graph scope one" || { echo "DEBUG: expected 'Graph scope one' in scoped results"; exit 1; }
+echo "$result" | grep -q "Graph scope one"
 
 # the other document's graph is invisible
 
 if echo "$result" | grep -q "Graph scope two"; then
-    echo "DEBUG: 'Graph scope two' leaked into results scoped to $container_one"
     exit 1
 fi


### PR DESCRIPTION
## Summary

Every LDH document is a named graph (document URI = graph name), and `PATCH` on a document URI already does graph-scoped updates. This PR establishes the **read-side counterpart** — and the punchline is that it needs **no server changes at all**: the SPARQL 1.1 Protocol's dataset specification on the existing `/sparql` endpoint (`?query=…&default-graph-uri=<doc-uri>`) scopes a query to exactly one document's graph.

The pass-through was verified to exist end-to-end:

- Core `SPARQLEndpointImpl` binds `default-graph-uri`/`named-graph-uri` on all three protocol request forms (GET, form POST, direct POST)
- `EndpointAccessorImpl` forwards them verbatim to Fuseki via `SPARQLClient`
- Fuseki applies protocol dataset semantics: the specified dataset overrides `FROM`/`FROM NAMED`, and with no `named-graph-uri` the `GRAPH` patterns match nothing — sound scoping
- The Fuseki-facing Varnish write-ban regex already covers `default-graph-uri` URLs, so cache invalidation is handled

Runtime verification against a running instance confirmed all of the above (scoped SELECT/CONSTRUCT counts matching `GRAPH <doc>` cross-checks, cross-dataspace isolation, `FROM` override).

## Changes

Four http-tests under `http-tests/sparql-protocol/query/` pin the behavior against regression:

- `GET-sparql-default-graph-uri.sh` — SELECT scoped to one container's graph sees its title and not another container's
- `POST-sparql-default-graph-uri.sh` — same via direct POST (`application/sparql-query`) with the dataset param on the request URI
- `GET-sparql-default-graph-uri-graph-pattern.sh` — `GRAPH` patterns match nothing under `default-graph-uri`, with a non-empty control query guarding the assertion
- `GET-sparql-default-graph-uri-from-override.sh` — the protocol dataset description overrides the query's `FROM` clause

Plus a CHANGELOG entry.

## Test results

Full `./run.sh` suite: all `sparql-protocol` tests green, including the new four. The 23 failures elsewhere are pre-existing (admin/acl, packages, and proxy SSRF-validation tests whose server-side behavior is on `ft-imports-ssrf-validation`, not this branch) and ran before the new tests in suite order.

## Noted, not addressed here

ASK queries through LDH's `/sparql` return a malformed empty result-set serialization instead of `<boolean>` (with or without dataset params; Fuseki-direct ASK is correct) — pre-existing, likely in the Core ask dispatch. Worth a separate issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)