### PR TITLE
Count SPARQL results with xmllint instead of grep -c

### DIFF
--- a/.github/workflows/http-tests.yml
+++ b/.github/workflows/http-tests.yml
@@ -12,7 +12,7 @@ jobs:
       BASE_URI: https://localhost:4443/
     steps:
       - name: Install Linux packages
-        run: sudo apt-get update && sudo apt-get install -qq raptor2-utils && sudo apt-get install curl
+        run: sudo apt-get update && sudo apt-get install -qq raptor2-utils libxml2-utils && sudo apt-get install curl
       - name: Set up Java 21
         uses: actions/setup-java@v4
         with:

--- a/http-tests/sparql-protocol/query/GET-sparql-default-graph-uri-graph-pattern.sh
+++ b/http-tests/sparql-protocol/query/GET-sparql-default-graph-uri-graph-pattern.sh
@@ -28,7 +28,7 @@ control=$(curl -k -f -s -G \
   --data-urlencode "query=SELECT * { ?s ?p ?o }" \
   --data-urlencode "default-graph-uri=${container}")
 
-control_count=$(echo "$control" | grep -c "<result>" || true)
+control_count=$(echo "$control" | xmllint --xpath 'count(//*[local-name()="result"])' -)
 
 [ "$control_count" -gt 0 ]
 
@@ -41,6 +41,6 @@ result=$(curl -k -f -s -G \
   --data-urlencode "query=SELECT * { GRAPH ?g { ?s ?p ?o } }" \
   --data-urlencode "default-graph-uri=${container}")
 
-result_count=$(echo "$result" | grep -c "<result>" || true)
+result_count=$(echo "$result" | xmllint --xpath 'count(//*[local-name()="result"])' -)
 
 [ "$result_count" -eq 0 ]


### PR DESCRIPTION
## Summary

The two numeric assertions in `sparql-protocol/query/GET-sparql-default-graph-uri-graph-pattern.sh` counted results with `grep -c "<result>"`, which only works because Jena's XML results writer happens to emit one `<result>` element per line. They now use `xmllint --xpath 'count(//*[local-name()="result"])'`, asserting the actual structure independent of serialization layout. Both output shapes verified against a live instance (`3` for the non-empty control, `0` for the sealed `GRAPH`-pattern case).

Includes the `libxml2-utils` CI-runner install commit (cherry-picked from #347, where `import-ontology.sh` uses `xmllint` for `sp:text` extraction) so this branch's CI is self-contained — the identical workflow line merges cleanly whichever PR lands first.

## Scope note

A survey of the whole suite found no other conversion candidates: the remaining XML greps are exact-string presence checks on known serializations (correct as `grep`), and the one other `grep -c` counts N-Triples lines, not XML. `xmllint` is used only where structure matters — one extraction, two counts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)