### PR TITLE
GitHub-backed graph versioning with Memento history UI (P2.2 MVP)

### DIFF
--- a/README.md
+++ b/README.md
@@ -165,6 +165,49 @@ The following tools are required for CLI scripts in the `bin/` directory:
 
 _:warning: Do not use blank nodes to identify applications or services. We recommend using the `urn:` URI scheme, since LinkedDataHub application resources are not accessible under their own dataspace._
 
+  ### Graph versioning
+
+  Since version 5.9.0, LinkedDataHub can mirror every document of a dataspace into a GitHub repository. Each document (named graph) becomes an N-Triples file, and every write (`POST`/`PUT`/`PATCH`/`DELETE`) becomes a commit authored with the agent's WebID — giving you a full history, audit trail, and undo capability using plain git tooling. Commits happen asynchronously in the background and are best-effort: if GitHub is unavailable or the token is invalid, writes succeed as usual and the failures are only logged.
+
+  Historical versions can be retrieved with the `version` query parameter using a commit SHA:
+  ```shell
+  curl -k -E ./ssl/owner/cert.pem:<your cert password> -H "Accept: text/turtle" 'https://localhost:4443/my-doc/?version=<commit-sha>'
+  ```
+  Version responses are immutable and carry a `Memento-Datetime` header with the commit's datetime. They are subject to the same access control as the live document.
+
+  Versioning is **disabled by default**. To enable it for a dataspace:
+
+  1. Create a GitHub repository (a private one is recommended) that will store the graph files.
+  2. Obtain an access token: on GitHub, go to **Settings > Developer settings > Personal access tokens > Fine-grained tokens > Generate new token**. Under **Repository access** select **Only select repositories** and pick the repository from step 1; under **Permissions > Repository permissions** set **Contents** to **Read and write**. Generate the token and copy it (it starts with `github_pat_`). A classic token with the `repo` scope works as well, but grants far broader access.
+  3. Describe the repository in [`config/system.trig`](https://github.com/AtomGraph/LinkedDataHub/blob/master/config/system.trig) and link the application to it (an example is included in the file):
+     ```turtle
+     <urn:linkeddatahub:apps/end-user>
+     {
+         <urn:linkeddatahub:apps/end-user> lapp:versioningRepository <urn:linkeddatahub:versioning/end-user> .
+     }
+
+     <urn:linkeddatahub:versioning/end-user>
+     {
+         <urn:linkeddatahub:versioning/end-user> a doap:GitRepository ;
+             doap:location <https://github.com/OWNER/REPO> ;
+             lapp:branch "main" ;
+             lapp:pathPrefix "graphs" .
+     }
+     ```
+  4. Put the token into `secrets/credentials.trig` (create the file if it does not exist) as an `a:authToken` of the repository resource:
+     ```turtle
+     @prefix a: <https://w3id.org/atomgraph/core#> .
+
+     <urn:linkeddatahub:versioning/end-user>
+     {
+         <urn:linkeddatahub:versioning/end-user> a:authToken "github_pat_..." .
+     }
+     ```
+  5. Enable the `credentials` secret in `docker-compose.yml` by uncommenting it in the top-level `secrets:` block and in the `linkeddatahub` service's `secrets:` list.
+  6. Restart with `docker-compose up`. The startup log will confirm: `Graph versioning enabled for application <...>`.
+
+  Multiple dataspaces can be versioned into different repositories with different tokens. The token never appears in the environment or the process table — it is merged into the internal context dataset from the Docker secret, the same mechanism used for SPARQL service credentials.
+
   ### Secrets
 
   Secrets used in `docker-compose.yml`:
@@ -181,6 +224,8 @@ _:warning: Do not use blank nodes to identify applications or services. We recom
     <dd>Login with Google authentication is enabled when this value is provided</dd>
     <dt><code>google_client_secret</code></dt>
     <dd>Google's OAuth client secret</dd>
+    <dt><code>credentials</code></dt>
+    <dd>TriG dataset (<code>secrets/credentials.trig</code>) with service credentials such as SPARQL auth and <a href="#graph-versioning">graph versioning</a> tokens, merged into the system dataset at startup</dd>
   </dl>
 
   ### Environment

--- a/config/system.trig
+++ b/config/system.trig
@@ -3,6 +3,7 @@
 @prefix ldt:	<https://www.w3.org/ns/ldt#> .
 @prefix sd:	    <http://www.w3.org/ns/sparql-service-description#> .
 @prefix dct:	<http://purl.org/dc/terms/> .
+@prefix doap:	<http://usefulinc.com/ns/doap#> .
 
 ### internal deployment wiring - not for public sharing ###
 ### maps apps to their backend SPARQL services, and assigns admin/end-user roles ###
@@ -33,7 +34,22 @@
 {
     <urn:linkeddatahub:apps/end-user> a lapp:EndUserApplication ;
         ldt:service <urn:linkeddatahub:services/end-user> .
+
+    # uncomment to enable GitHub-backed graph versioning for this dataspace:
+    # <urn:linkeddatahub:apps/end-user> lapp:versioningRepository <urn:linkeddatahub:versioning/end-user> .
 }
+
+# root end-user - versioning repository (GitHub-backed graph versioning)
+# the access token goes into secrets/credentials.trig as:
+#     <urn:linkeddatahub:versioning/end-user> { <urn:linkeddatahub:versioning/end-user> a:authToken "github_pat_..." . }
+
+# <urn:linkeddatahub:versioning/end-user>
+# {
+#     <urn:linkeddatahub:versioning/end-user> a doap:GitRepository ;
+#         doap:location <https://github.com/OWNER/REPO> ;
+#         lapp:branch "main" ;
+#         lapp:pathPrefix "graphs" .
+# }
 
 # root end-user - service description
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -216,13 +216,13 @@ configs:
                   add_header Access-Control-Allow-Origin "*" always;
                   add_header Access-Control-Allow-Methods "GET, POST, PUT, DELETE, PATCH, HEAD, OPTIONS" always;
                   add_header Access-Control-Allow-Headers "Accept, Content-Type, Authorization" always;
-                  add_header Access-Control-Expose-Headers "Link, Content-Location, Location" always;
+                  add_header Access-Control-Expose-Headers "Link, Content-Location, Location, Memento-Datetime" always;
 
                   if ($$request_method = OPTIONS) {
                       add_header Access-Control-Allow-Origin "*";
                       add_header Access-Control-Allow-Methods "GET, POST, PUT, DELETE, PATCH, HEAD, OPTIONS";
                       add_header Access-Control-Allow-Headers "Accept, Content-Type, Authorization";
-                      add_header Access-Control-Expose-Headers "Link, Content-Location, Location";
+                      add_header Access-Control-Expose-Headers "Link, Content-Location, Location, Memento-Datetime";
                       add_header Access-Control-Max-Age "1728000";
                       return 204;
                   }
@@ -288,13 +288,13 @@ configs:
                   add_header Access-Control-Allow-Origin "*" always;
                   add_header Access-Control-Allow-Methods "GET, POST, PUT, DELETE, PATCH, HEAD, OPTIONS" always;
                   add_header Access-Control-Allow-Headers "Accept, Content-Type, Authorization" always;
-                  add_header Access-Control-Expose-Headers "Link, Content-Location, Location" always;
+                  add_header Access-Control-Expose-Headers "Link, Content-Location, Location, Memento-Datetime" always;
 
                   if ($$request_method = OPTIONS) {
                       add_header Access-Control-Allow-Origin "*";
                       add_header Access-Control-Allow-Methods "GET, POST, PUT, DELETE, PATCH, HEAD, OPTIONS";
                       add_header Access-Control-Allow-Headers "Accept, Content-Type, Authorization";
-                      add_header Access-Control-Expose-Headers "Link, Content-Location, Location";
+                      add_header Access-Control-Expose-Headers "Link, Content-Location, Location, Memento-Datetime";
                       add_header Access-Control-Max-Age "1728000";
                       return 204;
                   }

--- a/http-tests/run.sh
+++ b/http-tests/run.sh
@@ -266,6 +266,8 @@ run_tests "proxy" $(find ./proxy/ -type f -name '*.sh')
 (( error_count += $? ))
 run_tests "sparql-protocol" $(find ./sparql-protocol/ -type f -name '*.sh')
 (( error_count += $? ))
+run_tests "versioning" $(find ./versioning/ -type f -name '*.sh')
+(( error_count += $? ))
 
 end_time=$(date +%s)
 runtime=$((end_time-start_time))

--- a/http-tests/versioning/DELETE-removes-file.sh
+++ b/http-tests/versioning/DELETE-removes-file.sh
@@ -1,0 +1,63 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# requires a dataspace configured with lapp:versioningRepository (branch "main", path prefix "graphs")
+# pointing at $VERSIONING_TEST_REPO ("owner/repo"), with the token in secrets/credentials.trig
+
+if [ -z "${VERSIONING_TEST_REPO:-}" ] || [ -z "${GITHUB_TOKEN:-}" ] || ! command -v gh > /dev/null; then
+    echo "SKIPPED: VERSIONING_TEST_REPO/GITHUB_TOKEN not set or gh CLI not available"
+    exit 0
+fi
+
+initialize_dataset "$END_USER_BASE_URL" "$TMP_END_USER_DATASET" "$END_USER_ENDPOINT_URL"
+initialize_dataset "$ADMIN_BASE_URL" "$TMP_ADMIN_DATASET" "$ADMIN_ENDPOINT_URL"
+purge_cache "$END_USER_VARNISH_SERVICE"
+purge_cache "$ADMIN_VARNISH_SERVICE"
+purge_cache "$FRONTEND_VARNISH_SERVICE"
+
+# add agent to the writers group
+
+add-agent-to-group.sh \
+  -f "$OWNER_CERT_FILE" \
+  -p "$OWNER_CERT_PWD" \
+  --agent "$AGENT_URI" \
+  "${ADMIN_BASE_URL}acl/groups/writers/"
+
+slug=$(uuidgen | tr '[:upper:]' '[:lower:]')
+doc_url="${END_USER_BASE_URL}${slug}/"
+path="graphs/${slug}.nt"
+
+# create a document and wait for its file to appear
+
+echo "<${doc_url}> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://www.w3.org/ns/ldt/document-hierarchy#Item> .
+<${doc_url}> <http://purl.org/dc/terms/title> \"To be deleted\" ." | \
+  put.sh \
+    -f "$AGENT_CERT_FILE" \
+    -p "$AGENT_CERT_PWD" \
+    -t "application/n-triples" \
+    "$doc_url"
+
+for i in $(seq 1 30); do
+    if gh api "repos/${VERSIONING_TEST_REPO}/contents/${path}?ref=main" > /dev/null 2>&1; then
+        break
+    fi
+    sleep 1
+done
+gh api "repos/${VERSIONING_TEST_REPO}/contents/${path}?ref=main" > /dev/null
+
+# delete the document and check that the file disappears
+
+delete.sh \
+  -f "$AGENT_CERT_FILE" \
+  -p "$AGENT_CERT_PWD" \
+  "$doc_url"
+
+for i in $(seq 1 30); do
+    if ! gh api "repos/${VERSIONING_TEST_REPO}/contents/${path}?ref=main" > /dev/null 2>&1; then
+        exit 0
+    fi
+    sleep 1
+done
+
+echo "DEBUG: file '${path}' still present in ${VERSIONING_TEST_REPO} after document deletion"
+exit 1

--- a/http-tests/versioning/GET-timemap.sh
+++ b/http-tests/versioning/GET-timemap.sh
@@ -1,0 +1,80 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# requires a dataspace configured with lapp:versioningRepository (branch "main", path prefix "graphs")
+# pointing at $VERSIONING_TEST_REPO ("owner/repo"), with the token in secrets/credentials.trig
+
+if [ -z "${VERSIONING_TEST_REPO:-}" ] || [ -z "${GITHUB_TOKEN:-}" ] || ! command -v gh > /dev/null; then
+    echo "SKIPPED: VERSIONING_TEST_REPO/GITHUB_TOKEN not set or gh CLI not available"
+    exit 0
+fi
+
+initialize_dataset "$END_USER_BASE_URL" "$TMP_END_USER_DATASET" "$END_USER_ENDPOINT_URL"
+initialize_dataset "$ADMIN_BASE_URL" "$TMP_ADMIN_DATASET" "$ADMIN_ENDPOINT_URL"
+purge_cache "$END_USER_VARNISH_SERVICE"
+purge_cache "$ADMIN_VARNISH_SERVICE"
+purge_cache "$FRONTEND_VARNISH_SERVICE"
+
+# add agent to the writers group
+
+add-agent-to-group.sh \
+  -f "$OWNER_CERT_FILE" \
+  -p "$OWNER_CERT_PWD" \
+  --agent "$AGENT_URI" \
+  "${ADMIN_BASE_URL}acl/groups/writers/"
+
+slug=$(uuidgen | tr '[:upper:]' '[:lower:]')
+doc_url="${END_USER_BASE_URL}${slug}/"
+path="graphs/${slug}.nt"
+
+# create a document and wait for its versioning commit
+
+echo "<${doc_url}> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://www.w3.org/ns/ldt/document-hierarchy#Item> .
+<${doc_url}> <http://purl.org/dc/terms/title> \"TimeMap test\" ." | \
+  put.sh \
+    -f "$AGENT_CERT_FILE" \
+    -p "$AGENT_CERT_PWD" \
+    -t "application/n-triples" \
+    "$doc_url"
+
+for i in $(seq 1 30); do
+    if gh api "repos/${VERSIONING_TEST_REPO}/contents/${path}?ref=main" > /dev/null 2>&1; then
+        break
+    fi
+    sleep 1
+done
+gh api "repos/${VERSIONING_TEST_REPO}/contents/${path}?ref=main" > /dev/null
+
+# check that the document advertises its TimeMap via the Link header
+
+response_headers=$(
+get.sh \
+  -f "$AGENT_CERT_FILE" \
+  -p "$AGENT_CERT_PWD" \
+  --accept 'application/n-triples' \
+  --head \
+  "$doc_url" \
+| tr -d '\r')
+
+echo "DEBUG: Response headers:"
+echo "$response_headers"
+
+echo "$response_headers" | grep -q "mementoweb.org/ns#timemap"
+
+# retrieve the TimeMap and check the memento entries
+
+timemap=$(
+get.sh \
+  -f "$AGENT_CERT_FILE" \
+  -p "$AGENT_CERT_PWD" \
+  --accept 'application/n-triples' \
+  "${doc_url}?timemap")
+
+echo "DEBUG: TimeMap:"
+echo "$timemap"
+
+echo "$timemap" | grep -q "mementoweb.org/ns#TimeMap"
+echo "$timemap" | grep -q "mementoweb.org/ns#Memento"
+echo "$timemap" | grep -q "${doc_url}?version="
+echo "$timemap" | grep -q "mementoweb.org/ns#mementoDatetime"
+echo "$timemap" | grep -q "$AGENT_URI"

--- a/http-tests/versioning/GET-version.sh
+++ b/http-tests/versioning/GET-version.sh
@@ -101,10 +101,17 @@ echo "$response_headers"
 echo "$response_headers" | grep -qi '^Memento-Datetime:'
 echo "$response_headers" | grep -qi '^Cache-Control:.*immutable'
 
-# a historical version is read-only: no write modes advertised, writes rejected with 405
+# a historical version is read-only: acl:Read advertised but no write modes, writes rejected with 405
+
+echo "$response_headers" | grep -q 'acl#Read'
 
 if echo "$response_headers" | grep -q 'acl#Write'; then
     echo "DEBUG: version response advertises acl:Write"
+    exit 1
+fi
+
+if echo "$response_headers" | grep -q 'acl#Append'; then
+    echo "DEBUG: version response advertises acl:Append"
     exit 1
 fi
 

--- a/http-tests/versioning/GET-version.sh
+++ b/http-tests/versioning/GET-version.sh
@@ -100,3 +100,20 @@ echo "$response_headers"
 
 echo "$response_headers" | grep -qi '^Memento-Datetime:'
 echo "$response_headers" | grep -qi '^Cache-Control:.*immutable'
+
+# a historical version is read-only: no write modes advertised, writes rejected with 405
+
+if echo "$response_headers" | grep -q 'acl#Write'; then
+    echo "DEBUG: version response advertises acl:Write"
+    exit 1
+fi
+
+(
+curl -k -w "%{http_code}\n" -o /dev/null -s \
+  -E "$AGENT_CERT_FILE":"$AGENT_CERT_PWD" \
+  -X PUT \
+  -H "Content-Type: application/n-triples" \
+  --data-binary "<${doc_url}> <http://purl.org/dc/terms/title> \"Overwrite attempt\" ." \
+  "${doc_url}?version=${sha1}"
+) \
+| grep -q '405'

--- a/http-tests/versioning/GET-version.sh
+++ b/http-tests/versioning/GET-version.sh
@@ -1,0 +1,102 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# requires a dataspace configured with lapp:versioningRepository (branch "main", path prefix "graphs")
+# pointing at $VERSIONING_TEST_REPO ("owner/repo"), with the token in secrets/credentials.trig
+
+if [ -z "${VERSIONING_TEST_REPO:-}" ] || [ -z "${GITHUB_TOKEN:-}" ] || ! command -v gh > /dev/null; then
+    echo "SKIPPED: VERSIONING_TEST_REPO/GITHUB_TOKEN not set or gh CLI not available"
+    exit 0
+fi
+
+initialize_dataset "$END_USER_BASE_URL" "$TMP_END_USER_DATASET" "$END_USER_ENDPOINT_URL"
+initialize_dataset "$ADMIN_BASE_URL" "$TMP_ADMIN_DATASET" "$ADMIN_ENDPOINT_URL"
+purge_cache "$END_USER_VARNISH_SERVICE"
+purge_cache "$ADMIN_VARNISH_SERVICE"
+purge_cache "$FRONTEND_VARNISH_SERVICE"
+
+# add agent to the writers group
+
+add-agent-to-group.sh \
+  -f "$OWNER_CERT_FILE" \
+  -p "$OWNER_CERT_PWD" \
+  --agent "$AGENT_URI" \
+  "${ADMIN_BASE_URL}acl/groups/writers/"
+
+slug=$(uuidgen | tr '[:upper:]' '[:lower:]')
+doc_url="${END_USER_BASE_URL}${slug}/"
+path="graphs/${slug}.nt"
+
+put_document()
+{
+    echo "<${doc_url}> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://www.w3.org/ns/ldt/document-hierarchy#Item> .
+<${doc_url}> <http://purl.org/dc/terms/title> \"${1}\" ." | \
+      put.sh \
+        -f "$AGENT_CERT_FILE" \
+        -p "$AGENT_CERT_PWD" \
+        -t "application/n-triples" \
+        "$doc_url"
+}
+
+head_sha()
+{
+    gh api "repos/${VERSIONING_TEST_REPO}/commits?path=${path}&per_page=1" --jq '.[0].sha' 2> /dev/null || true
+}
+
+# create the first version and wait for its commit
+
+put_document "First version"
+
+for i in $(seq 1 30); do
+    sha1=$(head_sha)
+    if [ -n "$sha1" ]; then break; fi
+    sleep 1
+done
+[ -n "$sha1" ]
+
+# update the document and wait for the second commit
+
+put_document "Second version"
+
+for i in $(seq 1 30); do
+    sha2=$(head_sha)
+    if [ -n "$sha2" ] && [ "$sha2" != "$sha1" ]; then break; fi
+    sleep 1
+done
+[ "$sha2" != "$sha1" ]
+
+# retrieve the first version and check its content
+
+response_body=$(
+get.sh \
+  -f "$AGENT_CERT_FILE" \
+  -p "$AGENT_CERT_PWD" \
+  --accept 'application/n-triples' \
+  "${doc_url}?version=${sha1}")
+
+echo "DEBUG: Response body:"
+echo "$response_body"
+
+echo "$response_body" | grep -q "First version"
+
+if echo "$response_body" | grep -q "Second version"; then
+    echo "DEBUG: historical version response contains the updated title"
+    exit 1
+fi
+
+# check the Memento-Datetime and immutable caching headers
+
+response_headers=$(
+get.sh \
+  -f "$AGENT_CERT_FILE" \
+  -p "$AGENT_CERT_PWD" \
+  --accept 'application/n-triples' \
+  --head \
+  "${doc_url}?version=${sha1}" \
+| tr -d '\r')
+
+echo "DEBUG: Response headers:"
+echo "$response_headers"
+
+echo "$response_headers" | grep -qi '^Memento-Datetime:'
+echo "$response_headers" | grep -qi '^Cache-Control:.*immutable'

--- a/http-tests/versioning/PUT-creates-commit.sh
+++ b/http-tests/versioning/PUT-creates-commit.sh
@@ -1,0 +1,56 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# requires a dataspace configured with lapp:versioningRepository (branch "main", path prefix "graphs")
+# pointing at $VERSIONING_TEST_REPO ("owner/repo"), with the token in secrets/credentials.trig
+
+if [ -z "${VERSIONING_TEST_REPO:-}" ] || [ -z "${GITHUB_TOKEN:-}" ] || ! command -v gh > /dev/null; then
+    echo "SKIPPED: VERSIONING_TEST_REPO/GITHUB_TOKEN not set or gh CLI not available"
+    exit 0
+fi
+
+initialize_dataset "$END_USER_BASE_URL" "$TMP_END_USER_DATASET" "$END_USER_ENDPOINT_URL"
+initialize_dataset "$ADMIN_BASE_URL" "$TMP_ADMIN_DATASET" "$ADMIN_ENDPOINT_URL"
+purge_cache "$END_USER_VARNISH_SERVICE"
+purge_cache "$ADMIN_VARNISH_SERVICE"
+purge_cache "$FRONTEND_VARNISH_SERVICE"
+
+# add agent to the writers group
+
+add-agent-to-group.sh \
+  -f "$OWNER_CERT_FILE" \
+  -p "$OWNER_CERT_PWD" \
+  --agent "$AGENT_URI" \
+  "${ADMIN_BASE_URL}acl/groups/writers/"
+
+# create a document
+
+slug=$(uuidgen | tr '[:upper:]' '[:lower:]')
+doc_url="${END_USER_BASE_URL}${slug}/"
+
+echo "<${doc_url}> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://www.w3.org/ns/ldt/document-hierarchy#Item> .
+<${doc_url}> <http://purl.org/dc/terms/title> \"Versioned document\" ." | \
+  put.sh \
+    -f "$AGENT_CERT_FILE" \
+    -p "$AGENT_CERT_PWD" \
+    -t "application/n-triples" \
+    "$doc_url"
+
+# wait for the async versioning commit to appear in the repository
+
+path="graphs/${slug}.nt"
+
+for i in $(seq 1 30); do
+    if gh api "repos/${VERSIONING_TEST_REPO}/contents/${path}?ref=main" > /dev/null 2>&1; then
+        break
+    fi
+    sleep 1
+done
+gh api "repos/${VERSIONING_TEST_REPO}/contents/${path}?ref=main" > /dev/null
+
+# check that the commit author is the agent's WebID
+
+author=$(gh api "repos/${VERSIONING_TEST_REPO}/commits?path=${path}&per_page=1" --jq '.[0].commit.author.name')
+echo "DEBUG: Expected author: $AGENT_URI"
+echo "DEBUG: Got author: $author"
+[ "$author" = "$AGENT_URI" ]

--- a/platform/entrypoint.sh
+++ b/platform/entrypoint.sh
@@ -694,7 +694,10 @@ CREDENTIALS_DATASET=/run/secrets/credentials
 
 if [ -f "$CREDENTIALS_DATASET" ]; then
     printf "\n### Loading credentials dataset from: %s\n" "$CREDENTIALS_DATASET"
-    trig --base="$BASE_URI" "$CONTEXT_DATASET" "$SERVICES_DATASET" "$CREDENTIALS_DATASET" > "$based_context_dataset"
+    # the secret mounts without a .trig extension, which riot needs to pick the parser - parse a suffixed copy
+    CREDENTIALS_DATASET_TRIG="$(mktemp).trig"
+    cat "$CREDENTIALS_DATASET" > "$CREDENTIALS_DATASET_TRIG"
+    trig --base="$BASE_URI" "$CONTEXT_DATASET" "$SERVICES_DATASET" "$CREDENTIALS_DATASET_TRIG" > "$based_context_dataset"
 else
     trig --base="$BASE_URI" "$CONTEXT_DATASET" "$SERVICES_DATASET" > "$based_context_dataset"
 fi

--- a/src/main/java/com/atomgraph/linkeddatahub/Application.java
+++ b/src/main/java/com/atomgraph/linkeddatahub/Application.java
@@ -105,6 +105,7 @@ import com.atomgraph.linkeddatahub.server.filter.request.ContentLengthLimitFilte
 import com.atomgraph.linkeddatahub.server.filter.request.auth.ProxiedWebIDFilter;
 import com.atomgraph.linkeddatahub.server.filter.response.ResponseHeadersFilter;
 import com.atomgraph.linkeddatahub.server.filter.response.CacheInvalidationFilter;
+import com.atomgraph.linkeddatahub.server.filter.response.VersioningFilter;
 import com.atomgraph.linkeddatahub.server.filter.response.XsltExecutableFilter;
 import com.atomgraph.linkeddatahub.server.interceptor.RDFPostMediaTypeInterceptor;
 import com.atomgraph.linkeddatahub.server.mapper.auth.oauth2.TokenExpiredExceptionMapper;
@@ -269,7 +270,7 @@ public class Application extends ResourceConfig
     private final SameSiteSourceResolver resolver;
     private final Map<String, OntologyRepository> endUserRepositories;
     private final MediaTypes mediaTypes;
-    private final Client client, externalClient, importClient, noCertClient;
+    private final Client client, externalClient, importClient, noCertClient, verifiedClient;
     private final Query documentTypeQuery, documentOwnerQuery, aclQuery, ownerAclQuery, webIDQuery, agentQuery, userAccountQuery, ontologyQuery; // no relative URIs
     private final Integer maxGetRequestSize;
     private final Processor xsltProc = new Processor(false);
@@ -305,6 +306,7 @@ public class Application extends ResourceConfig
     private final URI backendProxyAdmin;
     private final URI backendProxyEndUser;
     private Map<String, com.atomgraph.linkeddatahub.model.ServiceContext> serviceContextMap;
+    private final com.atomgraph.linkeddatahub.server.util.GraphVersioningService graphVersioningService;
 
     /**
      * Constructs system application and configures it using sevlet config.
@@ -701,7 +703,8 @@ public class Application extends ResourceConfig
             externalClient = getClient(keyStore, clientKeyStorePassword, trustStore, maxConnPerRoute, maxTotalConn, null, false, connectionRequestTimeout, socketTimeout, connectTimeout, connectionTimeToLive, validateAfterInactivity);
             importClient = getClient(keyStore, clientKeyStorePassword, trustStore, maxConnPerRoute, maxTotalConn, maxRequestRetries, true, connectionRequestTimeout, socketTimeout, connectTimeout, connectionTimeToLive, validateAfterInactivity);
             noCertClient = getNoCertClient(trustStore, maxConnPerRoute, maxTotalConn, maxRequestRetries, connectionRequestTimeout, socketTimeout, connectTimeout, connectionTimeToLive, validateAfterInactivity);
-            
+            verifiedClient = getVerifiedClient(maxConnPerRoute, maxTotalConn, maxRequestRetries, connectionRequestTimeout, socketTimeout, connectTimeout, connectionTimeToLive, validateAfterInactivity);
+
             if (maxContentLength != null)
             {
                 client.register(new ContentLengthLimitFilter(maxContentLength));
@@ -783,6 +786,9 @@ public class Application extends ResourceConfig
             {
                 serviceIt.close();
             }
+
+            graphVersioningService = new com.atomgraph.linkeddatahub.server.util.GraphVersioningService(ctxUnion, verifiedClient);
+            servletConfig.getServletContext().setAttribute(com.atomgraph.linkeddatahub.server.util.GraphVersioningService.class.getName(), graphVersioningService); // used in GraphVersioningListener to shut down its executor
 
             endUserRepositories = new ConcurrentHashMap<>();
             // global graph repository: bundled vocabularies/ontologies mapped from the prefix-mapping config
@@ -1100,6 +1106,7 @@ public class Application extends ResourceConfig
         register(new ResponseHeadersFilter());
         register(new XsltExecutableFilter());
         if (isInvalidateCache()) register(new CacheInvalidationFilter());
+        register(new VersioningFilter());
 //        register(new ProvenanceFilter());
     }
     
@@ -1727,11 +1734,113 @@ public class Application extends ResourceConfig
             throw new IllegalStateException(ex);
         }
     }
-    
+
+    /**
+     * Builds an HTTP client with standard TLS server verification (JVM default truststore and hostname verification).
+     * The other client factories disable hostname verification against a truststore that includes public CAs,
+     * which is unsafe for public-web API hosts — use this client for those.
+     *
+     * @param maxConnPerRoute max connections per route
+     * @param maxTotalConn max total connections
+     * @param maxRequestRetries maximum number of times that the HTTP client will retry a request
+     * @param connectionRequestTimeout timeout in milliseconds to wait for a connection lease from the pool (null to leave unset)
+     * @param socketTimeout socket (read) timeout in milliseconds (null to leave unset)
+     * @param connectTimeout connection (connect) timeout in milliseconds (null to leave unset)
+     * @param connectionTimeToLive time-to-live in milliseconds after which pooled connections are discarded (null to leave unset)
+     * @param validateAfterInactivity period of inactivity in milliseconds after which a pooled connection is revalidated before reuse (null to leave unset)
+     * @return client instance
+     */
+    public static Client getVerifiedClient(Integer maxConnPerRoute, Integer maxTotalConn, Integer maxRequestRetries, Integer connectionRequestTimeout, Integer socketTimeout, Integer connectTimeout, Long connectionTimeToLive, Integer validateAfterInactivity)
+    {
+        try
+        {
+            SSLContext ctx = SSLContext.getDefault();
+
+            Registry<ConnectionSocketFactory> socketFactoryRegistry = RegistryBuilder.<ConnectionSocketFactory>create().
+                register("https", new SSLConnectionSocketFactory(ctx, SSLConnectionSocketFactory.getDefaultHostnameVerifier())).
+                register("http", new PlainConnectionSocketFactory()).
+                build();
+
+            PoolingHttpClientConnectionManager conman = new PoolingHttpClientConnectionManager(socketFactoryRegistry, null, null, null, connectionTimeToLive != null ? connectionTimeToLive : -1L, TimeUnit.MILLISECONDS)
+            {
+
+                // https://github.com/eclipse-ee4j/jersey/issues/4449
+
+                @Override
+                public void close()
+                {
+                    super.shutdown();
+                }
+
+                @Override
+                public void shutdown()
+                {
+                    // Disable shutdown of the pool. This will be done later, when this factory is closed
+                    // This is a workaround for finalize method on jerseys ClientRuntime which
+                    // closes the client and shuts down the connection pool when it is garbage collected
+                };
+
+                // https://github.com/eclipse-ee4j/jersey/issues/2855
+
+                @Override
+                public void releaseConnection(final HttpClientConnection managedConn, final Object state, final long keepalive, final TimeUnit timeUnit)
+                {
+                    // set state to null to allow reuse of connections
+                    super.releaseConnection(managedConn, null, keepalive, timeUnit);
+                }
+
+            };
+            if (maxConnPerRoute != null) conman.setDefaultMaxPerRoute(maxConnPerRoute);
+            if (maxTotalConn != null) conman.setMaxTotal(maxTotalConn);
+            if (validateAfterInactivity != null) conman.setValidateAfterInactivity(validateAfterInactivity);
+
+            ClientConfig config = new ClientConfig();
+            config.connectorProvider(new ApacheConnectorProvider());
+            config.property(ClientProperties.FOLLOW_REDIRECTS, true);
+            config.property(ClientProperties.REQUEST_ENTITY_PROCESSING, RequestEntityProcessing.BUFFERED); // https://stackoverflow.com/questions/42139436/jersey-client-throws-cannot-retry-request-with-a-non-repeatable-request-entity
+            config.property(ApacheClientProperties.CONNECTION_MANAGER, conman);
+            RequestConfig.Builder requestConfig = RequestConfig.custom();
+            if (connectionRequestTimeout != null) requestConfig.setConnectionRequestTimeout(connectionRequestTimeout);
+            if (socketTimeout != null) requestConfig.setSocketTimeout(socketTimeout);
+            if (connectTimeout != null) requestConfig.setConnectTimeout(connectTimeout);
+            config.property(ApacheClientProperties.REQUEST_CONFIG, requestConfig.build());
+
+            if (maxRequestRetries != null)
+                config.property(ApacheClientProperties.RETRY_HANDLER, (HttpRequestRetryHandler) (IOException ex, int executionCount, HttpContext context) ->
+                {
+                    // Extract the HTTP host from the context
+                    HttpHost targetHost = (HttpHost)context.getAttribute(HttpCoreContext.HTTP_TARGET_HOST);
+                    String serverName = targetHost != null ? targetHost.getHostName() : "Unknown";
+
+                    if (executionCount > maxRequestRetries)
+                    {
+                        if (log.isWarnEnabled()) log.warn("Maximum tries reached for client HTTP pool to server '{}'", serverName);
+                        return false;
+                    }
+                    if (ex instanceof org.apache.http.NoHttpResponseException)
+                    {
+                        if (log.isWarnEnabled()) log.warn("No response from server '{}' on {} call", serverName, executionCount);
+                        return true;
+                    }
+                    return false;
+                });
+
+            return ClientBuilder.newBuilder().
+                withConfig(config).
+                sslContext(ctx).
+                build();
+        }
+        catch (NoSuchAlgorithmException ex)
+        {
+            if ( log.isErrorEnabled()) log.error("No such algorithm: {}", ex);
+            throw new IllegalStateException(ex);
+        }
+    }
+
     /**
      * Returns servlet configuration.
      * Context parameters can be accessed through it.
-     * 
+     *
      * @return servlet config object
      */
     public ServletConfig getServletConfig()
@@ -2249,7 +2358,27 @@ public class Application extends ResourceConfig
     {
         return noCertClient;
     }
-    
+
+    /**
+     * HTTP client instance with standard TLS server verification, for public-web API hosts.
+     *
+     * @return client instance
+     */
+    public Client getVerifiedClient()
+    {
+        return verifiedClient;
+    }
+
+    /**
+     * Service mirroring named graphs of versioning-enabled applications into GitHub repositories.
+     *
+     * @return versioning service
+     */
+    public com.atomgraph.linkeddatahub.server.util.GraphVersioningService getGraphVersioningService()
+    {
+        return graphVersioningService;
+    }
+
     /**
      * The email address from which notification emails are sent.
      * 

--- a/src/main/java/com/atomgraph/linkeddatahub/client/GitHubClient.java
+++ b/src/main/java/com/atomgraph/linkeddatahub/client/GitHubClient.java
@@ -17,8 +17,10 @@
 package com.atomgraph.linkeddatahub.client;
 
 import jakarta.json.Json;
+import jakarta.json.JsonArray;
 import jakarta.json.JsonObject;
 import jakarta.json.JsonObjectBuilder;
+import jakarta.json.JsonValue;
 import jakarta.ws.rs.client.Client;
 import jakarta.ws.rs.client.Entity;
 import jakarta.ws.rs.client.Invocation;
@@ -28,7 +30,9 @@ import jakarta.ws.rs.core.MediaType;
 import jakarta.ws.rs.core.Response;
 import java.net.URI;
 import java.time.Instant;
+import java.util.ArrayList;
 import java.util.Base64;
+import java.util.List;
 import java.util.Optional;
 import java.util.function.Supplier;
 import org.glassfish.jersey.client.ClientProperties;
@@ -172,6 +176,39 @@ public class GitHubClient
             if (response.getStatus() == Response.Status.NOT_FOUND.getStatusCode()) return Optional.empty();
 
             throw new RuntimeException("GitHub retrieval of '" + path + "' at '" + ref + "' from " + owner + "/" + repo + " failed with status " + response.getStatus());
+        }
+    }
+
+    /** A commit in a file's history: SHA, datetime, author name */
+    public record CommitInfo(String sha, Instant datetime, String authorName) { }
+
+    /**
+     * Lists commits that touched a file on the branch, most recent first.
+     *
+     * @param path file path within the repository
+     * @return commit list (up to 100), empty if the file has no history
+     */
+    public List<CommitInfo> listCommits(String path)
+    {
+        try (Response response = invoke(() -> endpoint.path("repos/{owner}/{repo}/commits").
+                queryParam("path", path).
+                queryParam("sha", branch).
+                queryParam("per_page", 100).
+                resolveTemplate("owner", owner).resolveTemplate("repo", repo).
+                request(GITHUB_JSON).
+                header(HttpHeaders.AUTHORIZATION, authorization).
+                buildGet()))
+        {
+            if (response.getStatus() != Response.Status.OK.getStatusCode()) return List.of();
+
+            List<CommitInfo> commits = new ArrayList<>();
+            for (JsonValue value : response.readEntity(JsonArray.class))
+            {
+                JsonObject commit = value.asJsonObject();
+                JsonObject author = commit.getJsonObject("commit").getJsonObject("author");
+                commits.add(new CommitInfo(commit.getString("sha"), Instant.parse(author.getString("date")), author.getString("name")));
+            }
+            return commits;
         }
     }
 

--- a/src/main/java/com/atomgraph/linkeddatahub/client/GitHubClient.java
+++ b/src/main/java/com/atomgraph/linkeddatahub/client/GitHubClient.java
@@ -1,0 +1,282 @@
+/**
+ *  Copyright 2026 Martynas Jusevičius <martynas@atomgraph.com>
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ */
+package com.atomgraph.linkeddatahub.client;
+
+import jakarta.json.Json;
+import jakarta.json.JsonObject;
+import jakarta.json.JsonObjectBuilder;
+import jakarta.ws.rs.client.Client;
+import jakarta.ws.rs.client.Entity;
+import jakarta.ws.rs.client.Invocation;
+import jakarta.ws.rs.client.WebTarget;
+import jakarta.ws.rs.core.HttpHeaders;
+import jakarta.ws.rs.core.MediaType;
+import jakarta.ws.rs.core.Response;
+import java.net.URI;
+import java.time.Instant;
+import java.util.Base64;
+import java.util.Optional;
+import java.util.function.Supplier;
+import org.glassfish.jersey.client.ClientProperties;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * GitHub REST API client for graph versioning.
+ * Wraps the Contents and Commits endpoints used to mirror named graphs as files in a repository.
+ *
+ * @author Martynas Jusevičius {@literal <martynas@atomgraph.com>}
+ * @see <a href="https://docs.github.com/en/rest/repos/contents">GitHub Contents API</a>
+ */
+public class GitHubClient
+{
+
+    private static final Logger log = LoggerFactory.getLogger(GitHubClient.class);
+
+    /** Default GitHub API base URI */
+    public static final URI API_BASE = URI.create("https://api.github.com");
+    /** GitHub API JSON media type */
+    public static final String GITHUB_JSON = "application/vnd.github+json";
+    /** GitHub API raw content media type */
+    public static final String GITHUB_RAW = "application/vnd.github.raw+json";
+    /** Author email used on commits (the author name carries the agent's WebID) */
+    public static final String AUTHOR_EMAIL = "noreply@linkeddatahub.invalid";
+    /** Maximum retries on rate-limited requests */
+    public static final int MAX_RETRIES = 2;
+
+    private final WebTarget endpoint;
+    private final String authorization;
+    private final String owner, repo, branch;
+
+    /** Result of a file commit: the commit SHA and the file's new blob SHA */
+    public record Commit(String commitSha, String blobSha) { }
+
+    /**
+     * Constructs a client for one repository branch.
+     *
+     * @param client HTTP client (must perform standard TLS server verification)
+     * @param apiBase API base URI (<code>https://api.github.com</code> in production, overridable for tests)
+     * @param token access token
+     * @param owner repository owner
+     * @param repo repository name
+     * @param branch branch name
+     */
+    public GitHubClient(Client client, URI apiBase, String token, String owner, String repo, String branch)
+    {
+        this.endpoint = client.target(apiBase);
+        this.authorization = "Bearer " + token;
+        this.owner = owner;
+        this.repo = repo;
+        this.branch = branch;
+    }
+
+    /**
+     * Creates or updates a file on the branch.
+     * The current blob SHA is fetched first, as the Contents API requires it for updates (optimistic locking).
+     *
+     * @param path file path within the repository
+     * @param content file content
+     * @param message commit message
+     * @param authorName commit author name (the agent's WebID)
+     * @return commit and blob SHAs
+     */
+    public Commit putFile(String path, byte[] content, String message, String authorName)
+    {
+        Optional<String> sha = getFileSha(path);
+
+        JsonObjectBuilder json = Json.createObjectBuilder().
+            add("message", message).
+            add("content", Base64.getEncoder().encodeToString(content)).
+            add("branch", branch).
+            add("author", author(authorName));
+        sha.ifPresent(s -> json.add("sha", s));
+
+        try (Response response = invoke(() -> contents(path).
+                request(GITHUB_JSON).
+                header(HttpHeaders.AUTHORIZATION, authorization).
+                buildPut(Entity.entity(json.build(), MediaType.APPLICATION_JSON_TYPE))))
+        {
+            if (response.getStatus() == Response.Status.OK.getStatusCode() || response.getStatus() == Response.Status.CREATED.getStatusCode())
+            {
+                JsonObject result = response.readEntity(JsonObject.class);
+                return new Commit(result.getJsonObject("commit").getString("sha"), result.getJsonObject("content").getString("sha"));
+            }
+
+            throw new RuntimeException("GitHub commit of '" + path + "' to " + owner + "/" + repo + " failed with status " + response.getStatus());
+        }
+    }
+
+    /**
+     * Deletes a file from the branch. A no-op if the file does not exist.
+     *
+     * @param path file path within the repository
+     * @param message commit message
+     * @param authorName commit author name (the agent's WebID)
+     */
+    public void deleteFile(String path, String message, String authorName)
+    {
+        Optional<String> sha = getFileSha(path);
+        if (sha.isEmpty())
+        {
+            if (log.isDebugEnabled()) log.debug("File '{}' not found in {}/{}, nothing to delete", path, owner, repo);
+            return;
+        }
+
+        JsonObject json = Json.createObjectBuilder().
+            add("message", message).
+            add("sha", sha.get()).
+            add("branch", branch).
+            add("author", author(authorName)).
+            build();
+
+        try (Response response = invoke(() -> contents(path).
+                request(GITHUB_JSON).
+                property(ClientProperties.SUPPRESS_HTTP_COMPLIANCE_VALIDATION, true). // the Contents API requires a body on DELETE
+                header(HttpHeaders.AUTHORIZATION, authorization).
+                build("DELETE", Entity.entity(json, MediaType.APPLICATION_JSON_TYPE))))
+        {
+            if (response.getStatus() != Response.Status.OK.getStatusCode())
+                throw new RuntimeException("GitHub deletion of '" + path + "' from " + owner + "/" + repo + " failed with status " + response.getStatus());
+        }
+    }
+
+    /**
+     * Retrieves raw file content at a given commit.
+     *
+     * @param path file path within the repository
+     * @param ref commit SHA (or any git ref)
+     * @return file content, or empty if not found at that ref
+     */
+    public Optional<byte[]> getFileAtCommit(String path, String ref)
+    {
+        try (Response response = invoke(() -> contents(path).queryParam("ref", ref).
+                request(GITHUB_RAW).
+                header(HttpHeaders.AUTHORIZATION, authorization).
+                buildGet()))
+        {
+            if (response.getStatus() == Response.Status.OK.getStatusCode()) return Optional.of(response.readEntity(byte[].class));
+            if (response.getStatus() == Response.Status.NOT_FOUND.getStatusCode()) return Optional.empty();
+
+            throw new RuntimeException("GitHub retrieval of '" + path + "' at '" + ref + "' from " + owner + "/" + repo + " failed with status " + response.getStatus());
+        }
+    }
+
+    /**
+     * Returns the committer datetime of a commit.
+     *
+     * @param sha commit SHA
+     * @return commit datetime, or empty if the commit is not found
+     */
+    public Optional<Instant> getCommitDate(String sha)
+    {
+        try (Response response = invoke(() -> endpoint.path("repos/{owner}/{repo}/commits/{sha}").
+                resolveTemplate("owner", owner).resolveTemplate("repo", repo).resolveTemplate("sha", sha).
+                request(GITHUB_JSON).
+                header(HttpHeaders.AUTHORIZATION, authorization).
+                buildGet()))
+        {
+            if (response.getStatus() != Response.Status.OK.getStatusCode()) return Optional.empty();
+
+            JsonObject result = response.readEntity(JsonObject.class);
+            String date = result.getJsonObject("commit").getJsonObject("committer").getString("date");
+            return Optional.of(Instant.parse(date));
+        }
+    }
+
+    /**
+     * Returns the current blob SHA of a file on the branch.
+     *
+     * @param path file path within the repository
+     * @return blob SHA, or empty if the file does not exist
+     */
+    public Optional<String> getFileSha(String path)
+    {
+        try (Response response = invoke(() -> contents(path).queryParam("ref", branch).
+                request(GITHUB_JSON).
+                header(HttpHeaders.AUTHORIZATION, authorization).
+                buildGet()))
+        {
+            if (response.getStatus() == Response.Status.OK.getStatusCode()) return Optional.of(response.readEntity(JsonObject.class).getString("sha"));
+
+            return Optional.empty();
+        }
+    }
+
+    private WebTarget contents(String path)
+    {
+        return endpoint.path("repos/{owner}/{repo}/contents/{path}").
+            resolveTemplate("owner", owner).
+            resolveTemplate("repo", repo).
+            resolveTemplate("path", path, false); // do not encode slashes in the path
+    }
+
+    private JsonObject author(String name)
+    {
+        return Json.createObjectBuilder().add("name", name).add("email", AUTHOR_EMAIL).build();
+    }
+
+    /**
+     * Invokes a request, retrying a bounded number of times when GitHub rate-limits it (429, or 403 with <code>Retry-After</code>).
+     */
+    private Response invoke(Supplier<Invocation> invocation)
+    {
+        Response response = invocation.get().invoke();
+
+        for (int retry = 0; retry < MAX_RETRIES && isRateLimited(response); retry++)
+        {
+            long delaySeconds = retryAfter(response);
+            response.close();
+            if (log.isWarnEnabled()) log.warn("GitHub rate limit hit on {}/{}, retrying after {}s", owner, repo, delaySeconds);
+
+            try
+            {
+                Thread.sleep(delaySeconds * 1000);
+            }
+            catch (InterruptedException ex)
+            {
+                Thread.currentThread().interrupt();
+                throw new RuntimeException(ex);
+            }
+
+            response = invocation.get().invoke();
+        }
+
+        return response;
+    }
+
+    private boolean isRateLimited(Response response)
+    {
+        if (response.getStatus() == 429) return true;
+
+        return response.getStatus() == Response.Status.FORBIDDEN.getStatusCode() &&
+            (response.getHeaderString("Retry-After") != null || "0".equals(response.getHeaderString("x-ratelimit-remaining")));
+    }
+
+    private long retryAfter(Response response)
+    {
+        String retryAfter = response.getHeaderString("Retry-After");
+        if (retryAfter != null)
+            try
+            {
+                return Math.min(Long.parseLong(retryAfter), 60);
+            }
+            catch (NumberFormatException ex) { }
+
+        return 5;
+    }
+
+}

--- a/src/main/java/com/atomgraph/linkeddatahub/listener/GraphVersioningListener.java
+++ b/src/main/java/com/atomgraph/linkeddatahub/listener/GraphVersioningListener.java
@@ -1,0 +1,44 @@
+/**
+ *  Copyright 2026 Martynas Jusevičius <martynas@atomgraph.com>
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ */
+package com.atomgraph.linkeddatahub.listener;
+
+import com.atomgraph.linkeddatahub.server.util.GraphVersioningService;
+import jakarta.servlet.ServletContextEvent;
+import jakarta.servlet.ServletContextListener;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Graph versioning listener.
+ * Shuts down the versioning service's background executor.
+ *
+ * @author Martynas Jusevičius {@literal <martynas@atomgraph.com>}
+ */
+public class GraphVersioningListener implements ServletContextListener
+{
+
+    private static final Logger log = LoggerFactory.getLogger(GraphVersioningListener.class);
+
+    @Override
+    public void contextDestroyed(ServletContextEvent sce)
+    {
+        if (log.isDebugEnabled()) log.debug("Shutting down {} thread pool", getClass().getName());
+        GraphVersioningService service = (GraphVersioningService)sce.getServletContext().getAttribute(GraphVersioningService.class.getName());
+        if (service != null) service.shutdown();
+    }
+
+}

--- a/src/main/java/com/atomgraph/linkeddatahub/server/filter/response/ResponseHeadersFilter.java
+++ b/src/main/java/com/atomgraph/linkeddatahub/server/filter/response/ResponseHeadersFilter.java
@@ -24,9 +24,11 @@ import com.atomgraph.linkeddatahub.apps.model.Application;
 import com.atomgraph.linkeddatahub.apps.model.Dataset;
 import com.atomgraph.linkeddatahub.model.auth.Agent;
 import com.atomgraph.linkeddatahub.server.model.impl.Dispatcher;
+import com.atomgraph.linkeddatahub.server.model.impl.DocumentHierarchyGraphStoreImpl;
 import com.atomgraph.linkeddatahub.server.security.AuthorizationContext;
 import com.atomgraph.linkeddatahub.vocabulary.ACL;
 import com.atomgraph.linkeddatahub.vocabulary.LAPP;
+import com.atomgraph.linkeddatahub.vocabulary.MEM;
 import java.io.IOException;
 import java.net.URI;
 import java.util.Optional;
@@ -52,6 +54,7 @@ public class ResponseHeadersFilter implements ContainerResponseFilter
 
     private static final Logger log = LoggerFactory.getLogger(ResponseHeadersFilter.class);
 
+    @Inject com.atomgraph.linkeddatahub.Application system;
     @Inject jakarta.inject.Provider<Optional<Application>> app;
     @Inject jakarta.inject.Provider<Optional<Dataset>> dataset;
     @Inject jakarta.inject.Provider<Optional<AuthorizationContext>> authorizationContext;
@@ -86,6 +89,10 @@ public class ResponseHeadersFilter implements ContainerResponseFilter
             // add Link rel=ldt:ontology, if the ontology URI is specified
             if (application.getOntology() != null)
                 response.getHeaders().add(HttpHeaders.LINK, new Link(URI.create(application.getOntology().getURI()), LDT.ontology.getURI(), null));
+            // add Link rel=mem:timemap, if the document is versioned
+            if (getSystem().getGraphVersioningService().getRepository(application.getURI()).isPresent() &&
+                    request.getUriInfo().getMatchedResources().stream().anyMatch(DocumentHierarchyGraphStoreImpl.class::isInstance))
+                response.getHeaders().add(HttpHeaders.LINK, new Link(URI.create(request.getUriInfo().getAbsolutePath() + "?" + DocumentHierarchyGraphStoreImpl.TIMEMAP_PARAM_NAME), MEM.timemap.getURI(), null));
             // add Link rel=ac:stylesheet, if the stylesheet URI is specified
             if (application.getStylesheet() != null)
                 response.getHeaders().add(HttpHeaders.LINK, new Link(URI.create(application.getStylesheet().getURI()), AC.stylesheet.getURI(), null));
@@ -97,6 +104,16 @@ public class ResponseHeadersFilter implements ContainerResponseFilter
             String linkValue = response.getHeaders().get(HttpHeaders.LINK).toString();
             response.getHeaders().putSingle(HttpHeaders.LINK, linkValue.substring(1, linkValue.length() - 1)); // trim leading and trailing bracket added by toString()
         }
+    }
+
+    /**
+     * Returns the system application.
+     *
+     * @return system application
+     */
+    public com.atomgraph.linkeddatahub.Application getSystem()
+    {
+        return system;
     }
 
     /**

--- a/src/main/java/com/atomgraph/linkeddatahub/server/filter/response/ResponseHeadersFilter.java
+++ b/src/main/java/com/atomgraph/linkeddatahub/server/filter/response/ResponseHeadersFilter.java
@@ -71,8 +71,14 @@ public class ResponseHeadersFilter implements ContainerResponseFilter
             response.getHeaders().add(HttpHeaders.LINK, new Link(URI.create(agent.getURI()), ACL.agent.getURI(), null));
         }
 
+        // historical version and TimeMap views are read-only: advertise acl:Read at most, so the UI disables edit affordances
+        boolean isSnapshotRequest = request.getUriInfo().getQueryParameters().containsKey(DocumentHierarchyGraphStoreImpl.VERSION_PARAM_NAME) ||
+            request.getUriInfo().getQueryParameters().containsKey(DocumentHierarchyGraphStoreImpl.TIMEMAP_PARAM_NAME);
+
         if (getAuthorizationContext().isPresent())
-            getAuthorizationContext().get().getModeURIs().forEach(mode -> response.getHeaders().add(HttpHeaders.LINK, new Link(mode, ACL.mode.getURI(), null)));
+            getAuthorizationContext().get().getModeURIs().stream().
+                filter(mode -> !isSnapshotRequest || mode.toString().equals(ACL.Read.getURI())).
+                forEach(mode -> response.getHeaders().add(HttpHeaders.LINK, new Link(mode, ACL.mode.getURI(), null)));
 
         // for proxy requests the external Link headers are forwarded by ProxyRequestFilter; suppress local-only hypermedia
         boolean isProxyRequest = request.getProperty(AC.uri.getURI()) != null;

--- a/src/main/java/com/atomgraph/linkeddatahub/server/filter/response/VersioningFilter.java
+++ b/src/main/java/com/atomgraph/linkeddatahub/server/filter/response/VersioningFilter.java
@@ -1,0 +1,101 @@
+/**
+ *  Copyright 2026 Martynas Jusevičius <martynas@atomgraph.com>
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ */
+package com.atomgraph.linkeddatahub.server.filter.response;
+
+import com.atomgraph.client.vocabulary.AC;
+import com.atomgraph.linkeddatahub.model.auth.Agent;
+import com.atomgraph.linkeddatahub.server.model.impl.DocumentHierarchyGraphStoreImpl;
+import java.io.IOException;
+import java.net.URI;
+import java.util.Optional;
+import java.util.Set;
+import jakarta.annotation.Priority;
+import jakarta.inject.Inject;
+import jakarta.ws.rs.HttpMethod;
+import jakarta.ws.rs.Priorities;
+import jakarta.ws.rs.container.ContainerRequestContext;
+import jakarta.ws.rs.container.ContainerResponseContext;
+import jakarta.ws.rs.container.ContainerResponseFilter;
+import jakarta.ws.rs.core.Response;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Schedules a versioning commit after each successful document write.
+ * The commit itself runs asynchronously in {@link com.atomgraph.linkeddatahub.server.util.GraphVersioningService}
+ * by reconciling the graph's repository file with its current store state, so this filter never
+ * delays or fails the response.
+ *
+ * @author Martynas Jusevičius {@literal <martynas@atomgraph.com>}
+ */
+@Priority(Priorities.USER + 100)
+public class VersioningFilter implements ContainerResponseFilter
+{
+
+    private static final Logger log = LoggerFactory.getLogger(VersioningFilter.class);
+
+    /** HTTP methods that modify a document graph */
+    public static final Set<String> WRITE_METHODS = Set.of(HttpMethod.POST, HttpMethod.PUT, HttpMethod.PATCH, HttpMethod.DELETE);
+
+    @Inject com.atomgraph.linkeddatahub.Application system;
+    @Inject jakarta.inject.Provider<Optional<com.atomgraph.linkeddatahub.apps.model.Application>> app;
+
+    @Override
+    public void filter(ContainerRequestContext request, ContainerResponseContext response) throws IOException
+    {
+        if (!WRITE_METHODS.contains(request.getMethod())) return;
+        if (response.getStatusInfo().getFamily() != Response.Status.Family.SUCCESSFUL) return; // excludes the PUT 308 redirect and error responses
+        if (request.getProperty(AC.uri.getURI()) != null) return; // proxied request — not a local document write
+
+        Optional<com.atomgraph.linkeddatahub.apps.model.Application> application = getApplication();
+        if (application == null || application.isEmpty()) return;
+
+        // only document graphs are versioned — literal-path resources (SPARQL endpoint, settings, ACL access, sign-up, packages) are not
+        if (request.getUriInfo().getMatchedResources().stream().noneMatch(DocumentHierarchyGraphStoreImpl.class::isInstance)) return;
+
+        String appURI = application.get().getURI();
+        if (getSystem().getGraphVersioningService().getRepository(appURI).isEmpty()) return;
+
+        URI graphURI = request.getUriInfo().getAbsolutePath();
+        String agentWebID = request.getSecurityContext().getUserPrincipal() instanceof Agent agent ? agent.getURI() : "anonymous";
+
+        if (log.isDebugEnabled()) log.debug("Scheduling versioning commit of graph <{}> after {} by <{}>", graphURI, request.getMethod(), agentWebID);
+        getSystem().getGraphVersioningService().commitAsync(getSystem().getServiceContext(application.get().getService()),
+            appURI, application.get().getBaseURI(), graphURI, agentWebID, request.getMethod());
+    }
+
+    /**
+     * Returns the system application.
+     *
+     * @return system application
+     */
+    public com.atomgraph.linkeddatahub.Application getSystem()
+    {
+        return system;
+    }
+
+    /**
+     * Returns the (optional) matched application.
+     *
+     * @return optional application
+     */
+    public Optional<com.atomgraph.linkeddatahub.apps.model.Application> getApplication()
+    {
+        return app.get();
+    }
+
+}

--- a/src/main/java/com/atomgraph/linkeddatahub/server/model/impl/DocumentHierarchyGraphStoreImpl.java
+++ b/src/main/java/com/atomgraph/linkeddatahub/server/model/impl/DocumentHierarchyGraphStoreImpl.java
@@ -47,6 +47,7 @@ import jakarta.inject.Inject;
 import jakarta.ws.rs.BadRequestException;
 import jakarta.ws.rs.Consumes;
 import jakarta.ws.rs.DELETE;
+import jakarta.ws.rs.GET;
 import jakarta.ws.rs.HttpMethod;
 import jakarta.ws.rs.InternalServerErrorException;
 import jakarta.ws.rs.NotFoundException;
@@ -55,7 +56,9 @@ import jakarta.ws.rs.PATCH;
 import jakarta.ws.rs.POST;
 import jakarta.ws.rs.PUT;
 import jakarta.ws.rs.WebApplicationException;
+import jakarta.ws.rs.core.CacheControl;
 import jakarta.ws.rs.core.Context;
+import jakarta.ws.rs.core.EntityTag;
 import jakarta.ws.rs.core.HttpHeaders;
 import jakarta.ws.rs.core.MediaType;
 import jakarta.ws.rs.core.Request;
@@ -74,6 +77,8 @@ import java.io.InputStream;
 import java.nio.channels.Channels;
 import java.nio.channels.FileChannel;
 import java.nio.charset.StandardCharsets;
+import java.time.ZoneId;
+import java.time.format.DateTimeFormatter;
 import java.security.DigestInputStream;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -130,6 +135,11 @@ public class DocumentHierarchyGraphStoreImpl extends com.atomgraph.core.model.im
      * The relative path of the content-addressed file container.
      */
     public static final String UPLOADS_PATH = "uploads";
+
+    /**
+     * Name of the query parameter that selects a historical graph version by commit SHA.
+     */
+    public static final String VERSION_PARAM_NAME = "version";
     
     private final com.atomgraph.linkeddatahub.apps.model.Application application;
     private final OntModel ontology;
@@ -201,7 +211,38 @@ public class DocumentHierarchyGraphStoreImpl extends com.atomgraph.core.model.im
             !secretaryDocURI.equals(uri))
             allowedMethods.add(HttpMethod.DELETE);
     }
-    
+
+    /**
+     * Implements <code>GET</code> method of SPARQL Graph Store Protocol.
+     * With a <code>version</code> query parameter, returns the graph's state at that commit from the
+     * versioning repository instead of the triplestore. Version responses are immutable.
+     *
+     * @return HTTP response
+     */
+    @Override
+    @GET
+    public Response get()
+    {
+        String version = getUriInfo().getQueryParameters().getFirst(VERSION_PARAM_NAME);
+        if (version == null) return super.get();
+
+        com.atomgraph.linkeddatahub.server.util.GraphVersioningService.Version graphVersion = getSystem().getGraphVersioningService().
+            getVersion(getApplication().getURI(), getApplication().getBaseURI(), getURI(), version).
+            orElseThrow(() -> new NotFoundException("Version '" + version + "' of graph <" + getURI() + "> not found"));
+
+        CacheControl cacheControl = new CacheControl();
+        cacheControl.setMaxAge(31536000);
+        cacheControl.getCacheExtension().put("immutable", "");
+
+        Response.ResponseBuilder rb = getResponseBuilder(graphVersion.model(), getURI()).
+            tag(new EntityTag("git-" + version)).
+            cacheControl(cacheControl);
+        if (graphVersion.datetime() != null)
+            rb.header("Memento-Datetime", DateTimeFormatter.RFC_1123_DATE_TIME.format(graphVersion.datetime().atZone(ZoneId.of("GMT"))));
+
+        return rb.build();
+    }
+
     /**
      * Implements <code>POST</code> method of SPARQL Graph Store Protocol.
      * Adds triples to the existing graph, skolemizes blank nodes, updates modification timestamp, and submits any imports.

--- a/src/main/java/com/atomgraph/linkeddatahub/server/model/impl/DocumentHierarchyGraphStoreImpl.java
+++ b/src/main/java/com/atomgraph/linkeddatahub/server/model/impl/DocumentHierarchyGraphStoreImpl.java
@@ -239,6 +239,9 @@ public class DocumentHierarchyGraphStoreImpl extends com.atomgraph.core.model.im
 
         String version = getUriInfo().getQueryParameters().getFirst(VERSION_PARAM_NAME);
         if (version == null) return super.get();
+        // commit SHAs only: movable refs (branches, tags) must not be served with immutable caching,
+        // and the hex-only value doubles as the ETag (the HTML writer per-agent-perturbs ETags as hex numbers)
+        if (!version.matches("[0-9a-f]{4,64}")) throw new NotFoundException("Version '" + version + "' of graph <" + getURI() + "> not found");
 
         com.atomgraph.linkeddatahub.server.util.GraphVersioningService.Version graphVersion = getSystem().getGraphVersioningService().
             getVersion(getApplication().getURI(), getApplication().getBaseURI(), getURI(), version).
@@ -249,7 +252,7 @@ public class DocumentHierarchyGraphStoreImpl extends com.atomgraph.core.model.im
         cacheControl.getCacheExtension().put("immutable", "");
 
         Response.ResponseBuilder rb = getResponseBuilder(graphVersion.model(), getURI()).
-            tag(new EntityTag("git-" + version)).
+            tag(new EntityTag(version)).
             cacheControl(cacheControl);
         if (graphVersion.datetime() != null)
             rb.header("Memento-Datetime", DateTimeFormatter.RFC_1123_DATE_TIME.format(graphVersion.datetime().atZone(ZoneId.of("GMT"))));

--- a/src/main/java/com/atomgraph/linkeddatahub/server/model/impl/DocumentHierarchyGraphStoreImpl.java
+++ b/src/main/java/com/atomgraph/linkeddatahub/server/model/impl/DocumentHierarchyGraphStoreImpl.java
@@ -140,6 +140,11 @@ public class DocumentHierarchyGraphStoreImpl extends com.atomgraph.core.model.im
      * Name of the query parameter that selects a historical graph version by commit SHA.
      */
     public static final String VERSION_PARAM_NAME = "version";
+
+    /**
+     * Name of the query parameter that retrieves the graph's version history as a Memento TimeMap.
+     */
+    public static final String TIMEMAP_PARAM_NAME = "timemap";
     
     private final com.atomgraph.linkeddatahub.apps.model.Application application;
     private final OntModel ontology;
@@ -223,6 +228,15 @@ public class DocumentHierarchyGraphStoreImpl extends com.atomgraph.core.model.im
     @GET
     public Response get()
     {
+        if (getUriInfo().getQueryParameters().containsKey(TIMEMAP_PARAM_NAME))
+        {
+            Model timeMap = getSystem().getGraphVersioningService().
+                getTimeMap(getApplication().getURI(), getApplication().getBaseURI(), getURI()).
+                orElseThrow(() -> new NotFoundException("Document <" + getURI() + "> is not versioned"));
+
+            return getResponseBuilder(timeMap, getURI()).build();
+        }
+
         String version = getUriInfo().getQueryParameters().getFirst(VERSION_PARAM_NAME);
         if (version == null) return super.get();
 

--- a/src/main/java/com/atomgraph/linkeddatahub/server/model/impl/DocumentHierarchyGraphStoreImpl.java
+++ b/src/main/java/com/atomgraph/linkeddatahub/server/model/impl/DocumentHierarchyGraphStoreImpl.java
@@ -50,6 +50,7 @@ import jakarta.ws.rs.DELETE;
 import jakarta.ws.rs.GET;
 import jakarta.ws.rs.HttpMethod;
 import jakarta.ws.rs.InternalServerErrorException;
+import jakarta.ws.rs.NotAllowedException;
 import jakarta.ws.rs.NotFoundException;
 import jakarta.ws.rs.OPTIONS;
 import jakarta.ws.rs.PATCH;
@@ -215,6 +216,19 @@ public class DocumentHierarchyGraphStoreImpl extends com.atomgraph.core.model.im
             !ownerDocURI.equals(uri) &&
             !secretaryDocURI.equals(uri))
             allowedMethods.add(HttpMethod.DELETE);
+
+        // historical version and TimeMap views are read-only
+        if (uriInfo.getQueryParameters().containsKey(VERSION_PARAM_NAME) || uriInfo.getQueryParameters().containsKey(TIMEMAP_PARAM_NAME))
+            allowedMethods.retainAll(Set.of(HttpMethod.GET));
+    }
+
+    /**
+     * Rejects the request if it addresses a historical version or TimeMap view, which are read-only.
+     */
+    private void checkSnapshotReadOnly()
+    {
+        if (getUriInfo().getQueryParameters().containsKey(VERSION_PARAM_NAME) || getUriInfo().getQueryParameters().containsKey(TIMEMAP_PARAM_NAME))
+            throw new NotAllowedException(HttpMethod.GET, new String[]{ HttpMethod.OPTIONS });
     }
 
     /**
@@ -271,6 +285,8 @@ public class DocumentHierarchyGraphStoreImpl extends com.atomgraph.core.model.im
     @POST
     public Response post(Model model)
     {
+        checkSnapshotReadOnly();
+
         if (log.isTraceEnabled()) log.trace("POST Graph Store request with RDF payload: {} payload size(): {}", model, model.size());
 
         final Model existingModel = getSystem().getServiceContext(getService()).getGraphStoreClient().getModel(getURI().toString());
@@ -312,6 +328,8 @@ public class DocumentHierarchyGraphStoreImpl extends com.atomgraph.core.model.im
     // the AuthorizationFilter only allows creating new child URIs for existing containers (i.e. there has to be a .. container already)
     public Response put(Model model)
     {
+        checkSnapshotReadOnly();
+
         if (log.isTraceEnabled()) log.trace("PUT Graph Store request with RDF payload: {} payload size(): {}", model, model.size());
 
         if (!getAllowedMethods().contains(HttpMethod.PUT))
@@ -421,6 +439,8 @@ public class DocumentHierarchyGraphStoreImpl extends com.atomgraph.core.model.im
     @Override
     public Response patch(UpdateRequest updateRequest)
     {
+        checkSnapshotReadOnly();
+
         if (updateRequest == null) throw new BadRequestException("SPARQL update not specified");
         if (log.isDebugEnabled()) log.debug("PATCH request on named graph with URI: {}", getURI());
         if (log.isDebugEnabled()) log.debug("PATCH update string: {}", updateRequest.toString());
@@ -506,6 +526,8 @@ public class DocumentHierarchyGraphStoreImpl extends com.atomgraph.core.model.im
     @Consumes(MediaType.MULTIPART_FORM_DATA)
     public Response postMultipart(FormDataMultiPart multiPart)
     {
+        checkSnapshotReadOnly();
+
         if (log.isDebugEnabled()) log.debug("MultiPart fields: {} body parts: {}", multiPart.getFields(), multiPart.getBodyParts());
 
         try
@@ -548,6 +570,8 @@ public class DocumentHierarchyGraphStoreImpl extends com.atomgraph.core.model.im
     @Consumes(MediaType.MULTIPART_FORM_DATA)
     public Response putMultipart(FormDataMultiPart multiPart)
     {
+        checkSnapshotReadOnly();
+
         if (log.isDebugEnabled()) log.debug("MultiPart fields: {} body parts: {}", multiPart.getFields(), multiPart.getBodyParts());
 
         try
@@ -585,6 +609,8 @@ public class DocumentHierarchyGraphStoreImpl extends com.atomgraph.core.model.im
     @Override
     public Response delete()
     {
+        checkSnapshotReadOnly();
+
         if (!getAllowedMethods().contains(HttpMethod.DELETE))
             throw new WebApplicationException("Cannot delete document", Response.status(Response.Status.METHOD_NOT_ALLOWED).allow(getAllowedMethods()).build());
 

--- a/src/main/java/com/atomgraph/linkeddatahub/server/util/GraphVersioningService.java
+++ b/src/main/java/com/atomgraph/linkeddatahub/server/util/GraphVersioningService.java
@@ -20,15 +20,18 @@ import com.atomgraph.core.vocabulary.A;
 import com.atomgraph.linkeddatahub.client.GitHubClient;
 import com.atomgraph.linkeddatahub.model.ServiceContext;
 import com.atomgraph.linkeddatahub.vocabulary.LAPP;
+import com.atomgraph.linkeddatahub.vocabulary.MEM;
 import jakarta.ws.rs.NotFoundException;
 import jakarta.ws.rs.client.Client;
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.net.URI;
+import java.net.URISyntaxException;
 import java.nio.charset.StandardCharsets;
 import java.time.Instant;
 import java.util.Arrays;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
@@ -42,9 +45,12 @@ import org.apache.jena.rdf.model.Resource;
 import org.apache.jena.rdf.model.ResourceFactory;
 import org.apache.jena.rdf.model.Statement;
 import org.apache.jena.rdf.model.StmtIterator;
+import org.apache.jena.datatypes.xsd.XSDDatatype;
 import org.apache.jena.riot.Lang;
 import org.apache.jena.riot.RDFDataMgr;
 import org.apache.jena.sparql.vocabulary.DOAP;
+import org.apache.jena.vocabulary.DCTerms;
+import org.apache.jena.vocabulary.RDF;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -214,6 +220,69 @@ public class GraphVersioningService
 
     /** A historical graph version: the model and the commit datetime */
     public record Version(Model model, Instant datetime) { }
+
+    /**
+     * Retrieves a graph's version history as a Memento TimeMap model.
+     *
+     * @param appURI application URI
+     * @param appBase application base URI
+     * @param graphURI graph (document) URI
+     * @return TimeMap model, or empty if the application is not versioned
+     */
+    public Optional<Model> getTimeMap(String appURI, URI appBase, URI graphURI)
+    {
+        Repository repository = repositories.get(appURI);
+        if (repository == null) return Optional.empty();
+
+        String path = path(repository.pathPrefix(), appBase, graphURI);
+        return Optional.of(toTimeMap(graphURI, repository.client().listCommits(path)));
+    }
+
+    /**
+     * Builds a Memento TimeMap model from a graph's commit history.
+     * Memento URIs use the <code>version</code> query parameter with the commit SHA.
+     *
+     * @param graphURI graph (document) URI
+     * @param commits commit history, most recent first
+     * @return TimeMap model
+     */
+    public static Model toTimeMap(URI graphURI, List<GitHubClient.CommitInfo> commits)
+    {
+        Model model = ModelFactory.createDefaultModel();
+        Resource original = model.createResource(graphURI.toString()).
+            addProperty(RDF.type, MEM.OriginalResource);
+        Resource timeMap = model.createResource(graphURI + "?timemap").
+            addProperty(RDF.type, MEM.TimeMap).
+            addProperty(MEM.original, original);
+        original.addProperty(MEM.timemap, timeMap);
+
+        for (GitHubClient.CommitInfo commit : commits)
+        {
+            Resource memento = model.createResource(graphURI + "?version=" + commit.sha()).
+                addProperty(RDF.type, MEM.Memento).
+                addProperty(MEM.original, original).
+                addProperty(MEM.mementoDatetime, model.createTypedLiteral(commit.datetime().toString(), XSDDatatype.XSDdateTime));
+            if (isAbsoluteURI(commit.authorName())) memento.addProperty(DCTerms.creator, model.createResource(commit.authorName()));
+
+            original.addProperty(MEM.memento, memento);
+        }
+
+        return model;
+    }
+
+    private static boolean isAbsoluteURI(String string)
+    {
+        if (string == null) return false;
+
+        try
+        {
+            return new URI(string).isAbsolute();
+        }
+        catch (URISyntaxException ex)
+        {
+            return false;
+        }
+    }
 
     /**
      * Maps a graph URI to its repository file path.

--- a/src/main/java/com/atomgraph/linkeddatahub/server/util/GraphVersioningService.java
+++ b/src/main/java/com/atomgraph/linkeddatahub/server/util/GraphVersioningService.java
@@ -1,0 +1,265 @@
+/**
+ *  Copyright 2026 Martynas Jusevičius <martynas@atomgraph.com>
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ */
+package com.atomgraph.linkeddatahub.server.util;
+
+import com.atomgraph.core.vocabulary.A;
+import com.atomgraph.linkeddatahub.client.GitHubClient;
+import com.atomgraph.linkeddatahub.model.ServiceContext;
+import com.atomgraph.linkeddatahub.vocabulary.LAPP;
+import jakarta.ws.rs.NotFoundException;
+import jakarta.ws.rs.client.Client;
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.net.URI;
+import java.nio.charset.StandardCharsets;
+import java.time.Instant;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Optional;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import org.apache.jena.rdf.model.Model;
+import org.apache.jena.rdf.model.ModelFactory;
+import org.apache.jena.rdf.model.Property;
+import org.apache.jena.rdf.model.Resource;
+import org.apache.jena.rdf.model.ResourceFactory;
+import org.apache.jena.rdf.model.Statement;
+import org.apache.jena.rdf.model.StmtIterator;
+import org.apache.jena.riot.Lang;
+import org.apache.jena.riot.RDFDataMgr;
+import org.apache.jena.sparql.vocabulary.DOAP;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Mirrors named graphs of versioning-enabled applications into GitHub repositories.
+ * The unit of work is reconciliation: a task re-reads the graph from the application's
+ * SPARQL service at execution time and makes the repository file match — including deleting
+ * the file when the graph is gone. Tasks for the same file are chained sequentially so
+ * commits never race the GitHub Contents API's SHA-based optimistic locking.
+ * Versioning is best-effort: task failures are logged, never propagated.
+ *
+ * @author Martynas Jusevičius {@literal <martynas@atomgraph.com>}
+ */
+public class GraphVersioningService
+{
+
+    private static final Logger log = LoggerFactory.getLogger(GraphVersioningService.class);
+
+    /** Auth token property (established by <code>select-root-services.rq</code>; Core's A vocabulary class lacks the constant) */
+    public static final Property authToken = ResourceFactory.createProperty(A.NS + "authToken");
+
+    /** Per-repository client and file path prefix */
+    public record Repository(GitHubClient client, String pathPrefix) { }
+
+    private final Map<String, Repository> repositories;
+    private final Map<String, CompletableFuture<Void>> commitChains = new ConcurrentHashMap<>();
+    private final ExecutorService executor = Executors.newFixedThreadPool(4);
+
+    /**
+     * Builds the per-application repository map from the context model.
+     * Applications without a <code>lapp:versioningRepository</code> are not versioned.
+     *
+     * @param contextModel union model of the context dataset
+     * @param client HTTP client with standard TLS server verification
+     */
+    public GraphVersioningService(Model contextModel, Client client)
+    {
+        repositories = new HashMap<>();
+
+        StmtIterator it = contextModel.listStatements(null, LAPP.versioningRepository, (org.apache.jena.rdf.model.RDFNode)null);
+        try
+        {
+            while (it.hasNext())
+            {
+                Statement stmt = it.nextStatement();
+                Resource app = stmt.getSubject();
+                Resource repo = stmt.getResource();
+
+                Repository repository = repository(app, repo, client);
+                if (repository != null) repositories.put(app.getURI(), repository);
+            }
+        }
+        finally
+        {
+            it.close();
+        }
+    }
+
+    private Repository repository(Resource app, Resource repo, Client client)
+    {
+        if (!repo.hasProperty(DOAP.location) || !repo.hasProperty(authToken))
+        {
+            if (log.isWarnEnabled()) log.warn("Versioning repository of application <{}> is missing doap:location or a:authToken, versioning disabled for it", app.getURI());
+            return null;
+        }
+
+        URI location = URI.create(repo.getPropertyResourceValue(DOAP.location).getURI());
+        String[] segments = location.getPath().substring(1).split("/");
+        if (segments.length != 2)
+        {
+            if (log.isWarnEnabled()) log.warn("Versioning repository location <{}> of application <{}> is not an owner/repository URL, versioning disabled for it", location, app.getURI());
+            return null;
+        }
+
+        String token = repo.getProperty(authToken).getString();
+        String branch = repo.hasProperty(LAPP.branch) ? repo.getProperty(LAPP.branch).getString() : "main";
+        String pathPrefix = repo.hasProperty(LAPP.pathPrefix) ? repo.getProperty(LAPP.pathPrefix).getString() : "graphs";
+
+        if (log.isInfoEnabled()) log.info("Graph versioning enabled for application <{}> into {} (branch '{}', path prefix '{}')", app.getURI(), location, branch, pathPrefix);
+        return new Repository(new GitHubClient(client, GitHubClient.API_BASE, token, segments[0], segments[1], branch), pathPrefix);
+    }
+
+    /**
+     * Returns the repository configured for an application, if any.
+     *
+     * @param appURI application URI
+     * @return repository, or empty if the application is not versioned
+     */
+    public Optional<Repository> getRepository(String appURI)
+    {
+        return Optional.ofNullable(repositories.get(appURI));
+    }
+
+    /**
+     * Schedules asynchronous reconciliation of a graph's repository file with its current store state.
+     * Chained per file path; returns immediately.
+     *
+     * @param serviceContext deployment context of the application's SPARQL service
+     * @param appURI application URI
+     * @param appBase application base URI
+     * @param graphURI graph (document) URI
+     * @param agentWebID WebID of the agent whose write triggered the commit (author of the commit)
+     * @param method HTTP method of the triggering request (part of the commit message)
+     */
+    public void commitAsync(ServiceContext serviceContext, String appURI, URI appBase, URI graphURI, String agentWebID, String method)
+    {
+        Repository repository = repositories.get(appURI);
+        if (repository == null) return;
+
+        String path = path(repository.pathPrefix(), appBase, graphURI);
+        String message = method + " " + graphURI;
+
+        commitChains.compute(path, (key, chain) ->
+        {
+            CompletableFuture<Void> previous = chain != null ? chain : CompletableFuture.completedFuture(null);
+            CompletableFuture<Void> next = previous.thenRunAsync(() -> reconcile(serviceContext, repository, path, graphURI, message, agentWebID), executor).
+                exceptionally(ex ->
+                {
+                    if (log.isErrorEnabled()) log.error("Failed to version graph <{}> as '{}': {}", graphURI, path, ex.getMessage());
+                    return null;
+                });
+            next.whenComplete((result, ex) -> commitChains.remove(key, next));
+            return next;
+        });
+    }
+
+    private void reconcile(ServiceContext serviceContext, Repository repository, String path, URI graphURI, String message, String agentWebID)
+    {
+        Model model;
+        try
+        {
+            model = serviceContext.getGraphStoreClient().getModel(graphURI.toString());
+        }
+        catch (NotFoundException ex)
+        {
+            repository.client().deleteFile(path, message, agentWebID);
+            if (log.isDebugEnabled()) log.debug("Deleted '{}' (graph <{}> is gone)", path, graphURI);
+            return;
+        }
+
+        GitHubClient.Commit commit = repository.client().putFile(path, toSortedNTriples(model), message, agentWebID);
+        if (log.isDebugEnabled()) log.debug("Committed graph <{}> as '{}': {}", graphURI, path, commit.commitSha());
+    }
+
+    /**
+     * Retrieves a graph's state at a given commit.
+     *
+     * @param appURI application URI
+     * @param appBase application base URI
+     * @param graphURI graph (document) URI
+     * @param ref commit SHA
+     * @return the graph model with its blob SHA, or empty if not versioned at that commit
+     */
+    public Optional<Version> getVersion(String appURI, URI appBase, URI graphURI, String ref)
+    {
+        Repository repository = repositories.get(appURI);
+        if (repository == null) return Optional.empty();
+
+        String path = path(repository.pathPrefix(), appBase, graphURI);
+        return repository.client().getFileAtCommit(path, ref).map(content ->
+        {
+            Model model = ModelFactory.createDefaultModel();
+            RDFDataMgr.read(model, new ByteArrayInputStream(content), graphURI.toString(), Lang.NTRIPLES);
+            return new Version(model, repository.client().getCommitDate(ref).orElse(null));
+        });
+    }
+
+    /** A historical graph version: the model and the commit datetime */
+    public record Version(Model model, Instant datetime) { }
+
+    /**
+     * Maps a graph URI to its repository file path.
+     *
+     * @param pathPrefix repository path prefix
+     * @param base application base URI
+     * @param graphURI graph URI
+     * @return file path
+     */
+    public static String path(String pathPrefix, URI base, URI graphURI)
+    {
+        String relative = base.relativize(graphURI).getPath();
+        if (relative.isEmpty()) relative = "root"; // the app base document itself
+        if (relative.endsWith("/")) relative = relative.substring(0, relative.length() - 1);
+
+        return pathPrefix + "/" + relative + ".nt";
+    }
+
+    /**
+     * Serializes a model as N-Triples with sorted lines, so successive serializations
+     * of the same graph are byte-identical and git diffs are minimal.
+     *
+     * @param model the model
+     * @return sorted N-Triples bytes
+     */
+    public static byte[] toSortedNTriples(Model model)
+    {
+        ByteArrayOutputStream out = new ByteArrayOutputStream();
+        RDFDataMgr.write(out, model, Lang.NTRIPLES);
+
+        String[] lines = out.toString(StandardCharsets.UTF_8).split("\n");
+        Arrays.sort(lines);
+
+        StringBuilder sorted = new StringBuilder();
+        for (String line : lines)
+            if (!line.isBlank()) sorted.append(line.stripTrailing()).append('\n');
+
+        return sorted.toString().getBytes(StandardCharsets.UTF_8);
+    }
+
+    /**
+     * Shuts down the background executor.
+     */
+    public void shutdown()
+    {
+        executor.shutdown();
+    }
+
+}

--- a/src/main/java/com/atomgraph/linkeddatahub/vocabulary/LAPP.java
+++ b/src/main/java/com/atomgraph/linkeddatahub/vocabulary/LAPP.java
@@ -98,4 +98,13 @@ public class LAPP
     /** Application property (for Link header rel) */
     public static final Property application = m_model.createObjectProperty( NS + "application" );
 
+    /** Versioning repository property linking an application to a <code>doap:GitRepository</code> */
+    public static final Property versioningRepository = m_model.createObjectProperty( NS + "versioningRepository" );
+
+    /** Git branch property of a versioning repository */
+    public static final Property branch = m_model.createDataProperty( NS + "branch" );
+
+    /** Path prefix property for graph files in a versioning repository */
+    public static final Property pathPrefix = m_model.createDataProperty( NS + "pathPrefix" );
+
 }

--- a/src/main/java/com/atomgraph/linkeddatahub/vocabulary/MEM.java
+++ b/src/main/java/com/atomgraph/linkeddatahub/vocabulary/MEM.java
@@ -1,0 +1,80 @@
+/**
+ *  Copyright 2026 Martynas Jusevičius <martynas@atomgraph.com>
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ */
+package com.atomgraph.linkeddatahub.vocabulary;
+
+import org.apache.jena.ontapi.OntModelFactory;
+import org.apache.jena.ontapi.OntSpecification;
+import org.apache.jena.ontapi.model.OntModel;
+import org.apache.jena.rdf.model.Property;
+import org.apache.jena.rdf.model.Resource;
+
+/**
+ * Memento vocabulary (RFC 7089).
+ *
+ * @author Martynas Jusevičius {@literal <martynas@atomgraph.com>}
+ * @see <a href="https://datatracker.ietf.org/doc/html/rfc7089">RFC 7089: HTTP Framework for Time-Based Access to Resource States -- Memento</a>
+ */
+public class MEM
+{
+
+    static
+    {
+        org.apache.jena.sys.JenaSystem.init(); // ensure Jena (RDFS vocab) is initialized before ontapi touches it
+    }
+
+    /** The RDF model that holds the vocabulary terms */
+    private static OntModel m_model = OntModelFactory.createModel(OntSpecification.OWL2_FULL_MEM);
+
+    /** The namespace of the vocabulary as a string */
+    public static final String NS = "http://mementoweb.org/ns#";
+
+    /**
+     * The namespace of the vocabulary as a string
+     *
+     * @return namespace URI
+     * @see #NS
+     */
+    public static String getURI()
+    {
+        return NS;
+    }
+
+    /** The namespace of the vocabulary as a resource */
+    public static final Resource NAMESPACE = m_model.createResource( NS );
+
+    /** Original resource class */
+    public static final Resource OriginalResource = m_model.createOntClass( NS + "OriginalResource" );
+
+    /** Memento class */
+    public static final Resource Memento = m_model.createOntClass( NS + "Memento" );
+
+    /** TimeMap class */
+    public static final Resource TimeMap = m_model.createOntClass( NS + "TimeMap" );
+
+    /** Original resource property */
+    public static final Property original = m_model.createObjectProperty( NS + "original" );
+
+    /** Memento property */
+    public static final Property memento = m_model.createObjectProperty( NS + "memento" );
+
+    /** Timemap property */
+    public static final Property timemap = m_model.createObjectProperty( NS + "timemap" );
+
+    /** Memento datetime property */
+    public static final Property mementoDatetime = m_model.createDataProperty( NS + "mementoDatetime" );
+
+}

--- a/src/main/webapp/WEB-INF/web.xml
+++ b/src/main/webapp/WEB-INF/web.xml
@@ -358,6 +358,9 @@ support@atomgraph.com]]></param-value>
     <listener>
         <listener-class>com.atomgraph.linkeddatahub.listener.EMailListener</listener-class>
     </listener>
+    <listener>
+        <listener-class>com.atomgraph.linkeddatahub.listener.GraphVersioningListener</listener-class>
+    </listener>
     <servlet-mapping>
         <servlet-name>default</servlet-name>
         <url-pattern>/static/*</url-pattern>

--- a/src/main/webapp/static/com/atomgraph/linkeddatahub/xsl/bootstrap/2.3.2/client/functions.xsl
+++ b/src/main/webapp/static/com/atomgraph/linkeddatahub/xsl/bootstrap/2.3.2/client/functions.xsl
@@ -89,6 +89,16 @@ exclude-result-prefixes="#all"
         <xsl:sequence select="if (ixsl:contains(ixsl:window(), 'LinkedDataHub.application')) then xs:anyURI(ixsl:get(ixsl:window(), 'LinkedDataHub.application')) else ()"/>
     </xsl:function>
 
+    <!-- TimeMap URI extracted from the Link response header by ldh:rdf-document-response; blank when the document is not versioned -->
+    <xsl:function name="ldh:timemap" as="xs:anyURI?">
+        <xsl:sequence select="if (ixsl:contains(ixsl:window(), 'LinkedDataHub.timemap') and not(ixsl:get(ixsl:window(), 'LinkedDataHub.timemap') = '')) then xs:anyURI(ixsl:get(ixsl:window(), 'LinkedDataHub.timemap')) else ()"/>
+    </xsl:function>
+
+    <!-- Memento-Datetime is a response header, not available in the client context; ?version= pages render server-side -->
+    <xsl:function name="ldh:memento-datetime" as="xs:string?">
+        <xsl:sequence select="()"/>
+    </xsl:function>
+
     <xsl:function name="lapp:origin" as="xs:anyURI">
         <xsl:sequence select="lapp:origin(ldt:base())"/>
     </xsl:function>

--- a/src/main/webapp/static/com/atomgraph/linkeddatahub/xsl/bootstrap/2.3.2/client/memento.xsl
+++ b/src/main/webapp/static/com/atomgraph/linkeddatahub/xsl/bootstrap/2.3.2/client/memento.xsl
@@ -1,6 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE xsl:stylesheet [
     <!ENTITY ldh     "https://w3id.org/atomgraph/linkeddatahub#">
+    <!ENTITY lapp    "https://w3id.org/atomgraph/linkeddatahub/apps#">
+    <!ENTITY ac      "https://w3id.org/atomgraph/client#">
     <!ENTITY rdf     "http://www.w3.org/1999/02/22-rdf-syntax-ns#">
     <!ENTITY memento "http://mementoweb.org/ns#">
 ]>
@@ -9,6 +11,8 @@ xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
 xmlns:ixsl="http://saxonica.com/ns/interactiveXSLT"
 xmlns:xs="http://www.w3.org/2001/XMLSchema"
 xmlns:ldh="&ldh;"
+xmlns:lapp="&lapp;"
+xmlns:ac="&ac;"
 xmlns:rdf="&rdf;"
 xmlns:memento="&memento;"
 xmlns:bs2="http://graphity.org/xsl/bootstrap/2.3.2"
@@ -52,7 +56,16 @@ version="3.0"
                     <div class="modal modal-constructor fade in" id="document-history-modal">
                         <div class="modal-header">
                             <button type="button" class="close">&#215;</button>
-                            <legend>History</legend>
+                            <legend>
+                                <xsl:value-of>
+                                    <xsl:apply-templates select="key('resources', 'history', document(resolve-uri('static/com/atomgraph/linkeddatahub/xsl/bootstrap/2.3.2/translations.rdf', $lapp:origin)))" mode="ac:label"/>
+                                </xsl:value-of>
+                            </legend>
+                            <p class="text-info">
+                                <xsl:value-of>
+                                    <xsl:apply-templates select="key('resources', 'history-description', document(resolve-uri('static/com/atomgraph/linkeddatahub/xsl/bootstrap/2.3.2/translations.rdf', $lapp:origin)))" mode="ac:label"/>
+                                </xsl:value-of>
+                            </p>
                         </div>
                         <div class="modal-body">
                             <xsl:choose>
@@ -64,8 +77,16 @@ version="3.0"
                                         </colgroup>
                                         <thead>
                                             <tr>
-                                                <th>Version</th>
-                                                <th>Agent</th>
+                                                <th>
+                                                    <xsl:value-of>
+                                                        <xsl:apply-templates select="key('resources', 'version', document(resolve-uri('static/com/atomgraph/linkeddatahub/xsl/bootstrap/2.3.2/translations.rdf', $lapp:origin)))" mode="ac:label"/>
+                                                    </xsl:value-of>
+                                                </th>
+                                                <th>
+                                                    <xsl:value-of>
+                                                        <xsl:apply-templates select="key('resources', 'agent', document(resolve-uri('static/com/atomgraph/linkeddatahub/xsl/bootstrap/2.3.2/translations.rdf', $lapp:origin)))" mode="ac:label"/>
+                                                    </xsl:value-of>
+                                                </th>
                                             </tr>
                                         </thead>
                                         <tbody>

--- a/src/main/webapp/static/com/atomgraph/linkeddatahub/xsl/bootstrap/2.3.2/client/memento.xsl
+++ b/src/main/webapp/static/com/atomgraph/linkeddatahub/xsl/bootstrap/2.3.2/client/memento.xsl
@@ -10,6 +10,7 @@
 xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
 xmlns:ixsl="http://saxonica.com/ns/interactiveXSLT"
 xmlns:xs="http://www.w3.org/2001/XMLSchema"
+xmlns:map="http://www.w3.org/2005/xpath-functions/map"
 xmlns:ldh="&ldh;"
 xmlns:lapp="&lapp;"
 xmlns:ac="&ac;"
@@ -90,8 +91,12 @@ version="3.0"
                                             </tr>
                                         </thead>
                                         <tbody>
-                                            <xsl:apply-templates select="$response?body//*[@rdf:about][rdf:type/@rdf:resource = '&memento;Memento']" mode="bs2:MementoList">
+                                            <xsl:variable name="mementos" select="$response?body//*[@rdf:about][rdf:type/@rdf:resource = '&memento;Memento']" as="element()*"/>
+                                            <!-- on the live document view, the latest version is the one being viewed -->
+                                            <xsl:variable name="latest-memento" select="sort($mementos, (), function($memento) { string($memento/memento:mementoDatetime) })[last()]/@rdf:about" as="attribute()?"/>
+                                            <xsl:apply-templates select="$mementos" mode="bs2:MementoList">
                                                 <xsl:sort select="memento:mementoDatetime" order="descending"/>
+                                                <xsl:with-param name="current-memento" select="if (map:contains(ldh:query-params(), 'version')) then xs:anyURI(ac:absolute-path(ldh:request-uri()) || '?version=' || ldh:query-params()?version) else xs:anyURI($latest-memento)"/>
                                             </xsl:apply-templates>
                                         </tbody>
                                     </table>

--- a/src/main/webapp/static/com/atomgraph/linkeddatahub/xsl/bootstrap/2.3.2/client/memento.xsl
+++ b/src/main/webapp/static/com/atomgraph/linkeddatahub/xsl/bootstrap/2.3.2/client/memento.xsl
@@ -1,0 +1,79 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE xsl:stylesheet [
+    <!ENTITY ldh     "https://w3id.org/atomgraph/linkeddatahub#">
+    <!ENTITY rdf     "http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+    <!ENTITY memento "http://mementoweb.org/ns#">
+]>
+<xsl:stylesheet
+xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
+xmlns:ixsl="http://saxonica.com/ns/interactiveXSLT"
+xmlns:xs="http://www.w3.org/2001/XMLSchema"
+xmlns:ldh="&ldh;"
+xmlns:rdf="&rdf;"
+xmlns:memento="&memento;"
+xmlns:bs2="http://graphity.org/xsl/bootstrap/2.3.2"
+xmlns:xhtml="http://www.w3.org/1999/xhtml"
+exclude-result-prefixes="#all"
+extension-element-prefixes="ixsl"
+version="3.0"
+>
+
+    <!-- Memento (RFC 7089) version history modal -->
+
+    <!-- open the version history modal instead of navigating to the TimeMap URL -->
+    <xsl:template match="a[contains-token(@class, 'document-history')]" mode="ixsl:onclick" priority="1">
+        <xsl:sequence select="ixsl:call(ixsl:event(), 'preventDefault', [])"/>
+        <xsl:variable name="timemap-uri" select="xs:anyURI(resolve-uri(@href, ldh:base-uri(.)))" as="xs:anyURI"/>
+        <xsl:variable name="container" select="id('tab-content', ixsl:page())/div[contains-token(@class, 'tab-pane')][contains-token(@class, 'active')]/div[contains-token(@class, 'document-body')]/div[contains-token(@class, 'content-body')]" as="element()"/>
+
+        <ixsl:set-style name="cursor" select="'progress'" object="ixsl:page()//body"/>
+
+        <xsl:variable name="request" select="map{ 'method': 'GET', 'href': $timemap-uri, 'headers': map{ 'Accept': 'application/rdf+xml' } }" as="map(*)"/>
+        <xsl:variable name="context" select="map{ 'request': $request, 'timemap-uri': $timemap-uri, 'container': $container }" as="map(*)"/>
+        <ixsl:promise select="
+          ixsl:http-request($context('request'))
+            => ixsl:then(ldh:rethread-response($context, ?))
+            => ixsl:then(ldh:handle-response#1)
+            => ixsl:then(ldh:timemap-response#1)
+        " on-failure="ldh:promise-failure#1"/>
+    </xsl:template>
+
+    <!-- renders the version history modal from the TimeMap RDF response -->
+    <xsl:function name="ldh:timemap-response" as="item()?" ixsl:updating="yes">
+        <xsl:param name="context" as="map(*)"/>
+        <xsl:variable name="response" select="$context('response')" as="map(*)"/>
+        <xsl:variable name="container" select="$context('container')" as="element()"/>
+
+        <xsl:for-each select="$response">
+            <ixsl:set-style name="cursor" select="'default'" object="ixsl:page()//body"/>
+
+            <xsl:for-each select="$container">
+                <xsl:result-document href="?." method="ixsl:append-content">
+                    <div class="modal fade in" id="document-history-modal">
+                        <div class="modal-header">
+                            <button type="button" class="close">&#215;</button>
+                            <h3>History</h3>
+                        </div>
+                        <div class="modal-body">
+                            <xsl:choose>
+                                <xsl:when test="$response?status = 200 and $response?media-type = 'application/rdf+xml'">
+                                    <ul class="unstyled">
+                                        <xsl:apply-templates select="$response?body//*[@rdf:about][rdf:type/@rdf:resource = '&memento;Memento']" mode="bs2:MementoList">
+                                            <xsl:sort select="memento:mementoDatetime" order="descending"/>
+                                        </xsl:apply-templates>
+                                    </ul>
+                                </xsl:when>
+                                <xsl:otherwise>
+                                    <div class="alert alert-error">
+                                        <xsl:text>Could not load the version history</xsl:text>
+                                    </div>
+                                </xsl:otherwise>
+                            </xsl:choose>
+                        </div>
+                    </div>
+                </xsl:result-document>
+            </xsl:for-each>
+        </xsl:for-each>
+    </xsl:function>
+
+</xsl:stylesheet>

--- a/src/main/webapp/static/com/atomgraph/linkeddatahub/xsl/bootstrap/2.3.2/client/memento.xsl
+++ b/src/main/webapp/static/com/atomgraph/linkeddatahub/xsl/bootstrap/2.3.2/client/memento.xsl
@@ -49,19 +49,31 @@ version="3.0"
 
             <xsl:for-each select="$container">
                 <xsl:result-document href="?." method="ixsl:append-content">
-                    <div class="modal fade in" id="document-history-modal">
+                    <div class="modal modal-constructor fade in" id="document-history-modal">
                         <div class="modal-header">
                             <button type="button" class="close">&#215;</button>
-                            <h3>History</h3>
+                            <legend>History</legend>
                         </div>
                         <div class="modal-body">
                             <xsl:choose>
                                 <xsl:when test="$response?status = 200 and $response?media-type = 'application/rdf+xml'">
-                                    <ul class="unstyled">
-                                        <xsl:apply-templates select="$response?body//*[@rdf:about][rdf:type/@rdf:resource = '&memento;Memento']" mode="bs2:MementoList">
-                                            <xsl:sort select="memento:mementoDatetime" order="descending"/>
-                                        </xsl:apply-templates>
-                                    </ul>
+                                    <table class="table table-striped">
+                                        <colgroup>
+                                            <col style="width: 60%;"/>
+                                            <col style="width: 40%;"/>
+                                        </colgroup>
+                                        <thead>
+                                            <tr>
+                                                <th>Version</th>
+                                                <th>Agent</th>
+                                            </tr>
+                                        </thead>
+                                        <tbody>
+                                            <xsl:apply-templates select="$response?body//*[@rdf:about][rdf:type/@rdf:resource = '&memento;Memento']" mode="bs2:MementoList">
+                                                <xsl:sort select="memento:mementoDatetime" order="descending"/>
+                                            </xsl:apply-templates>
+                                        </tbody>
+                                    </table>
                                 </xsl:when>
                                 <xsl:otherwise>
                                     <div class="alert alert-error">

--- a/src/main/webapp/static/com/atomgraph/linkeddatahub/xsl/bootstrap/2.3.2/document.xsl
+++ b/src/main/webapp/static/com/atomgraph/linkeddatahub/xsl/bootstrap/2.3.2/document.xsl
@@ -248,8 +248,18 @@ extension-element-prefixes="ixsl"
                 </xsl:apply-templates>
                 
                 <div id="doc-controls" class="span4">
-                    <xsl:apply-templates select="key('resources', ac:absolute-path(ldh:base-uri(.)))" mode="bs2:Timestamp"/>
-                </div>                
+                    <xsl:choose>
+                        <!-- versioned document: the timestamp links to its version history (Memento TimeMap) -->
+                        <xsl:when test="exists(ldh:timemap())">
+                            <a href="{ldh:timemap()}" class="document-history" title="History">
+                                <xsl:apply-templates select="key('resources', ac:absolute-path(ldh:base-uri(.)))" mode="bs2:Timestamp"/>
+                            </a>
+                        </xsl:when>
+                        <xsl:otherwise>
+                            <xsl:apply-templates select="key('resources', ac:absolute-path(ldh:base-uri(.)))" mode="bs2:Timestamp"/>
+                        </xsl:otherwise>
+                    </xsl:choose>
+                </div>
             </div>
         </div>
     </xsl:template>
@@ -510,6 +520,23 @@ extension-element-prefixes="ixsl"
             <xsl:apply-templates select="." mode="bs2:ActionBar">
                 <xsl:with-param name="active-mode" select="$mode"/>
             </xsl:apply-templates>
+
+            <!-- notice shown when a historical version is displayed (?version= query parameter) -->
+            <xsl:if test="map:contains(ldh:query-params(), 'version')">
+                <div class="alert alert-info">
+                    <xsl:text>You are viewing a historical version of this document</xsl:text>
+                    <xsl:if test="exists(ldh:memento-datetime())">
+                        <xsl:text> from </xsl:text>
+                        <strong>
+                            <xsl:value-of select="ldh:memento-datetime()"/>
+                        </strong>
+                    </xsl:if>
+                    <xsl:text>. </xsl:text>
+                    <a href="{ac:absolute-path(ldh:base-uri(.))}">
+                        <xsl:text>View the current version</xsl:text>
+                    </a>
+                </div>
+            </xsl:if>
 
             <!-- host for the RDFa editor toolbar (appended by rdfae:init-editing); empty until an editable region initializes -->
             <div class="navbar-inner editor-bar">

--- a/src/main/webapp/static/com/atomgraph/linkeddatahub/xsl/bootstrap/2.3.2/document.xsl
+++ b/src/main/webapp/static/com/atomgraph/linkeddatahub/xsl/bootstrap/2.3.2/document.xsl
@@ -524,16 +524,21 @@ extension-element-prefixes="ixsl"
             <!-- notice shown when a historical version is displayed (?version= query parameter) -->
             <xsl:if test="map:contains(ldh:query-params(), 'version')">
                 <div class="alert alert-info">
-                    <xsl:text>You are viewing a historical version of this document</xsl:text>
+                    <xsl:value-of>
+                        <xsl:apply-templates select="key('resources', 'historical-version-notice', document(resolve-uri('static/com/atomgraph/linkeddatahub/xsl/bootstrap/2.3.2/translations.rdf', $lapp:origin)))" mode="ac:label"/>
+                    </xsl:value-of>
                     <xsl:if test="exists(ldh:memento-datetime())">
-                        <xsl:text> from </xsl:text>
+                        <xsl:text> (</xsl:text>
                         <strong>
                             <xsl:value-of select="ldh:memento-datetime()"/>
                         </strong>
+                        <xsl:text>)</xsl:text>
                     </xsl:if>
                     <xsl:text>. </xsl:text>
                     <a href="{ac:absolute-path(ldh:base-uri(.))}">
-                        <xsl:text>View the current version</xsl:text>
+                        <xsl:value-of>
+                            <xsl:apply-templates select="key('resources', 'view-current-version', document(resolve-uri('static/com/atomgraph/linkeddatahub/xsl/bootstrap/2.3.2/translations.rdf', $lapp:origin)))" mode="ac:label"/>
+                        </xsl:value-of>
                     </a>
                 </div>
             </xsl:if>

--- a/src/main/webapp/static/com/atomgraph/linkeddatahub/xsl/bootstrap/2.3.2/imports/default.xsl
+++ b/src/main/webapp/static/com/atomgraph/linkeddatahub/xsl/bootstrap/2.3.2/imports/default.xsl
@@ -183,6 +183,13 @@ exclude-result-prefixes="#all"
         <!-- ac:document-uri strips the URL's #fragment so it doesn't get glued onto the last query value -->
         <xsl:sequence select="ldh:parse-query-params(substring-after(ac:document-uri(ldh:request-uri()), '?'))"/>
     </xsl:function>
+
+    <!-- representation-selecting query params (unlike display state such as ?mode, these select a different representation of the document URI) - they must survive the RDF re-fetch and every URL rebuild -->
+    <xsl:function name="ldh:snapshot-params" as="map(xs:string, xs:string*)">
+        <xsl:param name="query-params" as="map(xs:string, xs:string*)"/>
+
+        <xsl:sequence select="map:merge((if (map:contains($query-params, 'version')) then map{ 'version': $query-params?version } else (), if (map:contains($query-params, 'timemap')) then map{ 'timemap': $query-params?timemap } else ()))"/>
+    </xsl:function>
     
     <xsl:function name="ldh:base-uri" as="xs:anyURI" use-when="system-property('xsl:product-name') = 'SAXON'">
         <xsl:param name="arg" as="node()"/>

--- a/src/main/webapp/static/com/atomgraph/linkeddatahub/xsl/bootstrap/2.3.2/imports/default.xsl
+++ b/src/main/webapp/static/com/atomgraph/linkeddatahub/xsl/bootstrap/2.3.2/imports/default.xsl
@@ -131,6 +131,25 @@ exclude-result-prefixes="#all"
         <xsl:sequence select="$ac:uri"/>
     </xsl:function>
 
+    <!-- TimeMap URI from the Link response header (rel=mem:timemap), present when the document is versioned -->
+    <xsl:function name="ldh:timemap" as="xs:anyURI?" use-when="system-property('xsl:product-name') = 'SAXON'">
+        <xsl:variable name="entries" as="xs:string*">
+            <xsl:for-each select="$ldh:httpHeaders('Link')">
+                <xsl:analyze-string select="." regex="&lt;[^&gt;]+&gt;[^&lt;]*">
+                    <xsl:matching-substring>
+                        <xsl:sequence select="."/>
+                    </xsl:matching-substring>
+                </xsl:analyze-string>
+            </xsl:for-each>
+        </xsl:variable>
+        <xsl:sequence select="(for $entry in $entries return if (matches($entry, '^&lt;[^&gt;]+&gt;\s*;.*[;\s]rel\s*=\s*&quot;?[^&quot;\s,;]*mementoweb\.org/ns#timemap&quot;?')) then xs:anyURI(replace($entry, '^&lt;([^&gt;]+)&gt;.*$', '$1')) else ())[1]"/>
+    </xsl:function>
+
+    <!-- Memento-Datetime response header value, present on ?version= responses -->
+    <xsl:function name="ldh:memento-datetime" as="xs:string?" use-when="system-property('xsl:product-name') = 'SAXON'">
+        <xsl:sequence select="$ldh:httpHeaders('Memento-Datetime')[1]"/>
+    </xsl:function>
+
     <!-- Strips the leftmost subdomain and returns parent dataspace origin (scheme + host + port) -->
     <xsl:function name="ldh:parent-origin" as="xs:anyURI?">
         <xsl:param name="uri" as="xs:anyURI"/>
@@ -1505,6 +1524,50 @@ exclude-result-prefixes="#all"
     <!-- resolve relative @src URIs against base in proxy mode -->
     <xsl:template match="@src[not(ac:absolute-path(ldh:base-uri(.)) = ac:absolute-path(ldh:request-uri()))][not(starts-with(., '/')) and not(starts-with(., '#')) and not(contains(., ':'))]" mode="ldh:XHTMLContent" priority="1">
         <xsl:attribute name="{name()}" select="resolve-uri(., ldh:base-uri(.))"/>
+    </xsl:template>
+
+    <!-- DATE/DATETIME LITERALS -->
+    <!-- overrides the Web-Client templates that pass $ac:lang to format-date(Time): Saxon only ships English date names, so any other language makes it prepend a '[Language: en]' fallback marker to the output. TO-DO: upstream to Web-Client -->
+
+    <xsl:template match="text()[. castable as xs:date][../@rdf:datatype = '&xsd;date'] | srx:literal[@datatype = '&xsd;date']" priority="1">
+        <xsl:param name="id" as="xs:string?"/>
+        <xsl:param name="title" select="../@rdf:datatype" as="xs:string?"/>
+        <xsl:param name="class" as="xs:string?"/>
+
+        <span>
+            <xsl:if test="$id">
+                <xsl:attribute name="id" select="$id"/>
+            </xsl:if>
+            <xsl:if test="$title">
+                <xsl:attribute name="title" select="$title"/>
+            </xsl:if>
+            <xsl:if test="$class">
+                <xsl:attribute name="class" select="$class"/>
+            </xsl:if>
+
+            <xsl:sequence select="format-date(., '[D] [MNn] [Y]')"/>
+        </span>
+    </xsl:template>
+
+    <xsl:template match="text()[. castable as xs:dateTime][../@rdf:datatype = '&xsd;dateTime'] | srx:literal[@datatype = '&xsd;dateTime']" priority="1">
+        <xsl:param name="id" as="xs:string?"/>
+        <xsl:param name="title" select="../@rdf:datatype" as="xs:string?"/>
+        <xsl:param name="class" as="xs:string?"/>
+        <xsl:param name="timezone" select="implicit-timezone()" as="xs:dayTimeDuration?"/>
+
+        <span>
+            <xsl:if test="$id">
+                <xsl:attribute name="id" select="$id"/>
+            </xsl:if>
+            <xsl:if test="$title">
+                <xsl:attribute name="title" select="$title"/>
+            </xsl:if>
+            <xsl:if test="$class">
+                <xsl:attribute name="class" select="$class"/>
+            </xsl:if>
+
+            <xsl:sequence select="format-dateTime(adjust-dateTime-to-timezone(., $timezone), '[D] [MNn] [Y] [H01]:[m01]')"/>
+        </span>
     </xsl:template>
 
 </xsl:stylesheet>

--- a/src/main/webapp/static/com/atomgraph/linkeddatahub/xsl/bootstrap/2.3.2/imports/memento.xsl
+++ b/src/main/webapp/static/com/atomgraph/linkeddatahub/xsl/bootstrap/2.3.2/imports/memento.xsl
@@ -7,6 +7,9 @@
 <xsl:stylesheet version="3.0"
 xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
 xmlns:xs="http://www.w3.org/2001/XMLSchema"
+xmlns:map="http://www.w3.org/2005/xpath-functions/map"
+xmlns:ldh="https://w3id.org/atomgraph/linkeddatahub#"
+xmlns:ac="https://w3id.org/atomgraph/client#"
 xmlns:rdf="&rdf;"
 xmlns:memento="&memento;"
 xmlns:dct="&dct;"
@@ -16,18 +19,24 @@ exclude-result-prefixes="#all"
 
     <!-- Memento (RFC 7089) version history rendering -->
 
-    <!-- a version entry: datetime links to the memento (?version= URI); opens in a new tab so the CSR navigation (which drops query params) is bypassed -->
+    <!-- a version entry: datetime links to the memento (?version= URI), which navigates like any document link -->
     <xsl:template match="*[@rdf:about][rdf:type/@rdf:resource = '&memento;Memento']" mode="bs2:MementoList">
-        <li>
-            <a href="{@rdf:about}" target="_blank">
-                <xsl:apply-templates select="memento:mementoDatetime/text()"/>
-            </a>
-            <xsl:if test="dct:creator/@rdf:resource">
-                <span class="pull-right">
-                    <xsl:apply-templates select="dct:creator/@rdf:resource"/>
-                </span>
+        <!-- the memento URI of the version currently being viewed, when a ?version= view is active -->
+        <xsl:variable name="current-memento" select="if (map:contains(ldh:query-params(), 'version')) then xs:anyURI(ac:absolute-path(ldh:request-uri()) || '?version=' || ldh:query-params()?version) else ()" as="xs:anyURI?"/>
+
+        <tr>
+            <xsl:if test="@rdf:about = $current-memento">
+                <xsl:attribute name="class" select="'info'"/>
             </xsl:if>
-        </li>
+            <td>
+                <a href="{@rdf:about}">
+                    <xsl:apply-templates select="memento:mementoDatetime/text()"/>
+                </a>
+            </td>
+            <td>
+                <xsl:apply-templates select="dct:creator/@rdf:resource"/>
+            </td>
+        </tr>
     </xsl:template>
 
 </xsl:stylesheet>

--- a/src/main/webapp/static/com/atomgraph/linkeddatahub/xsl/bootstrap/2.3.2/imports/memento.xsl
+++ b/src/main/webapp/static/com/atomgraph/linkeddatahub/xsl/bootstrap/2.3.2/imports/memento.xsl
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE xsl:stylesheet [
+    <!ENTITY rdf     "http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+    <!ENTITY memento "http://mementoweb.org/ns#">
+    <!ENTITY dct     "http://purl.org/dc/terms/">
+]>
+<xsl:stylesheet version="3.0"
+xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
+xmlns:xs="http://www.w3.org/2001/XMLSchema"
+xmlns:rdf="&rdf;"
+xmlns:memento="&memento;"
+xmlns:dct="&dct;"
+xmlns:bs2="http://graphity.org/xsl/bootstrap/2.3.2"
+exclude-result-prefixes="#all"
+>
+
+    <!-- Memento (RFC 7089) version history rendering -->
+
+    <!-- a version entry: datetime links to the memento (?version= URI); opens in a new tab so the CSR navigation (which drops query params) is bypassed -->
+    <xsl:template match="*[@rdf:about][rdf:type/@rdf:resource = '&memento;Memento']" mode="bs2:MementoList">
+        <li>
+            <a href="{@rdf:about}" target="_blank">
+                <xsl:apply-templates select="memento:mementoDatetime/text()"/>
+            </a>
+            <xsl:if test="dct:creator/@rdf:resource">
+                <span class="pull-right">
+                    <xsl:apply-templates select="dct:creator/@rdf:resource"/>
+                </span>
+            </xsl:if>
+        </li>
+    </xsl:template>
+
+</xsl:stylesheet>

--- a/src/main/webapp/static/com/atomgraph/linkeddatahub/xsl/bootstrap/2.3.2/imports/memento.xsl
+++ b/src/main/webapp/static/com/atomgraph/linkeddatahub/xsl/bootstrap/2.3.2/imports/memento.xsl
@@ -25,13 +25,20 @@ exclude-result-prefixes="#all"
         <xsl:variable name="current-memento" select="if (map:contains(ldh:query-params(), 'version')) then xs:anyURI(ac:absolute-path(ldh:request-uri()) || '?version=' || ldh:query-params()?version) else ()" as="xs:anyURI?"/>
 
         <tr>
-            <xsl:if test="@rdf:about = $current-memento">
-                <xsl:attribute name="class" select="'info'"/>
-            </xsl:if>
             <td>
-                <a href="{@rdf:about}">
-                    <xsl:apply-templates select="memento:mementoDatetime/text()"/>
-                </a>
+                <xsl:choose>
+                    <!-- the version being viewed: bold, no self-link -->
+                    <xsl:when test="@rdf:about = $current-memento">
+                        <strong>
+                            <xsl:apply-templates select="memento:mementoDatetime/text()"/>
+                        </strong>
+                    </xsl:when>
+                    <xsl:otherwise>
+                        <a href="{@rdf:about}">
+                            <xsl:apply-templates select="memento:mementoDatetime/text()"/>
+                        </a>
+                    </xsl:otherwise>
+                </xsl:choose>
             </td>
             <td>
                 <xsl:apply-templates select="dct:creator/@rdf:resource"/>

--- a/src/main/webapp/static/com/atomgraph/linkeddatahub/xsl/bootstrap/2.3.2/imports/memento.xsl
+++ b/src/main/webapp/static/com/atomgraph/linkeddatahub/xsl/bootstrap/2.3.2/imports/memento.xsl
@@ -21,8 +21,8 @@ exclude-result-prefixes="#all"
 
     <!-- a version entry: datetime links to the memento (?version= URI), which navigates like any document link -->
     <xsl:template match="*[@rdf:about][rdf:type/@rdf:resource = '&memento;Memento']" mode="bs2:MementoList">
-        <!-- the memento URI of the version currently being viewed, when a ?version= view is active -->
-        <xsl:variable name="current-memento" select="if (map:contains(ldh:query-params(), 'version')) then xs:anyURI(ac:absolute-path(ldh:request-uri()) || '?version=' || ldh:query-params()?version) else ()" as="xs:anyURI?"/>
+        <!-- the memento URI of the version currently being viewed; when the live document is viewed, callers pass the latest memento -->
+        <xsl:param name="current-memento" select="if (map:contains(ldh:query-params(), 'version')) then xs:anyURI(ac:absolute-path(ldh:request-uri()) || '?version=' || ldh:query-params()?version) else ()" as="xs:anyURI?"/>
 
         <tr>
             <td>

--- a/src/main/webapp/static/com/atomgraph/linkeddatahub/xsl/bootstrap/2.3.2/layout.xsl
+++ b/src/main/webapp/static/com/atomgraph/linkeddatahub/xsl/bootstrap/2.3.2/layout.xsl
@@ -94,6 +94,7 @@ exclude-result-prefixes="#all">
     <xsl:import href="imports/sp.xsl"/>
     <xsl:import href="imports/sh.xsl"/>
     <xsl:import href="imports/lapp.xsl"/>
+    <xsl:import href="imports/memento.xsl"/>
     <xsl:import href="imports/services/youtube.xsl"/>
     <xsl:import href="document.xsl"/>
 

--- a/src/main/webapp/static/com/atomgraph/linkeddatahub/xsl/bootstrap/2.3.2/translations.rdf
+++ b/src/main/webapp/static/com/atomgraph/linkeddatahub/xsl/bootstrap/2.3.2/translations.rdf
@@ -521,4 +521,12 @@
         <rdfs:label xml:lang="en-US">Agent</rdfs:label>
         <rdfs:label xml:lang="es-ES">Agente</rdfs:label>
     </rdf:Description>
+    <rdf:Description rdf:nodeID="historical-version-notice">
+        <rdfs:label xml:lang="en-US">You are viewing a read-only historical version of this document</rdfs:label>
+        <rdfs:label xml:lang="es-ES">Está viendo una versión histórica de solo lectura de este documento</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:nodeID="view-current-version">
+        <rdfs:label xml:lang="en-US">View the current version</rdfs:label>
+        <rdfs:label xml:lang="es-ES">Ver la versión actual</rdfs:label>
+    </rdf:Description>
 </rdf:RDF>

--- a/src/main/webapp/static/com/atomgraph/linkeddatahub/xsl/bootstrap/2.3.2/translations.rdf
+++ b/src/main/webapp/static/com/atomgraph/linkeddatahub/xsl/bootstrap/2.3.2/translations.rdf
@@ -505,4 +505,20 @@
         <rdfs:label xml:lang="en-US">Error during query execution:</rdfs:label>
         <rdfs:label xml:lang="es-ES">Error durante la ejecución de la consulta:</rdfs:label>
     </rdf:Description>
+    <rdf:Description rdf:nodeID="history">
+        <rdfs:label xml:lang="en-US">History</rdfs:label>
+        <rdfs:label xml:lang="es-ES">Historial</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:nodeID="history-description">
+        <rdfs:label xml:lang="en-US">Every change to this document is saved as a version. Click a version to view the document as it was at that time.</rdfs:label>
+        <rdfs:label xml:lang="es-ES">Cada cambio en este documento se guarda como una versión. Haga clic en una versión para ver el documento tal como era en ese momento.</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:nodeID="version">
+        <rdfs:label xml:lang="en-US">Version</rdfs:label>
+        <rdfs:label xml:lang="es-ES">Versión</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:nodeID="agent">
+        <rdfs:label xml:lang="en-US">Agent</rdfs:label>
+        <rdfs:label xml:lang="es-ES">Agente</rdfs:label>
+    </rdf:Description>
 </rdf:RDF>

--- a/src/main/webapp/static/com/atomgraph/linkeddatahub/xsl/client.xsl
+++ b/src/main/webapp/static/com/atomgraph/linkeddatahub/xsl/client.xsl
@@ -326,13 +326,20 @@ WHERE
                     </xsl:for-each>
                 </xsl:if>
 
-                <!-- doc URI: proxied target if ?uri= set (keep its query — part of the resource identity), else local request URI (strip display params).
-                     fragment: always from the OUTER URL (ldh:request-uri()) per RFC 3986 — LDH-built URLs put the fragment outside ?uri= -->
-                <xsl:call-template name="ldh:DocumentNavigate">
-                    <xsl:with-param name="doc-uri" select="if (ac:uri()) then ac:document-uri(ac:uri()) else ac:absolute-path(ldh:request-uri())"/>
-                    <xsl:with-param name="fragment" select="ac:fragment-id(ldh:request-uri())"/>
-                    <xsl:with-param name="push-state" select="false()"/>
-                </xsl:call-template>
+                <xsl:choose>
+                    <!-- historical version (?version=) or TimeMap (?timemap) view of a local document: the server-rendered snapshot is the content.
+                         Re-fetching would load the *live* document over it and rewrite the URL (ldh:rdf-document-response pushes mode-only URLs). -->
+                    <xsl:when test="not(ac:uri()) and (map:contains(ldh:query-params(), 'version') or map:contains(ldh:query-params(), 'timemap'))"/>
+                    <xsl:otherwise>
+                        <!-- doc URI: proxied target if ?uri= set (keep its query — part of the resource identity), else local request URI (strip display params).
+                             fragment: always from the OUTER URL (ldh:request-uri()) per RFC 3986 — LDH-built URLs put the fragment outside ?uri= -->
+                        <xsl:call-template name="ldh:DocumentNavigate">
+                            <xsl:with-param name="doc-uri" select="if (ac:uri()) then ac:document-uri(ac:uri()) else ac:absolute-path(ldh:request-uri())"/>
+                            <xsl:with-param name="fragment" select="ac:fragment-id(ldh:request-uri())"/>
+                            <xsl:with-param name="push-state" select="false()"/>
+                        </xsl:call-template>
+                    </xsl:otherwise>
+                </xsl:choose>
             </xsl:otherwise>
         </xsl:choose>
     </xsl:template>

--- a/src/main/webapp/static/com/atomgraph/linkeddatahub/xsl/client.xsl
+++ b/src/main/webapp/static/com/atomgraph/linkeddatahub/xsl/client.xsl
@@ -326,20 +326,14 @@ WHERE
                     </xsl:for-each>
                 </xsl:if>
 
-                <xsl:choose>
-                    <!-- historical version (?version=) or TimeMap (?timemap) view of a local document: the server-rendered snapshot is the content.
-                         Re-fetching would load the *live* document over it and rewrite the URL (ldh:rdf-document-response pushes mode-only URLs). -->
-                    <xsl:when test="not(ac:uri()) and (map:contains(ldh:query-params(), 'version') or map:contains(ldh:query-params(), 'timemap'))"/>
-                    <xsl:otherwise>
-                        <!-- doc URI: proxied target if ?uri= set (keep its query — part of the resource identity), else local request URI (strip display params).
-                             fragment: always from the OUTER URL (ldh:request-uri()) per RFC 3986 — LDH-built URLs put the fragment outside ?uri= -->
-                        <xsl:call-template name="ldh:DocumentNavigate">
-                            <xsl:with-param name="doc-uri" select="if (ac:uri()) then ac:document-uri(ac:uri()) else ac:absolute-path(ldh:request-uri())"/>
-                            <xsl:with-param name="fragment" select="ac:fragment-id(ldh:request-uri())"/>
-                            <xsl:with-param name="push-state" select="false()"/>
-                        </xsl:call-template>
-                    </xsl:otherwise>
-                </xsl:choose>
+                <!-- doc URI: proxied target if ?uri= set (keep its query — part of the resource identity), else local request URI (strip display params, keep representation-selecting ones).
+                     fragment: always from the OUTER URL (ldh:request-uri()) per RFC 3986 — LDH-built URLs put the fragment outside ?uri= -->
+                <xsl:call-template name="ldh:DocumentNavigate">
+                    <xsl:with-param name="doc-uri" select="if (ac:uri()) then ac:document-uri(ac:uri()) else ac:absolute-path(ldh:request-uri())"/>
+                    <xsl:with-param name="fragment" select="ac:fragment-id(ldh:request-uri())"/>
+                    <xsl:with-param name="query-params" select="if (ac:uri()) then map{} else ldh:query-params()"/>
+                    <xsl:with-param name="push-state" select="false()"/>
+                </xsl:call-template>
             </xsl:otherwise>
         </xsl:choose>
     </xsl:template>
@@ -418,6 +412,7 @@ WHERE
         <xsl:variable name="response" select="$context('response')" as="map(*)"/>
         <xsl:variable name="doc-uri" select="$context('doc-uri')" as="xs:anyURI"/>
         <xsl:variable name="fragment" select="$context('fragment')" as="xs:string?"/>
+        <xsl:variable name="query-params" select="if (map:contains($context, 'query-params')) then $context('query-params') else map{}" as="map(xs:string, xs:string*)"/>
         <xsl:variable name="refresh-content" select="$context('refresh-content')" as="xs:boolean?"/>
 
         <xsl:for-each select="$response">
@@ -473,7 +468,7 @@ WHERE
 
                         <!-- align URL with the mode detected from the RDF document -->
                         <xsl:call-template name="ldh:PushState">
-                            <xsl:with-param name="href" select="ldh:href($doc-uri, ldh:build-query($mode), $fragment)"/>
+                            <xsl:with-param name="href" select="ldh:href($doc-uri, map:merge(($query-params, ldh:build-query($mode))), $fragment)"/>
                             <xsl:with-param name="title" select="$label"/>
                             <xsl:with-param name="container" select="id($body-id, ixsl:page())"/>
                         </xsl:call-template>
@@ -661,7 +656,7 @@ WHERE
                     <ixsl:set-property name="title" select="$label" object="ixsl:page()"/>
 
                     <xsl:call-template name="ldh:PushState">
-                        <xsl:with-param name="href" select="ldh:href($doc-uri, ldh:build-query($mode), $fragment)"/>
+                        <xsl:with-param name="href" select="ldh:href($doc-uri, map:merge(($query-params, ldh:build-query($mode))), $fragment)"/>
                         <xsl:with-param name="title" select="$label"/>
                         <xsl:with-param name="container" select="id($body-id, ixsl:page())"/>
                     </xsl:call-template>
@@ -1001,6 +996,7 @@ WHERE
         <xsl:call-template name="ldh:RDFDocumentLoad">
             <xsl:with-param name="doc-uri" select="$doc-uri"/>
             <xsl:with-param name="fragment" select="$fragment"/>
+            <xsl:with-param name="query-params" select="$query-params"/>
             <xsl:with-param name="controller" select="$controller"/>
         </xsl:call-template>
     </xsl:template>
@@ -1010,17 +1006,21 @@ WHERE
     <xsl:template name="ldh:RDFDocumentLoad">
         <xsl:param name="doc-uri" as="xs:anyURI"/>
         <xsl:param name="fragment" as="xs:string?"/>
+        <xsl:param name="query-params" select="map{}" as="map(xs:string, xs:string*)"/>
         <xsl:param name="refresh-content" as="xs:boolean?"/>
         <xsl:param name="controller" select="ixsl:get(ixsl:get(ixsl:window(), 'LinkedDataHub'), 'saxonController')"/>
+        <!-- representation-selecting params (?version=, ?timemap) ride along on the RDF request; display params do not -->
+        <xsl:variable name="snapshot-params" select="ldh:snapshot-params($query-params)" as="map(xs:string, xs:string*)"/>
         <!-- if the URI is external, dereference it through the proxy -->
         <!-- HTTP requests carry no fragment (protocol-level) -->
-        <xsl:variable name="request-uri" select="ldh:href($doc-uri, map{}, ())" as="xs:anyURI"/>
+        <xsl:variable name="request-uri" select="ldh:href($doc-uri, $snapshot-params, ())" as="xs:anyURI"/>
         <xsl:variable name="request" select="map{ 'method': 'GET', 'href': $request-uri, 'headers': map{ 'Accept': 'application/rdf+xml' } }" as="map(*)"/>
         <xsl:variable name="context" as="map(*)" select="
           map{
             'request': $request,
             'doc-uri': $doc-uri,
             'fragment': $fragment,
+            'query-params': $snapshot-params,
             'refresh-content': $refresh-content,
             'endpoint': sd:endpoint()
           }"/>

--- a/src/main/webapp/static/com/atomgraph/linkeddatahub/xsl/client.xsl
+++ b/src/main/webapp/static/com/atomgraph/linkeddatahub/xsl/client.xsl
@@ -102,6 +102,7 @@ extension-element-prefixes="ixsl"
     <xsl:import href="bootstrap/2.3.2/imports/sioc.xsl"/>
     <xsl:import href="bootstrap/2.3.2/imports/sp.xsl"/>
     <xsl:import href="bootstrap/2.3.2/imports/sh.xsl"/>
+    <xsl:import href="bootstrap/2.3.2/imports/memento.xsl"/>
     <xsl:import href="bootstrap/2.3.2/document.xsl"/>
     <xsl:import href="bootstrap/2.3.2/imports/services/youtube.xsl"/>
     <xsl:import href="converters/RDFXML2DataTable.xsl"/>
@@ -116,6 +117,7 @@ extension-element-prefixes="ixsl"
     <xsl:include href="bootstrap/2.3.2/client/navigation.xsl"/>
     <xsl:include href="bootstrap/2.3.2/client/block.xsl"/>
     <xsl:include href="bootstrap/2.3.2/client/modal.xsl"/>
+    <xsl:include href="bootstrap/2.3.2/client/memento.xsl"/>
     <xsl:include href="bootstrap/2.3.2/client/form.xsl"/>
     <xsl:include href="bootstrap/2.3.2/client/map.xsl"/> <!-- include in view.xsl and object.xsl instead? -->
     <xsl:include href="bootstrap/2.3.2/client/graph3d.xsl"/>
@@ -439,6 +441,10 @@ WHERE
                     <xsl:if test="$application">
                         <ixsl:set-property name="application" select="$application" object="ixsl:get(ixsl:window(), 'LinkedDataHub')"/>
                     </xsl:if>
+                    <!-- store TimeMap URI from Link header (present when the document is versioned); blank it when absent so non-versioned documents don't show the History link -->
+                    <xsl:variable name="timemap-link" select="tokenize(?headers?link, ',')[contains(., 'mementoweb.org/ns#timemap')][1]" as="xs:string?"/>
+                    <xsl:variable name="timemap" select="if ($timemap-link) then xs:anyURI(substring-before(substring-after(substring-before($timemap-link, ';'), '&lt;'), '&gt;')) else ()" as="xs:anyURI?"/>
+                    <ixsl:set-property name="timemap" select="($timemap, '')[1]" object="ixsl:get(ixsl:window(), 'LinkedDataHub')"/>
                     <xsl:for-each select="?body">
                         <xsl:variable name="results" select="." as="document-node()"/>
                         <ixsl:set-property name="{'`' || $doc-uri || '`'}" select="ldh:new-object()" object="ixsl:get(ixsl:window(), 'LinkedDataHub.contents')"/>

--- a/src/test/java/com/atomgraph/linkeddatahub/client/GitHubClientTest.java
+++ b/src/test/java/com/atomgraph/linkeddatahub/client/GitHubClientTest.java
@@ -144,6 +144,21 @@ public class GitHubClientTest
             return;
         }
 
+        if (path.equals("/repos/acme/graphs/commits"))
+        {
+            respond(exchange, 200, Json.createArrayBuilder().
+                add(Json.createObjectBuilder().
+                    add("sha", "sha-2").
+                    add("commit", Json.createObjectBuilder().
+                        add("author", Json.createObjectBuilder().add("date", "2026-08-17T11:00:00Z").add("name", "https://localhost/agent#this")))).
+                add(Json.createObjectBuilder().
+                    add("sha", "sha-1").
+                    add("commit", Json.createObjectBuilder().
+                        add("author", Json.createObjectBuilder().add("date", "2026-08-17T10:00:00Z").add("name", "https://localhost/agent#this")))).
+                build().toString());
+            return;
+        }
+
         if (path.startsWith("/repos/acme/graphs/commits/"))
         {
             respond(exchange, 200, Json.createObjectBuilder().
@@ -254,6 +269,16 @@ public class GitHubClientTest
     public void testGetCommitDate()
     {
         assertEquals(Optional.of(Instant.parse("2026-08-17T10:00:00Z")), gitHubClient.getCommitDate("commit-1"));
+    }
+
+    @Test
+    public void testListCommits()
+    {
+        var commits = gitHubClient.listCommits("graphs/doc.nt");
+
+        assertEquals(2, commits.size());
+        assertEquals(new GitHubClient.CommitInfo("sha-2", Instant.parse("2026-08-17T11:00:00Z"), "https://localhost/agent#this"), commits.get(0));
+        assertTrue(received.get(0).uri().contains("path=graphs") && received.get(0).uri().contains("sha=main"));
     }
 
 }

--- a/src/test/java/com/atomgraph/linkeddatahub/client/GitHubClientTest.java
+++ b/src/test/java/com/atomgraph/linkeddatahub/client/GitHubClientTest.java
@@ -1,0 +1,259 @@
+/**
+ *  Copyright 2026 Martynas Jusevičius <martynas@atomgraph.com>
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ */
+package com.atomgraph.linkeddatahub.client;
+
+import com.sun.net.httpserver.HttpExchange;
+import com.sun.net.httpserver.HttpServer;
+import jakarta.json.Json;
+import jakarta.json.JsonObject;
+import jakarta.ws.rs.client.Client;
+import jakarta.ws.rs.client.ClientBuilder;
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.InetSocketAddress;
+import java.net.URI;
+import java.nio.charset.StandardCharsets;
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.Base64;
+import java.util.List;
+import java.util.Optional;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Tests the GitHub API client against a local fake server.
+ *
+ * @author Martynas Jusevičius {@literal <martynas@atomgraph.com>}
+ */
+public class GitHubClientTest
+{
+
+    private HttpServer server;
+    private Client httpClient;
+    private GitHubClient gitHubClient;
+
+    /** Requests received by the fake server: method, path+query, Accept header, body */
+    private record Received(String method, String uri, String accept, String body) { }
+    private final List<Received> received = new ArrayList<>();
+
+    private String fileSha = null; // null = file does not exist on the fake server
+    private byte[] fileContent = null;
+    private int rateLimitResponses = 0; // number of upcoming requests to answer with 429
+
+    @BeforeEach
+    public void setUp() throws IOException
+    {
+        server = HttpServer.create(new InetSocketAddress(0), 0);
+        server.createContext("/", this::handle);
+        server.start();
+
+        httpClient = ClientBuilder.newClient();
+        gitHubClient = new GitHubClient(httpClient, URI.create("http://localhost:" + server.getAddress().getPort()),
+            "test-token", "acme", "graphs", "main");
+    }
+
+    @AfterEach
+    public void tearDown()
+    {
+        httpClient.close();
+        server.stop(0);
+    }
+
+    private void handle(HttpExchange exchange) throws IOException
+    {
+        String body;
+        try (InputStream in = exchange.getRequestBody())
+        {
+            body = new String(in.readAllBytes(), StandardCharsets.UTF_8);
+        }
+        received.add(new Received(exchange.getRequestMethod(), exchange.getRequestURI().toString(),
+            exchange.getRequestHeaders().getFirst("Accept"), body));
+
+        if (rateLimitResponses > 0)
+        {
+            rateLimitResponses--;
+            exchange.getResponseHeaders().set("Retry-After", "0");
+            exchange.sendResponseHeaders(429, -1);
+            exchange.close();
+            return;
+        }
+
+        String path = exchange.getRequestURI().getPath();
+        String method = exchange.getRequestMethod();
+
+        if (path.startsWith("/repos/acme/graphs/contents/"))
+        {
+            switch (method)
+            {
+                case "GET" ->
+                {
+                    if (fileSha == null)
+                    {
+                        respond(exchange, 404, "{\"message\": \"Not Found\"}");
+                        return;
+                    }
+                    if ("application/vnd.github.raw+json".equals(exchange.getRequestHeaders().getFirst("Accept")))
+                    {
+                        exchange.getResponseHeaders().set("Content-Type", "application/vnd.github.raw+json");
+                        exchange.sendResponseHeaders(200, fileContent.length);
+                        exchange.getResponseBody().write(fileContent);
+                        exchange.close();
+                        return;
+                    }
+                    respond(exchange, 200, Json.createObjectBuilder().add("sha", fileSha).build().toString());
+                }
+                case "PUT" ->
+                {
+                    JsonObject json = Json.createReader(new ByteArrayInputStream(body.getBytes(StandardCharsets.UTF_8))).readObject();
+                    boolean creating = fileSha == null;
+                    fileContent = Base64.getDecoder().decode(json.getString("content"));
+                    fileSha = "blob-" + received.size();
+                    respond(exchange, creating ? 201 : 200, Json.createObjectBuilder().
+                        add("commit", Json.createObjectBuilder().add("sha", "commit-" + received.size())).
+                        add("content", Json.createObjectBuilder().add("sha", fileSha)).
+                        build().toString());
+                }
+                case "DELETE" ->
+                {
+                    fileSha = null;
+                    fileContent = null;
+                    respond(exchange, 200, "{}");
+                }
+                default -> respond(exchange, 405, "{}");
+            }
+            return;
+        }
+
+        if (path.startsWith("/repos/acme/graphs/commits/"))
+        {
+            respond(exchange, 200, Json.createObjectBuilder().
+                add("commit", Json.createObjectBuilder().
+                    add("committer", Json.createObjectBuilder().add("date", "2026-08-17T10:00:00Z"))).
+                build().toString());
+            return;
+        }
+
+        respond(exchange, 404, "{}");
+    }
+
+    private void respond(HttpExchange exchange, int status, String json) throws IOException
+    {
+        byte[] bytes = json.getBytes(StandardCharsets.UTF_8);
+        exchange.getResponseHeaders().set("Content-Type", "application/json");
+        exchange.sendResponseHeaders(status, bytes.length);
+        exchange.getResponseBody().write(bytes);
+        exchange.close();
+    }
+
+    @Test
+    public void testPutFileCreatesWithoutSha()
+    {
+        GitHubClient.Commit commit = gitHubClient.putFile("graphs/doc.nt", "<a> <b> <c> .\n".getBytes(StandardCharsets.UTF_8), "PUT https://localhost/doc/", "https://localhost/agent#this");
+
+        // create: SHA probe 404s, then PUT without "sha"
+        assertEquals(2, received.size());
+        assertEquals("GET", received.get(0).method());
+        assertEquals("PUT", received.get(1).method());
+        JsonObject put = Json.createReader(new ByteArrayInputStream(received.get(1).body().getBytes(StandardCharsets.UTF_8))).readObject();
+        assertTrue(!put.containsKey("sha"));
+        assertEquals("main", put.getString("branch"));
+        assertEquals("https://localhost/agent#this", put.getJsonObject("author").getString("name"));
+        assertEquals("<a> <b> <c> .\n", new String(Base64.getDecoder().decode(put.getString("content")), StandardCharsets.UTF_8));
+        assertEquals("commit-2", commit.commitSha());
+    }
+
+    @Test
+    public void testPutFileUpdatesWithSha()
+    {
+        gitHubClient.putFile("graphs/doc.nt", "v1".getBytes(StandardCharsets.UTF_8), "PUT", "agent");
+        received.clear();
+
+        gitHubClient.putFile("graphs/doc.nt", "v2".getBytes(StandardCharsets.UTF_8), "PUT", "agent");
+
+        // update: SHA probe succeeds, then PUT with "sha"
+        assertEquals(2, received.size());
+        JsonObject put = Json.createReader(new ByteArrayInputStream(received.get(1).body().getBytes(StandardCharsets.UTF_8))).readObject();
+        assertTrue(put.containsKey("sha"));
+        assertArrayEquals("v2".getBytes(StandardCharsets.UTF_8), fileContent);
+    }
+
+    @Test
+    public void testGetFileAtCommitUsesRawMediaType()
+    {
+        gitHubClient.putFile("graphs/doc.nt", "raw content".getBytes(StandardCharsets.UTF_8), "PUT", "agent");
+        received.clear();
+
+        Optional<byte[]> content = gitHubClient.getFileAtCommit("graphs/doc.nt", "commit-2");
+
+        assertArrayEquals("raw content".getBytes(StandardCharsets.UTF_8), content.get());
+        assertEquals("application/vnd.github.raw+json", received.get(0).accept());
+    }
+
+    @Test
+    public void testGetFileAtCommitNotFound()
+    {
+        assertTrue(gitHubClient.getFileAtCommit("graphs/missing.nt", "commit-1").isEmpty());
+    }
+
+    @Test
+    public void testDeleteFile()
+    {
+        gitHubClient.putFile("graphs/doc.nt", "v1".getBytes(StandardCharsets.UTF_8), "PUT", "agent");
+        received.clear();
+
+        gitHubClient.deleteFile("graphs/doc.nt", "DELETE https://localhost/doc/", "agent");
+
+        assertEquals(2, received.size()); // SHA probe + DELETE
+        assertEquals("DELETE", received.get(1).method());
+        JsonObject delete = Json.createReader(new ByteArrayInputStream(received.get(1).body().getBytes(StandardCharsets.UTF_8))).readObject();
+        assertTrue(delete.containsKey("sha"));
+    }
+
+    @Test
+    public void testDeleteMissingFileIsNoOp()
+    {
+        gitHubClient.deleteFile("graphs/missing.nt", "DELETE", "agent");
+
+        assertEquals(1, received.size()); // only the SHA probe, no DELETE
+    }
+
+    @Test
+    public void testRateLimitedRequestIsRetried()
+    {
+        gitHubClient.putFile("graphs/doc.nt", "v1".getBytes(StandardCharsets.UTF_8), "PUT", "agent");
+        received.clear();
+        rateLimitResponses = 1;
+
+        Optional<byte[]> content = gitHubClient.getFileAtCommit("graphs/doc.nt", "commit-2");
+
+        assertTrue(content.isPresent());
+        assertEquals(2, received.size()); // 429 response, then the retry
+    }
+
+    @Test
+    public void testGetCommitDate()
+    {
+        assertEquals(Optional.of(Instant.parse("2026-08-17T10:00:00Z")), gitHubClient.getCommitDate("commit-1"));
+    }
+
+}

--- a/src/test/java/com/atomgraph/linkeddatahub/server/filter/response/VersioningFilterTest.java
+++ b/src/test/java/com/atomgraph/linkeddatahub/server/filter/response/VersioningFilterTest.java
@@ -1,0 +1,182 @@
+/**
+ *  Copyright 2026 Martynas Jusevičius <martynas@atomgraph.com>
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ */
+package com.atomgraph.linkeddatahub.server.filter.response;
+
+import com.atomgraph.client.vocabulary.AC;
+import com.atomgraph.linkeddatahub.model.auth.Agent;
+import com.atomgraph.linkeddatahub.model.ServiceContext;
+import com.atomgraph.linkeddatahub.server.model.impl.DocumentHierarchyGraphStoreImpl;
+import com.atomgraph.linkeddatahub.server.util.GraphVersioningService;
+import jakarta.ws.rs.container.ContainerRequestContext;
+import jakarta.ws.rs.container.ContainerResponseContext;
+import jakarta.ws.rs.core.Response;
+import jakarta.ws.rs.core.SecurityContext;
+import jakarta.ws.rs.core.UriInfo;
+import java.io.IOException;
+import java.net.URI;
+import java.util.List;
+import java.util.Optional;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+/**
+ * Tests the fire/skip conditions of the versioning response filter.
+ *
+ * @author Martynas Jusevičius {@literal <martynas@atomgraph.com>}
+ */
+@ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = Strictness.LENIENT)
+public class VersioningFilterTest
+{
+
+    private static final URI BASE_URI = URI.create("https://localhost:4443/");
+    private static final URI DOC_URI = URI.create("https://localhost:4443/docs/one/");
+    private static final String APP_URI = "urn:linkeddatahub:apps/end-user";
+
+    @Mock private ContainerRequestContext request;
+    @Mock private ContainerResponseContext response;
+    @Mock private UriInfo uriInfo;
+    @Mock private SecurityContext securityContext;
+    @Mock private Agent agent;
+    @Mock private com.atomgraph.linkeddatahub.Application system;
+    @Mock private com.atomgraph.linkeddatahub.apps.model.Application application;
+    @Mock private com.atomgraph.linkeddatahub.model.Service service;
+    @Mock private ServiceContext serviceContext;
+    @Mock private GraphVersioningService versioningService;
+    @Mock private DocumentHierarchyGraphStoreImpl graphStore;
+
+    private VersioningFilter filter;
+
+    @BeforeEach
+    public void setUp()
+    {
+        filter = new VersioningFilter();
+        filter.system = system;
+        filter.app = () -> Optional.of(application);
+
+        // a qualifying document write; individual tests break one condition at a time
+        when(request.getMethod()).thenReturn("PUT");
+        when(request.getProperty(AC.uri.getURI())).thenReturn(null);
+        when(request.getUriInfo()).thenReturn(uriInfo);
+        when(request.getSecurityContext()).thenReturn(securityContext);
+        when(response.getStatusInfo()).thenReturn(Response.Status.CREATED);
+        when(uriInfo.getMatchedResources()).thenReturn(List.of(graphStore));
+        when(uriInfo.getAbsolutePath()).thenReturn(DOC_URI);
+        when(securityContext.getUserPrincipal()).thenReturn(agent);
+        when(agent.getURI()).thenReturn("https://localhost:4443/agents/one/#this");
+        when(application.getURI()).thenReturn(APP_URI);
+        when(application.getBaseURI()).thenReturn(BASE_URI);
+        when(application.getService()).thenReturn(service);
+        when(system.getGraphVersioningService()).thenReturn(versioningService);
+        when(system.getServiceContext(service)).thenReturn(serviceContext);
+        when(versioningService.getRepository(APP_URI)).thenReturn(Optional.of(new GraphVersioningService.Repository(null, "graphs")));
+    }
+
+    @Test
+    public void testQualifyingWriteSchedulesCommit() throws IOException
+    {
+        filter.filter(request, response);
+
+        verify(versioningService).commitAsync(serviceContext, APP_URI, BASE_URI, DOC_URI, "https://localhost:4443/agents/one/#this", "PUT");
+    }
+
+    @Test
+    public void testGetIsSkipped() throws IOException
+    {
+        when(request.getMethod()).thenReturn("GET");
+
+        filter.filter(request, response);
+
+        verifyNoCommit();
+    }
+
+    @Test
+    public void testRedirectIsSkipped() throws IOException
+    {
+        when(response.getStatusInfo()).thenReturn(Response.Status.PERMANENT_REDIRECT);
+
+        filter.filter(request, response);
+
+        verifyNoCommit();
+    }
+
+    @Test
+    public void testErrorResponseIsSkipped() throws IOException
+    {
+        when(response.getStatusInfo()).thenReturn(Response.Status.FORBIDDEN);
+
+        filter.filter(request, response);
+
+        verifyNoCommit();
+    }
+
+    @Test
+    public void testProxyRequestIsSkipped() throws IOException
+    {
+        when(request.getProperty(AC.uri.getURI())).thenReturn(URI.create("https://remote.example/doc"));
+
+        filter.filter(request, response);
+
+        verifyNoCommit();
+    }
+
+    @Test
+    public void testUnmatchedApplicationIsSkipped() throws IOException
+    {
+        filter.app = () -> Optional.empty();
+
+        filter.filter(request, response);
+
+        verifyNoCommit();
+    }
+
+    @Test
+    public void testNonDocumentResourceIsSkipped() throws IOException
+    {
+        when(uriInfo.getMatchedResources()).thenReturn(List.of(new Object())); // e.g. the SPARQL endpoint or Settings resource
+
+        filter.filter(request, response);
+
+        verifyNoCommit();
+    }
+
+    @Test
+    public void testUnconfiguredApplicationIsSkipped() throws IOException
+    {
+        when(versioningService.getRepository(APP_URI)).thenReturn(Optional.empty());
+
+        filter.filter(request, response);
+
+        verifyNoCommit();
+    }
+
+    private void verifyNoCommit()
+    {
+        verify(versioningService, never()).commitAsync(any(), anyString(), any(), any(), anyString(), anyString());
+    }
+
+}

--- a/src/test/java/com/atomgraph/linkeddatahub/server/util/GraphVersioningServiceTest.java
+++ b/src/test/java/com/atomgraph/linkeddatahub/server/util/GraphVersioningServiceTest.java
@@ -16,10 +16,15 @@
  */
 package com.atomgraph.linkeddatahub.server.util;
 
+import com.atomgraph.linkeddatahub.client.GitHubClient;
+import com.atomgraph.linkeddatahub.vocabulary.MEM;
 import java.net.URI;
 import java.nio.charset.StandardCharsets;
+import java.time.Instant;
+import java.util.List;
 import org.apache.jena.rdf.model.Model;
 import org.apache.jena.rdf.model.ModelFactory;
+import org.apache.jena.rdf.model.Resource;
 import org.apache.jena.rdf.model.ResourceFactory;
 import org.apache.jena.vocabulary.DCTerms;
 import org.apache.jena.vocabulary.RDF;
@@ -84,6 +89,25 @@ public class GraphVersioningServiceTest
         String[] lines = new String(GraphVersioningService.toSortedNTriples(model), StandardCharsets.UTF_8).split("\n");
         assertEquals(2, lines.length);
         assertTrue(lines[0].compareTo(lines[1]) < 0);
+    }
+
+    @Test
+    public void testTimeMap()
+    {
+        URI graphURI = URI.create("https://localhost:4443/doc/");
+        Model model = GraphVersioningService.toTimeMap(graphURI, List.of(
+            new GitHubClient.CommitInfo("sha-2", Instant.parse("2026-08-17T11:00:00Z"), "https://localhost/agent#this"),
+            new GitHubClient.CommitInfo("sha-1", Instant.parse("2026-08-17T10:00:00Z"), "Not A URI")));
+
+        Resource timeMap = model.createResource("https://localhost:4443/doc/?timemap");
+        Resource memento = model.createResource("https://localhost:4443/doc/?version=sha-2");
+        assertTrue(model.contains(timeMap, RDF.type, MEM.TimeMap));
+        assertTrue(model.contains(memento, RDF.type, MEM.Memento));
+        assertTrue(model.contains(memento, MEM.original, model.createResource(graphURI.toString())));
+        assertEquals("2026-08-17T11:00:00Z", memento.getProperty(MEM.mementoDatetime).getString());
+        assertEquals("https://localhost/agent#this", memento.getPropertyResourceValue(DCTerms.creator).getURI());
+        // the non-URI author name must not become a creator resource
+        assertTrue(model.createResource("https://localhost:4443/doc/?version=sha-1").getPropertyResourceValue(DCTerms.creator) == null);
     }
 
     @Test

--- a/src/test/java/com/atomgraph/linkeddatahub/server/util/GraphVersioningServiceTest.java
+++ b/src/test/java/com/atomgraph/linkeddatahub/server/util/GraphVersioningServiceTest.java
@@ -1,0 +1,101 @@
+/**
+ *  Copyright 2026 Martynas Jusevičius <martynas@atomgraph.com>
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ */
+package com.atomgraph.linkeddatahub.server.util;
+
+import java.net.URI;
+import java.nio.charset.StandardCharsets;
+import org.apache.jena.rdf.model.Model;
+import org.apache.jena.rdf.model.ModelFactory;
+import org.apache.jena.rdf.model.ResourceFactory;
+import org.apache.jena.vocabulary.DCTerms;
+import org.apache.jena.vocabulary.RDF;
+import org.apache.jena.vocabulary.RDFS;
+import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Tests the pure graph-to-file mapping and serialization methods.
+ *
+ * @author Martynas Jusevičius {@literal <martynas@atomgraph.com>}
+ */
+public class GraphVersioningServiceTest
+{
+
+    private static final URI BASE = URI.create("https://localhost:4443/");
+
+    @Test
+    public void testContainerPath()
+    {
+        assertEquals("graphs/data/products.nt", GraphVersioningService.path("graphs", BASE, URI.create("https://localhost:4443/data/products/")));
+    }
+
+    @Test
+    public void testNestedPath()
+    {
+        assertEquals("graphs/data/products/one.nt", GraphVersioningService.path("graphs", BASE, URI.create("https://localhost:4443/data/products/one/")));
+    }
+
+    @Test
+    public void testBasePath()
+    {
+        assertEquals("graphs/root.nt", GraphVersioningService.path("graphs", BASE, BASE));
+    }
+
+    @Test
+    public void testSortedNTriplesIsDeterministic()
+    {
+        Model first = ModelFactory.createDefaultModel();
+        first.add(first.createResource("https://localhost:4443/doc/"), RDF.type, first.createResource("https://www.w3.org/ns/ldt/document-hierarchy#Item"));
+        first.add(first.createResource("https://localhost:4443/doc/"), DCTerms.title, "Document");
+        first.add(first.createResource("https://localhost:4443/doc/"), RDFS.seeAlso, first.createResource("https://localhost:4443/other/"));
+
+        // same statements, inserted in a different order
+        Model second = ModelFactory.createDefaultModel();
+        second.add(second.createResource("https://localhost:4443/doc/"), RDFS.seeAlso, second.createResource("https://localhost:4443/other/"));
+        second.add(second.createResource("https://localhost:4443/doc/"), DCTerms.title, "Document");
+        second.add(second.createResource("https://localhost:4443/doc/"), RDF.type, second.createResource("https://www.w3.org/ns/ldt/document-hierarchy#Item"));
+
+        assertArrayEquals(GraphVersioningService.toSortedNTriples(first), GraphVersioningService.toSortedNTriples(second));
+    }
+
+    @Test
+    public void testSortedNTriplesLinesAreSorted()
+    {
+        Model model = ModelFactory.createDefaultModel();
+        model.add(model.createResource("https://localhost:4443/z/"), DCTerms.title, "Z");
+        model.add(model.createResource("https://localhost:4443/a/"), DCTerms.title, "A");
+
+        String[] lines = new String(GraphVersioningService.toSortedNTriples(model), StandardCharsets.UTF_8).split("\n");
+        assertEquals(2, lines.length);
+        assertTrue(lines[0].compareTo(lines[1]) < 0);
+    }
+
+    @Test
+    public void testSortedNTriplesRoundTrips()
+    {
+        Model model = ModelFactory.createDefaultModel();
+        model.add(model.createResource("https://localhost:4443/doc/"), DCTerms.title, ResourceFactory.createLangLiteral("multi\nline", "en"));
+
+        Model parsed = ModelFactory.createDefaultModel();
+        parsed.read(new java.io.ByteArrayInputStream(GraphVersioningService.toSortedNTriples(model)), null, "N-TRIPLES");
+
+        assertTrue(model.isIsomorphicWith(parsed));
+    }
+
+}


### PR DESCRIPTION
Closes the audit roadmap's history/undo/audit-trail gap (P2.2) per the wiki [implementation plan v1.3](https://github.com/AtomGraph/LinkedDataHub/wiki/Graph-Versioning-Implementation-Plan).

## Capture

Every document write (`POST`/`PUT`/`PATCH`/`DELETE`) on a versioning-enabled dataspace schedules an async **reconcile task**: re-read the graph from the store, commit it as a **sorted N-Triples** file to a GitHub repository (graph gone → file deleted). Commits are chained per file path so they never race the Contents API's SHA optimistic locking, and are **authored with the agent's WebID** — `git log` is the audit trail. Best-effort by design: failures are logged, responses are never delayed or failed.

Configured per dataspace via `lapp:versioningRepository` → `doap:GitRepository` in `config/system.trig`; the fine-grained token lives in `secrets/credentials.trig` (`a:authToken`), merged at entrypoint like SPARQL service credentials. The GitHub client runs on a new hostname-verified HTTP client factory.

## Retrieval

- `GET <doc>?version=<sha>` serves the historical graph through the normal content-negotiation pipeline with `Memento-Datetime`, a SHA ETag, and immutable `Cache-Control`; restricted to hex commit SHAs (movable refs must not be cached as immutable). Inherits the live document's ACL.
- `GET <doc>?timemap` serves an RFC 7089 **TimeMap** as RDF (Memento vocabulary), built from the repository's commit history; advertised via `Link rel=memento:timemap`, consumed like `acl:mode` in both pipelines.

## History UI

The document's modified-datetime in the action bar becomes a link when the document is versioned; clicking it opens a modal (Request-access-style table, translated strings) listing versions newest-first with the current one marked. Version links navigate in-app: `version`/`timemap` are now **representation-selecting params** (`ldh:snapshot-params()`) threaded through the CSR fetch and every URL rebuild, so snapshot pages render fully — content blocks included — from the historical graph. A banner marks historical views.

## Incidental fixes

- Entrypoint: parse the credentials secret from a `.trig`-suffixed copy (extensionless secret mount made `riot` fail silently and killed startup)
- Date literals no longer render Saxon's `[Language: en]` fallback marker (TO-DO: upstream to Web-Client)

## Testing

- 116 unit tests green, including new coverage: `GitHubClient` against a JDK-built-in fake server, TimeMap model shape, sorted-serialization determinism, `VersioningFilter` fire/skip conditions
- New `http-tests/versioning/` suite (gated on `VERSIONING_TEST_REPO` + `GITHUB_TOKEN`): commit creation with WebID author, `?version=` round-trip with `Memento-Datetime`, TimeMap contents, file deletion
- Verified end-to-end against a live repository: capture, modal, snapshot navigation, immutable caching

Versioning is **off by default** — without `lapp:versioningRepository` config, behavior is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)