### PR TITLE
Inline creation in views

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -123,6 +123,10 @@ Key implementation files:
 
 The SPARQL endpoint forwarding chain ensures ContentMode blocks (charts, maps) query the **remote** app's SPARQL endpoint, not the local one. `LinkedDataHub.endpoint` is reset to the local endpoint by `ldh:HTMLDocumentLoaded` on every HTML page navigation, so there is no stale state when navigating back to local documents.
 
+### UI Conventions
+
+**Form placement follows document membership.** A creation/edit form for a resource that lives (or will live) in its **own document** renders as a modal (`div.modal.modal-constructor` — Container/Item creation, document edit, inline creation in views); a form for a resource being added **to the current document** renders inline in the content body (`ldh:render-add-row-form`, content-block forms). The main content body renders only the current document's content.
+
 ### Key Extension Points
 - **Vocabulary definitions** in `com.atomgraph.linkeddatahub.vocabulary`
 - **Custom resource handlers** in `com.atomgraph.linkeddatahub.resource`

--- a/src/main/resources/com/atomgraph/linkeddatahub/ldh.ttl
+++ b/src/main/resources/com/atomgraph/linkeddatahub/ldh.ttl
@@ -22,7 +22,7 @@
     owl:imports dh:, ac:, <http://spinrdf.org/spin>, foaf:, sd:, nfo:, owl: ;
     rdfs:label "LinkedDataHub ontology" ;
     rdfs:comment "Should be imported and reused by all extending applications" ;
-    owl:versionInfo "1.1.6" .
+    owl:versionInfo "1.1.7" .
 
 # PROPERTIES
 
@@ -103,6 +103,20 @@
     rdfs:range :View ;
     rdfs:label "Inverse property view" ;
     rdfs:comment "Attaches a view to a property for inverse relationships (?value property $about)" ;
+    rdfs:isDefinedBy : .
+
+:container a owl:ObjectProperty ;
+    rdfs:domain :View ;
+    rdfs:range dh:Container ;
+    rdfs:label "Item container" ;
+    rdfs:comment "Container under which instances created inline from the view are stored as child documents" ;
+    rdfs:isDefinedBy : .
+
+:showWhenEmpty a owl:DatatypeProperty ;
+    rdfs:domain :View ;
+    rdfs:range xsd:boolean ;
+    rdfs:label "Show when empty" ;
+    rdfs:comment "Whether the view block is shown when its query returns no results. Defaults to true" ;
     rdfs:isDefinedBy : .
 
 # CLASSES
@@ -324,11 +338,15 @@
       PREFIX spin:  <http://spinrdf.org/spin#>
       PREFIX sp:    <http://spinrdf.org/sp#>
       PREFIX rdfs:  <http://www.w3.org/2000/01/rdf-schema#>
+      PREFIX xsd:   <http://www.w3.org/2001/XMLSchema#>
       PREFIX ac:    <https://w3id.org/atomgraph/client#>
+      PREFIX ldh:   <https://w3id.org/atomgraph/linkeddatahub#>
 
       CONSTRUCT {
           $this spin:query [ a sp:Select ] ;
-              ac:mode [ a rdfs:Resource ] .
+              ac:mode [ a rdfs:Resource ] ;
+              ldh:container [ a rdfs:Resource ] ;
+              ldh:showWhenEmpty [ a xsd:boolean ] .
       }
       WHERE {}""" ;
     rdfs:label "View constructor" ;

--- a/src/main/resources/com/linkeddatahub/packages/skos/ns.ttl
+++ b/src/main/resources/com/linkeddatahub/packages/skos/ns.ttl
@@ -55,7 +55,7 @@ WHERE
         GRAPH ?narrowerGraph
         {
           ?narrower skos:prefLabel ?prefLabel .
-          FILTER (langMatches(lang(?prefLabel), "en"))
+          FILTER (langMatches(lang(?prefLabel), "en") || lang(?prefLabel) = "")
         }
       }
   }
@@ -84,7 +84,7 @@ WHERE
         GRAPH ?broaderGraph
         {
           ?broader skos:prefLabel ?prefLabel .
-          FILTER (langMatches(lang(?prefLabel), "en"))
+          FILTER (langMatches(lang(?prefLabel), "en") || lang(?prefLabel) = "")
         }
       }
   }
@@ -130,7 +130,7 @@ WHERE
         GRAPH ?memberGraph
         {
           ?member skos:prefLabel ?prefLabel .
-          FILTER (langMatches(lang(?prefLabel), "en"))
+          FILTER (langMatches(lang(?prefLabel), "en") || lang(?prefLabel) = "")
         }
       }
   }
@@ -174,7 +174,7 @@ WHERE
   { GRAPH ?graph
       { ?concept  skos:inScheme  $about ;
             skos:prefLabel ?prefLabel .
-        FILTER (langMatches(lang(?prefLabel), "en"))
+        FILTER (langMatches(lang(?prefLabel), "en") || lang(?prefLabel) = "")
       }
   }
 ORDER BY ?prefLabel

--- a/src/main/webapp/static/com/atomgraph/linkeddatahub/xsl/bootstrap/2.3.2/client/block.xsl
+++ b/src/main/webapp/static/com/atomgraph/linkeddatahub/xsl/bootstrap/2.3.2/client/block.xsl
@@ -116,19 +116,28 @@ exclude-result-prefixes="#all"
         ]]>
     </xsl:variable>
     
-    <!-- combined forward + inverse view-block lookup; substitutes VALUES ?type { ... } from the resource's rdf:types -->
+    <!-- combined forward + inverse view-block lookup; substitutes VALUES ?type { ... } from the resource's rdf:types.
+         Besides ?block, binds the inline-creation metadata: attachment ?property, ?inverse direction flag, the ?forClass
+         to construct (property range for forward views, domain for inverse ones) and the view's ldh:container/ldh:showWhenEmpty.
+         Runs against the /ns ontology union, so ldh:container asserted on a package view from the app's own namespace is visible. -->
     <xsl:variable name="ontology-view-query" as="xs:string">
         <![CDATA[
             PREFIX  rdfs: <http://www.w3.org/2000/01/rdf-schema#>
             PREFIX  ldh:  <https://w3id.org/atomgraph/linkeddatahub#>
 
-            SELECT DISTINCT ?block
+            SELECT DISTINCT ?block ?property ?inverse ?forClass ?container ?showWhenEmpty
             WHERE {
               {
                 ?property  ldh:view  ?block .
                   { ?property  rdfs:domain  ?type }
                 UNION
                   { ?property  rdfs:subPropertyOf+/rdfs:domain  ?type }
+                BIND(false AS ?inverse)
+                OPTIONAL {
+                    { ?property  rdfs:range  ?forClass }
+                  UNION
+                    { ?property  rdfs:subPropertyOf+/rdfs:range  ?forClass }
+                }
               }
               UNION
               {
@@ -136,7 +145,15 @@ exclude-result-prefixes="#all"
                   { ?property  rdfs:range  ?type }
                 UNION
                   { ?property  rdfs:subPropertyOf+/rdfs:range  ?type }
+                BIND(true AS ?inverse)
+                OPTIONAL {
+                    { ?property  rdfs:domain  ?forClass }
+                  UNION
+                    { ?property  rdfs:subPropertyOf+/rdfs:domain  ?forClass }
+                }
               }
+              OPTIONAL { ?block  ldh:container  ?container }
+              OPTIONAL { ?block  ldh:showWhenEmpty  ?showWhenEmpty }
             }
         ]]>
         <!-- VALUES ?type goes here -->
@@ -673,13 +690,31 @@ exclude-result-prefixes="#all"
 
         <xsl:if test="$response?status = 200 and $response?media-type = 'application/sparql-results+xml'">
             <xsl:variable name="results" select="$response?body" as="document-node()"/>
-            <xsl:variable name="view-uris" select="distinct-values($results/srx:sparql/srx:results/srx:result/srx:binding[@name = 'block']/srx:uri/xs:anyURI(.))" as="xs:anyURI*"/>
 
-            <xsl:for-each select="$view-uris">
-                <xsl:variable name="view-uri" select="xs:anyURI(.)" as="xs:anyURI"/>
+            <!-- one fetch per view; the first row of each group supplies the inline-creation metadata (multiple ?type/?forClass rows can occur) -->
+            <xsl:for-each-group select="$results/srx:sparql/srx:results/srx:result[srx:binding[@name = 'block']/srx:uri]" group-by="srx:binding[@name = 'block']/srx:uri">
+                <xsl:variable name="view-uri" select="xs:anyURI(current-grouping-key())" as="xs:anyURI"/>
                 <xsl:variable name="view-request-uri" select="ldh:href(ac:document-uri($view-uri), map{})" as="xs:anyURI"/>
                 <xsl:variable name="view-request" select="map{ 'method': 'GET', 'href': $view-request-uri, 'headers': map{ 'Accept': 'application/rdf+xml' } }" as="map(*)"/>
-                <xsl:variable name="view-context" as="map(*)" select="map:merge(($context, map{ 'request': $view-request, 'view-uri': $view-uri }))"/>
+                <!-- ?forClass is read from srx:uri only: bnode ranges (e.g. owl:unionOf lists) cannot be constructed -->
+                <xsl:variable name="view-metadata" as="map(*)*">
+                    <xsl:for-each select="srx:binding[@name = 'property']/srx:uri">
+                        <xsl:sequence select="map{ 'view-property': xs:anyURI(.) }"/>
+                    </xsl:for-each>
+                    <xsl:if test="srx:binding[@name = 'inverse']/srx:literal = 'true'">
+                        <xsl:sequence select="map{ 'view-inverse': true() }"/>
+                    </xsl:if>
+                    <xsl:for-each select="srx:binding[@name = 'forClass']/srx:uri">
+                        <xsl:sequence select="map{ 'view-for-class': xs:anyURI(.) }"/>
+                    </xsl:for-each>
+                    <xsl:for-each select="srx:binding[@name = 'container']/srx:uri">
+                        <xsl:sequence select="map{ 'view-container': xs:anyURI(.) }"/>
+                    </xsl:for-each>
+                    <xsl:for-each select="srx:binding[@name = 'showWhenEmpty']/srx:literal">
+                        <xsl:sequence select="map{ 'view-show-when-empty': string(.) }"/>
+                    </xsl:for-each>
+                </xsl:variable>
+                <xsl:variable name="view-context" as="map(*)" select="map:merge(($context, map{ 'request': $view-request, 'view-uri': $view-uri }, $view-metadata))"/>
 
                 <ixsl:promise select="
                     ixsl:http-request($view-request) =>
@@ -700,14 +735,52 @@ exclude-result-prefixes="#all"
                         ixsl:then(ldh:ontology-view-render-thunk#1)
                     "
                     on-failure="ldh:promise-failure#1"/>
-            </xsl:for-each>
+            </xsl:for-each-group>
         </xsl:if>
 
         <xsl:sequence select="$context"/>
     </xsl:function>
 
-    <!-- render one view block from its loaded RDF, append into the wrapper's .span12 alongside the typed resource block, hydrate via existing ldh:RenderRow chain -->
+    <!-- render one view block from its loaded RDF. Creatable views (ldh:container + inferred forClass) first HEAD the container for its acl:mode Link headers, which gate the Create button; the rest insert directly -->
     <xsl:function name="ldh:ontology-view-render-thunk" as="map(*)" ixsl:updating="yes">
+        <xsl:param name="context" as="map(*)"/>
+
+        <xsl:message>ldh:ontology-view-render-thunk</xsl:message>
+
+        <xsl:choose>
+            <xsl:when test="map:contains($context, 'view-container') and map:contains($context, 'view-for-class')">
+                <xsl:variable name="container-request" select="map{ 'method': 'HEAD', 'href': ldh:href($context('view-container'), map{}), 'headers': map{ 'Accept': 'application/rdf+xml' } }" as="map(*)"/>
+                <xsl:variable name="container-context" select="map:merge(($context, map{ 'container-request': $container-request }))" as="map(*)"/>
+
+                <ixsl:promise select="
+                    ixsl:resolve($container-context) =>
+                        ixsl:then(ldh:http-request-threaded(?, 'container-request', 'container-response')) =>
+                        ixsl:then(ldh:handle-response(?, 'container-response')) =>
+                        ixsl:then(ldh:set-container-acl-modes#1) =>
+                        ixsl:then(ldh:ontology-view-insert#1)
+                    "
+                    on-failure="ldh:promise-failure#1"/>
+
+                <xsl:sequence select="$context"/>
+            </xsl:when>
+            <xsl:otherwise>
+                <xsl:sequence select="ldh:ontology-view-insert($context)"/>
+            </xsl:otherwise>
+        </xsl:choose>
+    </xsl:function>
+
+    <!-- extract acl:mode URIs from the container HEAD response's Link headers (emitted by ResponseHeadersFilter, forwarded for remote containers by ProxyRequestFilter); same parsing as ldh:rdf-document-response. A non-200 response yields no modes, which downstream reads as no Create button -->
+    <xsl:function name="ldh:set-container-acl-modes" as="map(*)" ixsl:updating="no">
+        <xsl:param name="context" as="map(*)"/>
+        <xsl:variable name="response" select="$context('container-response')" as="map(*)"/>
+        <xsl:variable name="acl-mode-links" select="tokenize($response?headers?link, ',')[contains(., '&acl;mode')]" as="xs:string*"/>
+        <xsl:variable name="acl-modes" select="for $mode-link in $acl-mode-links return xs:anyURI(substring-before(substring-after(substring-before($mode-link, ';'), '&lt;'), '&gt;'))" as="xs:anyURI*"/>
+
+        <xsl:sequence select="map:merge(($context, map{ 'container-acl-modes': $acl-modes }))"/>
+    </xsl:function>
+
+    <!-- append the rendered view block into the wrapper's .span12 alongside the typed resource block, stamp the inline-creation metadata as data-* attributes, hydrate via existing ldh:RenderRow chain -->
+    <xsl:function name="ldh:ontology-view-insert" as="map(*)" ixsl:updating="yes">
         <xsl:param name="context" as="map(*)"/>
         <xsl:variable name="response" select="$context('response')" as="map(*)"/>
         <xsl:variable name="container" select="$context('container')" as="element()"/>
@@ -715,7 +788,7 @@ exclude-result-prefixes="#all"
         <xsl:variable name="view-uri" select="$context('view-uri')" as="xs:anyURI"/>
         <xsl:variable name="base-uri" select="$context('base-uri')" as="xs:anyURI"/>
 
-        <xsl:message>ldh:ontology-view-render-thunk</xsl:message>
+        <xsl:message>ldh:ontology-view-insert</xsl:message>
 
         <xsl:if test="$response?status = 200 and $response?media-type = 'application/rdf+xml'">
             <xsl:variable name="view-rdf" select="$response?body" as="document-node()"/>
@@ -738,6 +811,27 @@ exclude-result-prefixes="#all"
                 <!-- hydrate the freshly-injected wrapper via the existing view.xsl:62 RenderRow handler -->
                 <xsl:variable name="injected" select="$span12/*[last()]" as="element()?"/>
                 <xsl:if test="$injected">
+                    <!-- stamp inline-creation metadata before hydration so ldh:RenderViewResults can read it off the wrapper -->
+                    <xsl:for-each select="$injected">
+                        <xsl:if test="map:contains($context, 'view-property')">
+                            <ixsl:set-attribute name="data-property" select="string($context('view-property'))" object="."/>
+                        </xsl:if>
+                        <xsl:if test="map:contains($context, 'view-inverse')">
+                            <ixsl:set-attribute name="data-inverse" select="'true'" object="."/>
+                        </xsl:if>
+                        <xsl:if test="map:contains($context, 'view-for-class')">
+                            <ixsl:set-attribute name="data-for-class" select="string($context('view-for-class'))" object="."/>
+                        </xsl:if>
+                        <xsl:if test="map:contains($context, 'view-container')">
+                            <ixsl:set-attribute name="data-container" select="string($context('view-container'))" object="."/>
+                        </xsl:if>
+                        <xsl:if test="map:contains($context, 'view-show-when-empty')">
+                            <ixsl:set-attribute name="data-show-when-empty" select="string($context('view-show-when-empty'))" object="."/>
+                        </xsl:if>
+                        <xsl:if test="map:contains($context, 'container-acl-modes')">
+                            <ixsl:set-attribute name="data-acl-modes" select="string-join($context('container-acl-modes'), ' ')" object="."/>
+                        </xsl:if>
+                    </xsl:for-each>
                     <xsl:variable name="factories" as="(function(item()?) as item()*)*">
                         <xsl:apply-templates select="$injected" mode="ldh:RenderRow"/>
                     </xsl:variable>

--- a/src/main/webapp/static/com/atomgraph/linkeddatahub/xsl/bootstrap/2.3.2/client/block/view.xsl
+++ b/src/main/webapp/static/com/atomgraph/linkeddatahub/xsl/bootstrap/2.3.2/client/block/view.xsl
@@ -809,7 +809,21 @@ exclude-result-prefixes="#all"
                         <xsl:value-of select="($container/descendant::*[@property = '&dct;title']/text())[1]"/>
                     </h2>
                 </xsl:where-populated>
-  
+
+                <!-- inline creation: Create button for views carrying ldh:container metadata (stamped as data-* attributes by ldh:ontology-view-insert, RDFa as fallback for hand-authored view blocks). PUT into the container requires acl:Write there (checked on the parent URI for new documents); forward views additionally PATCH the linking triple into the current document, hence acl:Write here too -->
+                <xsl:variable name="view-block" select="$container/ancestor::div[contains-token(@class, 'block')][1]" as="element()?"/>
+                <xsl:variable name="create-container" select="($view-block/@data-container, $container/descendant::*[@property = '&ldh;container']/@resource)[1]" as="xs:string?"/>
+                <xsl:variable name="create-for-class" select="$view-block/@data-for-class" as="xs:string?"/>
+                <xsl:if test="exists($create-container) and exists($create-for-class) and tokenize($view-block/@data-acl-modes, ' ') = '&acl;Write' and (exists($view-block/@data-inverse) or acl:mode() = '&acl;Write')">
+                    <div class="pull-right">
+                        <button type="button" class="btn add-instance" data-for-class="{$create-for-class}" data-container="{$create-container}" title="{ac:label(key('resources', 'create-instance-title', document(resolve-uri('static/com/atomgraph/linkeddatahub/xsl/bootstrap/2.3.2/translations.rdf', $lapp:origin))))}">
+                            <xsl:value-of>
+                                <xsl:apply-templates select="key('resources', '&ac;ConstructMode', document(ac:document-uri('&ac;')))" mode="ac:label"/>
+                            </xsl:value-of>
+                        </button>
+                    </div>
+                </xsl:if>
+
                 <xsl:call-template name="bs2:ViewModeList">
                     <xsl:with-param name="active-mode" select="$active-mode"/>
                 </xsl:call-template>
@@ -895,6 +909,18 @@ exclude-result-prefixes="#all"
         <xsl:variable name="limit" select="if ($select-xml/json:map/json:number[@key = 'limit']) then xs:integer($select-xml/json:map/json:number[@key = 'limit']) else 0" as="xs:integer"/>
         <xsl:variable name="offset" select="if ($select-xml/json:map/json:number[@key = 'offset']) then xs:integer($select-xml/json:map/json:number[@key = 'offset']) else 0" as="xs:integer"/>
         <xsl:variable name="exact-count" select="count($results/rdf:RDF/rdf:Description)" as="xs:integer"/>
+
+        <!-- ldh:showWhenEmpty (default true): when false, hide the whole injected view block while the query returns no results and un-hide it when results appear on a later refresh. Only evaluated on the first page: at offset 0 an empty page means an empty result set, while a non-zero offset implies interaction with a visible block -->
+        <xsl:if test="$offset = 0">
+            <xsl:variable name="view-block" select="$container/ancestor::div[contains-token(@class, 'block')][1]" as="element()?"/>
+            <xsl:variable name="show-when-empty" select="not(($view-block/@data-show-when-empty, $container/descendant::*[@property = '&ldh;showWhenEmpty']/text())[1] = ('false', '0'))" as="xs:boolean"/>
+            <xsl:if test="not($show-when-empty)">
+                <xsl:for-each select="$view-block">
+                    <ixsl:set-style name="display" select="if ($exact-count = 0) then 'none' else ''" object="."/>
+                </xsl:for-each>
+            </xsl:if>
+        </xsl:if>
+
         <xsl:choose>
             <xsl:when test="$offset = 0 and ($limit = 0 or $exact-count lt $limit)">
                 <xsl:for-each select="id($result-count-container-id, ixsl:page())">
@@ -2266,6 +2292,241 @@ exclude-result-prefixes="#all"
         </xsl:for-each>
 
         <xsl:sequence select="$context"/>
+    </xsl:function>
+
+    <!-- INLINE CREATION -->
+
+    <!-- update template for the forward linking triple, substituted with the same replace() idiom as the constructor update strings. INSERT/WHERE form: PATCH only accepts INSERT/WHERE and DELETE WHERE (DocumentHierarchyGraphStoreImpl) -->
+    <xsl:variable name="view-instance-link-string" as="xs:string">
+        <![CDATA[
+            INSERT
+              { $about  $property  $this }
+            WHERE
+              {}
+        ]]>
+    </xsl:variable>
+
+    <!-- open the instance creation modal form for a view carrying ldh:container metadata (stamped as data-* attributes by ldh:ontology-view-insert) -->
+    <xsl:template match="div[contains-token(@class, 'block')]//button[contains-token(@class, 'add-instance')][@data-for-class][@data-container]" mode="ixsl:onclick">
+        <xsl:sequence select="ixsl:call(ixsl:event(), 'preventDefault', [])[current-date() lt xs:date('2000-01-01')]"/>
+        <xsl:variable name="view-block" select="ancestor::div[contains-token(@class, 'block')][@data-property][1]" as="element()"/>
+        <xsl:variable name="content-body" select="ancestor::div[contains-token(@class, 'document-body')]/div[contains-token(@class, 'content-body')]" as="element()"/>
+        <xsl:variable name="forClass" select="xs:anyURI(@data-for-class)" as="xs:anyURI"/>
+        <xsl:variable name="container-uri" select="xs:anyURI(@data-container)" as="xs:anyURI"/>
+        <xsl:variable name="doc-uri" select="resolve-uri(ac:uuid() || '/', $container-uri)" as="xs:anyURI"/> <!-- build a relative URI for the container's child document -->
+        <xsl:variable name="this" select="$doc-uri" as="xs:anyURI"/>
+
+        <ixsl:set-style name="cursor" select="'progress'" object="ixsl:page()//body"/>
+
+        <!-- 'base-uri' = the container, so the form treats the new document as a child of it; 'view-*' keys carry the linkage metadata through the chain -->
+        <xsl:variable name="context" as="map(*)" select="map{
+            'content-body': $content-body,
+            'forClass': $forClass,
+            'doc-uri': $doc-uri,
+            'base-uri': $container-uri,
+            'this': $this,
+            'view-property': xs:anyURI($view-block/@data-property),
+            'view-inverse': exists($view-block/@data-inverse),
+            'view-about': xs:anyURI($view-block/ancestor::*[@about][1]/@about),
+            'view-block-id': string($view-block/@id)
+        }"/>
+
+        <ixsl:promise select="ixsl:resolve($context) =>
+            ixsl:then(ldh:fire-load-set-parallel(?, [
+              [ ldh:load-constructed-doc#1, 'constructed-doc-request', 'constructed-doc-response', ldh:set-constructed-doc#1 ]
+            ])) =>
+            ixsl:then(ldh:set-add-modal-form-resource#1) =>
+            ixsl:then(ldh:set-view-instance-resource#1) =>
+            ixsl:then(ldh:fire-load-set-parallel(?, [
+              [ ldh:load-type-metadata#1,     'type-metadata-request',     'type-metadata-response',     ldh:set-type-metadata#1 ],
+              [ ldh:load-property-metadata#1, 'property-metadata-request', 'property-metadata-response', ldh:set-property-metadata#1 ],
+              [ ldh:load-constraints#1,       'constraints-request',       'constraints-response',       ldh:set-constraints#1 ]
+            ])) =>
+            ixsl:then(ldh:render-view-instance-modal-form#1) =>
+            ixsl:finally(ldh:reset-cursor#0)"
+            on-failure="ldh:promise-failure#1"/>
+    </xsl:template>
+
+    <!-- Promise-chain step after ldh:set-add-modal-form-resource: rename the SPIN-constructed bnode resource to the new document URI (document-as-instance, uniform with Container/Item creation). Without this the server would skolemize the bnode into an unpredictable fragment URI and the linking triple could not be built client-side. Pure-XSLT (no I/O). -->
+    <xsl:function name="ldh:set-view-instance-resource" as="map(*)" ixsl:updating="no">
+        <xsl:param name="context" as="map(*)"/>
+        <xsl:variable name="constructed-doc" select="$context('constructed-doc')" as="document-node()"/>
+        <xsl:variable name="resource" select="$context('resource')" as="element()"/>
+        <xsl:variable name="doc-uri" select="$context('doc-uri')" as="xs:anyURI"/>
+        <!-- safe to rename: ldh:set-add-modal-form-resource only selects a resource that no other description references -->
+        <xsl:variable name="renamed-doc" as="document-node()">
+            <xsl:document>
+                <rdf:RDF>
+                    <xsl:for-each select="$constructed-doc/rdf:RDF/*">
+                        <xsl:choose>
+                            <xsl:when test=". is $resource">
+                                <rdf:Description rdf:about="{$doc-uri}">
+                                    <xsl:copy-of select="@* except @rdf:nodeID, node()"/>
+                                </rdf:Description>
+                            </xsl:when>
+                            <xsl:otherwise>
+                                <xsl:copy-of select="."/>
+                            </xsl:otherwise>
+                        </xsl:choose>
+                    </xsl:for-each>
+                </rdf:RDF>
+            </xsl:document>
+        </xsl:variable>
+
+        <xsl:sequence select="map:merge(($context, map{ 'constructed-doc': $renamed-doc, 'resource': key('resources', $doc-uri, $renamed-doc) }), map{ 'duplicates': 'use-last' })"/>
+    </xsl:function>
+
+    <!-- renders the creation modal via ldh:render-add-modal-form, then stamps the linkage metadata on the modal element so the submit and response handlers (separate events) can read it -->
+    <xsl:function name="ldh:render-view-instance-modal-form" as="item()*" ixsl:updating="yes">
+        <xsl:param name="context" as="map(*)"/>
+        <xsl:variable name="content-body" select="$context('content-body')" as="element()"/>
+        <xsl:variable name="doc-uri" select="$context('doc-uri')" as="xs:anyURI"/>
+
+        <xsl:message>ldh:render-view-instance-modal-form</xsl:message>
+
+        <xsl:sequence select="ldh:render-add-modal-form($context)"/>
+
+        <xsl:for-each select="$content-body/div[contains-token(@class, 'modal-constructor')][@about = $doc-uri]">
+            <ixsl:set-attribute name="data-property" select="string($context('view-property'))" object="."/>
+            <xsl:if test="$context('view-inverse')">
+                <ixsl:set-attribute name="data-inverse" select="'true'" object="."/>
+            </xsl:if>
+            <ixsl:set-attribute name="data-about" select="string($context('view-about'))" object="."/>
+            <ixsl:set-attribute name="data-block-id" select="$context('view-block-id')" object="."/>
+        </xsl:for-each>
+    </xsl:function>
+
+    <!-- submit inline creation modal form: forward view — the linking triple <about> <property> <new> is PATCHed into the current document by the response callback -->
+    <xsl:template match="div[contains-token(@class, 'modal-constructor')][@data-property][not(@data-inverse)]//form[contains-token(@class, 'form-horizontal')][upper-case(@method) = 'PUT']" mode="ixsl:onsubmit" priority="3"> <!-- prioritize over modal.xsl -->
+        <xsl:next-match>
+            <xsl:with-param name="callback" select="ldh:view-instance-form-response#1"/>
+        </xsl:next-match>
+    </xsl:template>
+
+    <!-- submit inline creation modal form: inverse view — the linking triple <new> <property> <about> belongs in the new document's graph, so it ships inside the PUT body -->
+    <xsl:template match="div[contains-token(@class, 'modal-constructor')][@data-property][@data-inverse]//form[contains-token(@class, 'form-horizontal')][upper-case(@method) = 'PUT']" mode="ixsl:onsubmit" priority="3"> <!-- prioritize over modal.xsl -->
+        <xsl:param name="elements" select=".//input | .//textarea | .//select" as="element()*"/>
+        <xsl:sequence select="ixsl:call(ixsl:event(), 'preventDefault', [])"/>
+        <xsl:variable name="modal" select="ancestor::div[contains-token(@class, 'modal-constructor')][1]" as="element()"/>
+        <!-- pre-process form before submitting it: syncs input values, so it must precede ldh:parse-rdf-post -->
+        <xsl:apply-templates select="." mode="ldh:FormPreSubmit"/>
+        <xsl:variable name="triples" select="ldh:parse-rdf-post($elements)" as="element()*"/>
+        <!-- canonicalize XML in rdf:XMLLiterals -->
+        <xsl:variable name="triples" as="element()*">
+            <xsl:apply-templates select="$triples" mode="ldh:CanonicalizeXML"/>
+        </xsl:variable>
+        <xsl:variable name="link-triple" as="element()">
+            <json:map>
+                <json:string key="subject"><xsl:sequence select="string($modal/@about)"/></json:string>
+                <json:string key="predicate"><xsl:sequence select="string($modal/@data-property)"/></json:string>
+                <json:string key="object"><xsl:sequence select="string($modal/@data-about)"/></json:string>
+            </json:map>
+        </xsl:variable>
+
+        <xsl:next-match>
+            <xsl:with-param name="callback" select="ldh:view-instance-form-response#1"/>
+            <!-- append $link-triple to the $request-body sent with the request, but not to the $resources rendered afterwards -->
+            <xsl:with-param name="request-body" as="document-node()">
+                <xsl:document>
+                    <rdf:RDF>
+                        <xsl:sequence select="ldh:triples-to-descriptions(($triples, $link-triple))"/>
+                    </rdf:RDF>
+                </xsl:document>
+            </xsl:with-param>
+        </xsl:next-match>
+    </xsl:template>
+
+    <!-- Per-flow callback for the inline creation PUT response. On 201 Created: close the modal, establish the forward linking triple (inverse ones shipped in the PUT body), refresh the view. Everything else delegates to the plain constructor modal flow (violation re-render, error alert). -->
+    <xsl:function name="ldh:view-instance-form-response" ixsl:updating="yes">
+        <xsl:param name="context" as="map(*)"/>
+        <xsl:variable name="response" select="$context('response')" as="map(*)"/>
+
+        <xsl:message>ldh:view-instance-form-response</xsl:message>
+
+        <xsl:choose>
+            <xsl:when test="$response?status = 201 and map:contains($response?headers, 'location')">
+                <xsl:variable name="modal" select="$context('block')" as="element()"/>
+                <!-- read the linkage metadata off the modal before removing it -->
+                <xsl:variable name="property" select="$modal/@data-property" as="xs:string"/>
+                <xsl:variable name="inverse" select="exists($modal/@data-inverse)" as="xs:boolean"/>
+                <xsl:variable name="about" select="$modal/@data-about" as="xs:string"/>
+                <xsl:variable name="block-id" select="$modal/@data-block-id" as="xs:string"/>
+                <xsl:variable name="created-uri" select="ac:absolute-path(xs:anyURI($response?headers?location))" as="xs:anyURI"/> <!-- server-authoritative -->
+                <xsl:variable name="doc-uri" select="$context('doc-uri')" as="xs:anyURI"/>
+                <xsl:sequence select="ixsl:call($modal, 'remove', [])[current-date() lt xs:date('2000-01-01')]"/>
+
+                <xsl:choose>
+                    <!-- inverse linking triple already shipped inside the PUT body: refresh straight away -->
+                    <xsl:when test="$inverse">
+                        <xsl:sequence select="ldh:refresh-view($block-id)"/>
+                    </xsl:when>
+                    <!-- forward: INSERT the linking triple into the current document, then refresh -->
+                    <xsl:otherwise>
+                        <xsl:variable name="update-string" select="replace($view-instance-link-string, '$about', '&lt;' || $about || '&gt;', 'q')" as="xs:string"/>
+                        <xsl:variable name="update-string" select="replace($update-string, '$property', '&lt;' || $property || '&gt;', 'q')" as="xs:string"/>
+                        <xsl:variable name="update-string" select="replace($update-string, '$this', '&lt;' || $created-uri || '&gt;', 'q')" as="xs:string"/>
+                        <xsl:variable name="etag" select="ixsl:get(ixsl:get(ixsl:get(ixsl:window(), 'LinkedDataHub.contents'), '`' || $doc-uri || '`'), 'etag')" as="xs:string"/>
+                        <!-- If-Match header checks preconditions, i.e. that the graph has not been modified in the meanwhile -->
+                        <xsl:variable name="link-request" select="map{ 'method': 'PATCH', 'href': ldh:href($doc-uri, map{}), 'media-type': 'application/sparql-update', 'body': $update-string, 'headers': map{ 'If-Match': $etag, 'Accept': 'application/rdf+xml', 'Cache-Control': 'no-cache' } }" as="map(*)"/>
+                        <xsl:variable name="link-context" as="map(*)" select="map{ 'request': $link-request, 'doc-uri': $doc-uri, 'block-id': $block-id }"/>
+
+                        <ixsl:promise select="
+                            ixsl:http-request($link-context('request')) =>
+                                ixsl:then(ldh:rethread-response($link-context, ?)) =>
+                                ixsl:then(ldh:handle-response#1) =>
+                                ixsl:then(ldh:view-instance-link-response#1)
+                            "
+                            on-failure="ldh:promise-failure#1"/>
+                    </xsl:otherwise>
+                </xsl:choose>
+            </xsl:when>
+            <!-- 200/204, constraint violations and errors take the same path as the plain constructor modal flow -->
+            <xsl:otherwise>
+                <xsl:sequence select="ldh:constructor-form-response($context)"/>
+            </xsl:otherwise>
+        </xsl:choose>
+    </xsl:function>
+
+    <!-- callback for the forward linking triple PATCH -->
+    <xsl:function name="ldh:view-instance-link-response" ixsl:updating="yes">
+        <xsl:param name="context" as="map(*)"/>
+        <xsl:variable name="response" select="$context('response')" as="map(*)"/>
+        <xsl:variable name="doc-uri" select="$context('doc-uri')" as="xs:anyURI"/>
+        <xsl:variable name="block-id" select="$context('block-id')" as="xs:string"/>
+
+        <xsl:message>ldh:view-instance-link-response</xsl:message>
+
+        <xsl:choose>
+            <xsl:when test="$response?status = (200, 204)">
+                <xsl:variable name="etag" select="$response?headers?etag" as="xs:string?"/>
+                <xsl:if test="$etag">
+                    <!-- store ETag header value under window.LinkedDataHub.contents[$doc-uri].etag so subsequent edits of the current document don't fail preconditions -->
+                    <ixsl:set-property name="etag" select="$etag" object="ixsl:get(ixsl:get(ixsl:window(), 'LinkedDataHub.contents'), '`' || $doc-uri || '`')"/>
+                </xsl:if>
+
+                <xsl:sequence select="ldh:refresh-view($block-id)"/>
+            </xsl:when>
+            <xsl:otherwise>
+                <xsl:sequence select="ldh:error-response-alert($context)"/>
+            </xsl:otherwise>
+        </xsl:choose>
+    </xsl:function>
+
+    <!-- re-run the view block's RenderRow chain with fresh results (Cache-Control: no-cache). Applied directly to the View element because $refresh-content is not tunneled and would not survive the generic block.xsl re-entry -->
+    <xsl:function name="ldh:refresh-view" as="item()*" ixsl:updating="yes">
+        <xsl:param name="block-id" as="xs:string"/>
+
+        <xsl:for-each select="id($block-id, ixsl:page())/div[contains-token(@class, 'span12')]/div[@typeof = '&ldh;View']">
+            <xsl:variable name="factories" as="(function(item()?) as item()*)*">
+                <xsl:apply-templates select="." mode="ldh:RenderRow">
+                    <xsl:with-param name="refresh-content" select="true()"/>
+                </xsl:apply-templates>
+            </xsl:variable>
+            <xsl:for-each select="$factories">
+                <xsl:variable name="factory" select="."/>
+                <ixsl:promise select="$factory(())" on-failure="ldh:promise-failure#1"/>
+            </xsl:for-each>
+        </xsl:for-each>
     </xsl:function>
 
 </xsl:stylesheet>

--- a/src/main/webapp/static/com/atomgraph/linkeddatahub/xsl/bootstrap/2.3.2/client/block/view.xsl
+++ b/src/main/webapp/static/com/atomgraph/linkeddatahub/xsl/bootstrap/2.3.2/client/block/view.xsl
@@ -810,20 +810,6 @@ exclude-result-prefixes="#all"
                     </h2>
                 </xsl:where-populated>
 
-                <!-- inline creation: Create button for views carrying ldh:container metadata (stamped as data-* attributes by ldh:ontology-view-insert, RDFa as fallback for hand-authored view blocks). PUT into the container requires acl:Write there (checked on the parent URI for new documents); forward views additionally PATCH the linking triple into the current document, hence acl:Write here too -->
-                <xsl:variable name="view-block" select="$container/ancestor::div[contains-token(@class, 'block')][1]" as="element()?"/>
-                <xsl:variable name="create-container" select="($view-block/@data-container, $container/descendant::*[@property = '&ldh;container']/@resource)[1]" as="xs:string?"/>
-                <xsl:variable name="create-for-class" select="$view-block/@data-for-class" as="xs:string?"/>
-                <xsl:if test="exists($create-container) and exists($create-for-class) and tokenize($view-block/@data-acl-modes, ' ') = '&acl;Write' and (exists($view-block/@data-inverse) or acl:mode() = '&acl;Write')">
-                    <div class="pull-right">
-                        <button type="button" class="btn add-instance" data-for-class="{$create-for-class}" data-container="{$create-container}" title="{ac:label(key('resources', 'create-instance-title', document(resolve-uri('static/com/atomgraph/linkeddatahub/xsl/bootstrap/2.3.2/translations.rdf', $lapp:origin))))}">
-                            <xsl:value-of>
-                                <xsl:apply-templates select="key('resources', '&ac;ConstructMode', document(ac:document-uri('&ac;')))" mode="ac:label"/>
-                            </xsl:value-of>
-                        </button>
-                    </div>
-                </xsl:if>
-
                 <xsl:call-template name="bs2:ViewModeList">
                     <xsl:with-param name="active-mode" select="$active-mode"/>
                 </xsl:call-template>
@@ -894,6 +880,20 @@ exclude-result-prefixes="#all"
                         </label>
                     </form>
                 </div>
+
+                <!-- inline creation: Create button for views carrying ldh:container metadata (stamped as data-* attributes by ldh:ontology-view-insert, RDFa as fallback for hand-authored view blocks). Floated last so it lines up left of the mandatory order-by/mode controls, which keep their position across views. PUT into the container requires acl:Write there (checked on the parent URI for new documents); forward views additionally PATCH the linking triple into the current document, hence acl:Write here too -->
+                <xsl:variable name="view-block" select="$container/ancestor::div[contains-token(@class, 'block')][1]" as="element()?"/>
+                <xsl:variable name="create-container" select="($view-block/@data-container, $container/descendant::*[@property = '&ldh;container']/@resource)[1]" as="xs:string?"/>
+                <xsl:variable name="create-for-class" select="$view-block/@data-for-class" as="xs:string?"/>
+                <xsl:if test="exists($create-container) and exists($create-for-class) and tokenize($view-block/@data-acl-modes, ' ') = '&acl;Write' and (exists($view-block/@data-inverse) or acl:mode() = '&acl;Write')">
+                    <div class="pull-right">
+                        <button type="button" class="btn btn-primary add-instance" data-for-class="{$create-for-class}" data-container="{$create-container}" title="{ac:label(key('resources', 'create-instance-title', document(resolve-uri('static/com/atomgraph/linkeddatahub/xsl/bootstrap/2.3.2/translations.rdf', $lapp:origin))))}">
+                            <xsl:value-of>
+                                <xsl:apply-templates select="key('resources', '&ac;ConstructMode', document(ac:document-uri('&ac;')))" mode="ac:label"/>
+                            </xsl:value-of>
+                        </button>
+                    </div>
+                </xsl:if>
 
                 <div>
                     <p id="{$result-count-container-id}" class="result-count"/>
@@ -2314,16 +2314,16 @@ exclude-result-prefixes="#all"
         <xsl:variable name="forClass" select="xs:anyURI(@data-for-class)" as="xs:anyURI"/>
         <xsl:variable name="container-uri" select="xs:anyURI(@data-container)" as="xs:anyURI"/>
         <xsl:variable name="doc-uri" select="resolve-uri(ac:uuid() || '/', $container-uri)" as="xs:anyURI"/> <!-- build a relative URI for the container's child document -->
-        <xsl:variable name="this" select="$doc-uri" as="xs:anyURI"/>
+        <xsl:variable name="this" select="xs:anyURI($doc-uri || '#id' || ac:uuid())" as="xs:anyURI"/> <!-- the instance is a fragment resource within the new document, same minting as the type-typeahead flow -->
 
         <ixsl:set-style name="cursor" select="'progress'" object="ixsl:page()//body"/>
 
-        <!-- 'base-uri' = the container, so the form treats the new document as a child of it; 'view-*' keys carry the linkage metadata through the chain -->
+        <!-- 'types' is initially set to ($forClass) so the shape fetch targets the right class, same as the type-typeahead flow; 'view-*' keys carry the linkage metadata through the chain -->
         <xsl:variable name="context" as="map(*)" select="map{
             'content-body': $content-body,
             'forClass': $forClass,
+            'types': ($forClass),
             'doc-uri': $doc-uri,
-            'base-uri': $container-uri,
             'this': $this,
             'view-property': xs:anyURI($view-block/@data-property),
             'view-inverse': exists($view-block/@data-inverse),
@@ -2333,11 +2333,12 @@ exclude-result-prefixes="#all"
 
         <ixsl:promise select="ixsl:resolve($context) =>
             ixsl:then(ldh:fire-load-set-parallel(?, [
-              [ ldh:load-constructed-doc#1, 'constructed-doc-request', 'constructed-doc-response', ldh:set-constructed-doc#1 ]
+              [ ldh:load-constructed-doc#1, 'constructed-doc-request', 'constructed-doc-response', ldh:set-constructed-doc#1 ],
+              [ ldh:load-shapes#1,          'shapes-request',          'shapes-response',          ldh:set-shapes#1 ]
             ])) =>
-            ixsl:then(ldh:set-add-modal-form-resource#1) =>
-            ixsl:then(ldh:set-view-instance-resource#1) =>
+            ixsl:then(ldh:set-typeahead-form-resource#1) =>
             ixsl:then(ldh:fire-load-set-parallel(?, [
+              [ ldh:load-constructors#1,      'constructors-request',      'constructors-response',      ldh:set-constructors#1 ],
               [ ldh:load-type-metadata#1,     'type-metadata-request',     'type-metadata-response',     ldh:set-type-metadata#1 ],
               [ ldh:load-property-metadata#1, 'property-metadata-request', 'property-metadata-response', ldh:set-property-metadata#1 ],
               [ ldh:load-constraints#1,       'constraints-request',       'constraints-response',       ldh:set-constraints#1 ]
@@ -2347,52 +2348,71 @@ exclude-result-prefixes="#all"
             on-failure="ldh:promise-failure#1"/>
     </xsl:template>
 
-    <!-- Promise-chain step after ldh:set-add-modal-form-resource: rename the SPIN-constructed bnode resource to the new document URI (document-as-instance, uniform with Container/Item creation). Without this the server would skolemize the bnode into an unpredictable fragment URI and the linking triple could not be built client-side. Pure-XSLT (no I/O). -->
-    <xsl:function name="ldh:set-view-instance-resource" as="map(*)" ixsl:updating="no">
-        <xsl:param name="context" as="map(*)"/>
-        <xsl:variable name="constructed-doc" select="$context('constructed-doc')" as="document-node()"/>
-        <xsl:variable name="resource" select="$context('resource')" as="element()"/>
-        <xsl:variable name="doc-uri" select="$context('doc-uri')" as="xs:anyURI"/>
-        <!-- safe to rename: ldh:set-add-modal-form-resource only selects a resource that no other description references -->
-        <xsl:variable name="renamed-doc" as="document-node()">
-            <xsl:document>
-                <rdf:RDF>
-                    <xsl:for-each select="$constructed-doc/rdf:RDF/*">
-                        <xsl:choose>
-                            <xsl:when test=". is $resource">
-                                <rdf:Description rdf:about="{$doc-uri}">
-                                    <xsl:copy-of select="@* except @rdf:nodeID, node()"/>
-                                </rdf:Description>
-                            </xsl:when>
-                            <xsl:otherwise>
-                                <xsl:copy-of select="."/>
-                            </xsl:otherwise>
-                        </xsl:choose>
-                    </xsl:for-each>
-                </rdf:RDF>
-            </xsl:document>
-        </xsl:variable>
-
-        <xsl:sequence select="map:merge(($context, map{ 'constructed-doc': $renamed-doc, 'resource': key('resources', $doc-uri, $renamed-doc) }), map{ 'duplicates': 'use-last' })"/>
-    </xsl:function>
-
-    <!-- renders the creation modal via ldh:render-add-modal-form, then stamps the linkage metadata on the modal element so the submit and response handlers (separate events) can read it -->
+    <!-- Terminal callback for the add-instance onclick chain. Renders the instantiated resource with the same bs2:Form pipeline as the type-typeahead row form (ldh:render-typeahead-row-form), but with method='put' targeting the new document — the RDF/POST body then describes the fragment instance and the PUT auto-creates the containing Item document around it. Stamps the linkage metadata on the modal element so the submit and response handlers (separate events) can read it. -->
     <xsl:function name="ldh:render-view-instance-modal-form" as="item()*" ixsl:updating="yes">
         <xsl:param name="context" as="map(*)"/>
         <xsl:variable name="content-body" select="$context('content-body')" as="element()"/>
         <xsl:variable name="doc-uri" select="$context('doc-uri')" as="xs:anyURI"/>
+        <xsl:variable name="this" select="$context('this')" as="xs:anyURI"/>
+        <xsl:variable name="forClass" select="$context('forClass')" as="xs:anyURI"/>
+        <xsl:variable name="instance-doc" select="$context('instance-doc')" as="document-node()"/>
+        <xsl:variable name="constructed-doc" select="$context('constructed-doc')" as="document-node()"/>
+        <xsl:variable name="type-metadata" select="$context('type-metadata')" as="document-node()?"/>
+        <xsl:variable name="property-metadata" select="$context('property-metadata')" as="document-node()?"/>
+        <xsl:variable name="constraints" select="$context('constraints')" as="document-node()?"/>
+        <xsl:variable name="constructors" select="$context('constructors')" as="document-node()?"/>
+        <xsl:variable name="shapes" select="$context('shapes')" as="document-node()?"/>
+        <xsl:variable name="classes" select="()" as="element()*"/>
 
         <xsl:message>ldh:render-view-instance-modal-form</xsl:message>
 
-        <xsl:sequence select="ldh:render-add-modal-form($context)"/>
+        <xsl:for-each select="$content-body">
+            <!-- the document-level bs2:Form template renders the form shell (hidden rdf input, form actions); prototype-only object bnodes are suppressed by resource.xsl -->
+            <xsl:variable name="form" as="element()*">
+                <xsl:apply-templates select="$instance-doc" mode="bs2:Form">
+                    <xsl:with-param name="method" select="'put'"/>
+                    <xsl:with-param name="action" select="ldh:href($doc-uri)" as="xs:anyURI" tunnel="yes"/>
+                    <xsl:with-param name="form-actions-class" select="'form-actions modal-footer'" as="xs:string?"/>
+                    <xsl:with-param name="classes" select="$classes"/>
+                    <xsl:with-param name="type-metadata" select="$type-metadata" tunnel="yes"/>
+                    <xsl:with-param name="property-metadata" select="$property-metadata" tunnel="yes"/>
+                    <xsl:with-param name="constructor" select="$constructed-doc" tunnel="yes"/>
+                    <xsl:with-param name="constructors" select="$constructors" tunnel="yes"/>
+                    <xsl:with-param name="constraints" select="$constraints" tunnel="yes"/>
+                    <xsl:with-param name="shapes" select="$shapes" tunnel="yes"/>
+                    <xsl:with-param name="base-uri" select="$doc-uri" tunnel="yes"/>
+                </xsl:apply-templates>
+            </xsl:variable>
 
-        <xsl:for-each select="$content-body/div[contains-token(@class, 'modal-constructor')][@about = $doc-uri]">
-            <ixsl:set-attribute name="data-property" select="string($context('view-property'))" object="."/>
-            <xsl:if test="$context('view-inverse')">
-                <ixsl:set-attribute name="data-inverse" select="'true'" object="."/>
+            <xsl:result-document href="?." method="ixsl:append-content">
+                <div class="modal modal-constructor fade in" about="{$doc-uri}" typeof="{$forClass}"> <!-- @about identifies the new document URL (uniform with the other modals so submit handlers can read $block/@about); the instance URI travels on @data-instance -->
+                    <div class="modal-header">
+                        <button type="button" class="close">&#215;</button>
+
+                        <legend>
+                        </legend>
+                    </div>
+
+                    <div class="modal-body">
+                        <xsl:copy-of select="$form"/>
+                    </div>
+                </div>
+            </xsl:result-document>
+
+            <xsl:for-each select="./div[contains-token(@class, 'modal-constructor')][@about = $doc-uri]">
+                <ixsl:set-attribute name="data-property" select="string($context('view-property'))" object="."/>
+                <xsl:if test="$context('view-inverse')">
+                    <ixsl:set-attribute name="data-inverse" select="'true'" object="."/>
+                </xsl:if>
+                <ixsl:set-attribute name="data-about" select="string($context('view-about'))" object="."/>
+                <ixsl:set-attribute name="data-instance" select="string($this)" object="."/>
+                <ixsl:set-attribute name="data-block-id" select="$context('view-block-id')" object="."/>
+            </xsl:for-each>
+
+            <!-- add event listeners to the descendants of the form -->
+            <xsl:if test="id($form/@id, ixsl:page())">
+                <xsl:apply-templates select="id($form/@id, ixsl:page())" mode="ldh:RenderRowForm"/>
             </xsl:if>
-            <ixsl:set-attribute name="data-about" select="string($context('view-about'))" object="."/>
-            <ixsl:set-attribute name="data-block-id" select="$context('view-block-id')" object="."/>
         </xsl:for-each>
     </xsl:function>
 
@@ -2417,7 +2437,7 @@ exclude-result-prefixes="#all"
         </xsl:variable>
         <xsl:variable name="link-triple" as="element()">
             <json:map>
-                <json:string key="subject"><xsl:sequence select="string($modal/@about)"/></json:string>
+                <json:string key="subject"><xsl:sequence select="string($modal/@data-instance)"/></json:string>
                 <json:string key="predicate"><xsl:sequence select="string($modal/@data-property)"/></json:string>
                 <json:string key="object"><xsl:sequence select="string($modal/@data-about)"/></json:string>
             </json:map>
@@ -2450,21 +2470,23 @@ exclude-result-prefixes="#all"
                 <xsl:variable name="property" select="$modal/@data-property" as="xs:string"/>
                 <xsl:variable name="inverse" select="exists($modal/@data-inverse)" as="xs:boolean"/>
                 <xsl:variable name="about" select="$modal/@data-about" as="xs:string"/>
+                <xsl:variable name="instance" select="$modal/@data-instance" as="xs:string"/>
                 <xsl:variable name="block-id" select="$modal/@data-block-id" as="xs:string"/>
-                <xsl:variable name="created-uri" select="ac:absolute-path(xs:anyURI($response?headers?location))" as="xs:anyURI"/> <!-- server-authoritative -->
                 <xsl:variable name="doc-uri" select="$context('doc-uri')" as="xs:anyURI"/>
                 <xsl:sequence select="ixsl:call($modal, 'remove', [])[current-date() lt xs:date('2000-01-01')]"/>
 
                 <xsl:choose>
                     <!-- inverse linking triple already shipped inside the PUT body: refresh straight away -->
                     <xsl:when test="$inverse">
+                        <ixsl:set-style name="cursor" select="'default'" object="ixsl:page()//body"/>
+
                         <xsl:sequence select="ldh:refresh-view($block-id)"/>
                     </xsl:when>
                     <!-- forward: INSERT the linking triple into the current document, then refresh -->
                     <xsl:otherwise>
                         <xsl:variable name="update-string" select="replace($view-instance-link-string, '$about', '&lt;' || $about || '&gt;', 'q')" as="xs:string"/>
                         <xsl:variable name="update-string" select="replace($update-string, '$property', '&lt;' || $property || '&gt;', 'q')" as="xs:string"/>
-                        <xsl:variable name="update-string" select="replace($update-string, '$this', '&lt;' || $created-uri || '&gt;', 'q')" as="xs:string"/>
+                        <xsl:variable name="update-string" select="replace($update-string, '$this', '&lt;' || $instance || '&gt;', 'q')" as="xs:string"/>
                         <xsl:variable name="etag" select="ixsl:get(ixsl:get(ixsl:get(ixsl:window(), 'LinkedDataHub.contents'), '`' || $doc-uri || '`'), 'etag')" as="xs:string"/>
                         <!-- If-Match header checks preconditions, i.e. that the graph has not been modified in the meanwhile -->
                         <xsl:variable name="link-request" select="map{ 'method': 'PATCH', 'href': ldh:href($doc-uri, map{}), 'media-type': 'application/sparql-update', 'body': $update-string, 'headers': map{ 'If-Match': $etag, 'Accept': 'application/rdf+xml', 'Cache-Control': 'no-cache' } }" as="map(*)"/>
@@ -2504,28 +2526,55 @@ exclude-result-prefixes="#all"
                     <ixsl:set-property name="etag" select="$etag" object="ixsl:get(ixsl:get(ixsl:window(), 'LinkedDataHub.contents'), '`' || $doc-uri || '`')"/>
                 </xsl:if>
 
+                <ixsl:set-style name="cursor" select="'default'" object="ixsl:page()//body"/>
+
                 <xsl:sequence select="ldh:refresh-view($block-id)"/>
             </xsl:when>
             <xsl:otherwise>
+                <ixsl:set-style name="cursor" select="'default'" object="ixsl:page()//body"/>
+
                 <xsl:sequence select="ldh:error-response-alert($context)"/>
             </xsl:otherwise>
         </xsl:choose>
     </xsl:function>
 
-    <!-- re-run the view block's RenderRow chain with fresh results (Cache-Control: no-cache). Applied directly to the View element because $refresh-content is not tunneled and would not survive the generic block.xsl re-entry -->
+    <!-- Re-query the view block's results with fresh data (Cache-Control: no-cache). Rebuilds the request context from the contents cache like the pager/order/mode listeners do: the view's RDFa (spin:query) is replaced by the toolbar on the initial render, so re-entering ldh:RenderRow would no longer match the view template -->
     <xsl:function name="ldh:refresh-view" as="item()*" ixsl:updating="yes">
         <xsl:param name="block-id" as="xs:string"/>
 
+        <xsl:message>ldh:refresh-view block-id: '<xsl:value-of select="$block-id"/>' matched views: <xsl:value-of select="count(id($block-id, ixsl:page())/div[contains-token(@class, 'span12')]/div[@typeof = '&ldh;View'])"/></xsl:message>
+
         <xsl:for-each select="id($block-id, ixsl:page())/div[contains-token(@class, 'span12')]/div[@typeof = '&ldh;View']">
-            <xsl:variable name="factories" as="(function(item()?) as item()*)*">
-                <xsl:apply-templates select="." mode="ldh:RenderRow">
+            <xsl:variable name="container" select="." as="element()"/>
+            <xsl:variable name="block" select="ancestor::div[contains-token(@class, 'block')][1]" as="element()"/>
+            <xsl:variable name="cache" select="ixsl:get(ixsl:get(ixsl:window(), 'LinkedDataHub.contents'), '`' || $block/@about || '`')" as="item()"/>
+            <xsl:message>ldh:refresh-view block URI: <xsl:value-of select="$block/@about"/> cache found: <xsl:value-of select="exists($cache)"/></xsl:message>
+            <xsl:variable name="select-string" select="ixsl:get($cache, 'select-string')" as="xs:string"/>
+            <xsl:variable name="select-xml" select="ixsl:get($cache, 'select-xml')" as="document-node()"/>
+            <xsl:variable name="initial-var-name" select="ixsl:get($cache, 'initial-var-name')" as="xs:string"/>
+            <xsl:variable name="endpoint" select="ixsl:get($cache, 'endpoint')" as="xs:anyURI"/>
+            <xsl:variable name="active-class" select="tokenize($container//ul[contains-token(@class, 'view-mode-list')]/li[contains-token(@class, 'active')]/@class, ' ')[not(. = 'active')]" as="xs:string"/>
+            <xsl:variable name="active-mode" select="map:get($class-modes, $active-class)" as="xs:anyURI"/>
+
+            <xsl:variable name="view-context" as="map(*)">
+                <xsl:call-template name="ldh:RenderView">
+                    <xsl:with-param name="container" select="$container"/>
+                    <xsl:with-param name="active-mode" select="$active-mode"/>
+                    <xsl:with-param name="select-string" select="$select-string"/>
+                    <xsl:with-param name="select-xml" select="$select-xml"/>
+                    <xsl:with-param name="initial-var-name" select="$initial-var-name"/>
+                    <xsl:with-param name="endpoint" select="$endpoint"/>
                     <xsl:with-param name="refresh-content" select="true()"/>
-                </xsl:apply-templates>
+                    <xsl:with-param name="cache" select="$cache"/>
+                </xsl:call-template>
             </xsl:variable>
-            <xsl:for-each select="$factories">
-                <xsl:variable name="factory" select="."/>
-                <ixsl:promise select="$factory(())" on-failure="ldh:promise-failure#1"/>
-            </xsl:for-each>
+            <xsl:variable name="context" select="map:merge((map{ 'block': $container }, $view-context))" as="map(*)"/>
+
+            <ixsl:promise select="
+                ixsl:resolve($context) =>
+                    ixsl:then(ldh:view-results-thunk#1)
+                "
+                on-failure="ldh:promise-failure#1"/>
         </xsl:for-each>
     </xsl:function>
 

--- a/src/main/webapp/static/com/atomgraph/linkeddatahub/xsl/bootstrap/2.3.2/client/block/view.xsl
+++ b/src/main/webapp/static/com/atomgraph/linkeddatahub/xsl/bootstrap/2.3.2/client/block/view.xsl
@@ -2476,10 +2476,8 @@ exclude-result-prefixes="#all"
                 <xsl:sequence select="ixsl:call($modal, 'remove', [])[current-date() lt xs:date('2000-01-01')]"/>
 
                 <xsl:choose>
-                    <!-- inverse linking triple already shipped inside the PUT body: refresh straight away -->
+                    <!-- inverse linking triple already shipped inside the PUT body: refresh straight away. The cursor stays 'progress' (set on form submit) until ldh:render-view restores it -->
                     <xsl:when test="$inverse">
-                        <ixsl:set-style name="cursor" select="'default'" object="ixsl:page()//body"/>
-
                         <xsl:sequence select="ldh:refresh-view($block-id)"/>
                     </xsl:when>
                     <!-- forward: INSERT the linking triple into the current document, then refresh -->
@@ -2526,8 +2524,7 @@ exclude-result-prefixes="#all"
                     <ixsl:set-property name="etag" select="$etag" object="ixsl:get(ixsl:get(ixsl:window(), 'LinkedDataHub.contents'), '`' || $doc-uri || '`')"/>
                 </xsl:if>
 
-                <ixsl:set-style name="cursor" select="'default'" object="ixsl:page()//body"/>
-
+                <!-- the cursor stays 'progress' (set on form submit) until ldh:render-view restores it -->
                 <xsl:sequence select="ldh:refresh-view($block-id)"/>
             </xsl:when>
             <xsl:otherwise>

--- a/src/main/webapp/static/com/atomgraph/linkeddatahub/xsl/bootstrap/2.3.2/client/modal.xsl
+++ b/src/main/webapp/static/com/atomgraph/linkeddatahub/xsl/bootstrap/2.3.2/client/modal.xsl
@@ -718,9 +718,12 @@ LIMIT   10
     <!-- submit instance creation modal form using PUT -->
 
     <xsl:template match="div[contains-token(@class, 'modal-constructor')]//form[contains-token(@class, 'form-horizontal')][upper-case(@method) = 'PUT']" mode="ixsl:onsubmit" priority="2">
+        <!-- ldh:constructor-form-response stamps render-fn=ldh:render-constructor-form#2 (mode="bs2:Form") so the violation re-render keeps co-shipped peer Descriptions (content blocks) visible. Higher-priority flow templates (e.g. inline view creation) re-stamp $callback and/or supply $request-body via xsl:next-match. -->
+        <xsl:param name="callback" select="ldh:constructor-form-response#1" as="function(map(*)) as item()*"/>
+        <xsl:param name="request-body" as="document-node()?"/>
         <xsl:next-match>
-            <!-- ldh:constructor-form-response stamps render-fn=ldh:render-constructor-form#2 (mode="bs2:Form") so the violation re-render keeps co-shipped peer Descriptions (content blocks) visible. -->
-            <xsl:with-param name="callback" select="ldh:constructor-form-response#1"/>
+            <xsl:with-param name="callback" select="$callback"/>
+            <xsl:with-param name="request-body" select="$request-body"/>
         </xsl:next-match>
     </xsl:template>
     


### PR DESCRIPTION
Implements the [Inline Creation in Views](https://github.com/AtomGraph/LinkedDataHub/wiki/Inline-Creation-in-Views) proposal.

Views attached to properties via `ldh:view`/`ldh:inverseView` get a **Create** button in the view toolbar when the View carries the new `ldh:container` metadata. The button opens a modal with the full row-form UI (SPIN constructor + SHACL shapes) for the class inferred from the ontology (`rdfs:range` for forward views, `rdfs:domain` for inverse, including `rdfs:subPropertyOf` paths). Submitting issues a single `PUT` that creates the container's child document with the instance as a `#id{uuid}` fragment; forward views then `PATCH` the linking triple into the current document (`INSERT/WHERE` form), while inverse views ship it inside the `PUT` body. The view re-queries in place afterwards.

- New vocabulary: `ldh:container` and `ldh:showWhenEmpty` (default `true` — when `false`, empty views are hidden)
- Create button gated on `acl:Write`, read from the container's `acl:mode` Link headers via a HEAD request; forward views additionally require `acl:Write` on the current document
- Discovery metadata (`?property`, direction, `?forClass`, `?container`, `?showWhenEmpty`) travels through the ontology view query against `/ns`, so package views can be annotated from the app's own namespace
- SKOS package views now tolerate untagged `prefLabel` literals (LDH forms submit plain `xsd:string`)
- Codifies the form-placement convention (modal vs inline by document membership) in CLAUDE.md

🤖 Generated with [Claude Code](https://claude.com/claude-code)