### PR TITLE
Modal document save re-renders with the active layout mode

### DIFF
--- a/src/main/java/com/atomgraph/linkeddatahub/server/filter/response/CacheInvalidationFilter.java
+++ b/src/main/java/com/atomgraph/linkeddatahub/server/filter/response/CacheInvalidationFilter.java
@@ -16,7 +16,6 @@
  */
 package com.atomgraph.linkeddatahub.server.filter.response;
 
-import com.atomgraph.client.vocabulary.AC;
 import com.atomgraph.linkeddatahub.apps.model.AdminApplication;
 import com.atomgraph.linkeddatahub.apps.model.EndUserApplication;
 import java.io.IOException;
@@ -83,14 +82,6 @@ public class CacheInvalidationFilter implements ContainerResponseFilter
             {
                 banIfNotNull(getSystem().getFrontendProxy(), relativeParentURI.toString());
                 banIfNotNull(getSystem().getServiceContext(getApplication().get().getService()).getBackendProxy(), relativeParentURI.toString());
-            }
-
-            // ban all results of queries that use forClass type
-            if (req.getUriInfo().getQueryParameters().containsKey(AC.forClass.getLocalName()))
-            {
-                String forClass = req.getUriInfo().getQueryParameters().getFirst(AC.forClass.getLocalName());
-                banIfNotNull(getSystem().getFrontendProxy(), forClass);
-                banIfNotNull(getSystem().getServiceContext(getApplication().get().getService()).getBackendProxy(), forClass);
             }
         }
 

--- a/src/main/webapp/static/com/atomgraph/linkeddatahub/xsl/bootstrap/2.3.2/client/modal.xsl
+++ b/src/main/webapp/static/com/atomgraph/linkeddatahub/xsl/bootstrap/2.3.2/client/modal.xsl
@@ -151,14 +151,14 @@ LIMIT   10
                                     <button type="button" class="btn dropdown-toggle create-action"></button>
                                     <ul class="dropdown-menu">
                                         <li>
-                                            <button data-for-class="&dh;Container" href="{ldh:href(ac:absolute-path(ldh:base-uri(.)), ldh:build-query(xs:anyURI('&ac;ModalMode'), xs:anyURI('&dh;Container')))}" class="btn add-constructor" title="&dh;Container" id="{generate-id()}-remote-rdf-container">
+                                            <button data-for-class="&dh;Container" class="btn add-constructor" title="&dh;Container" id="{generate-id()}-remote-rdf-container">
                                                 <xsl:value-of>
                                                     <xsl:apply-templates select="key('resources', '&dh;Container', document(ac:document-uri('&dh;')))" mode="ac:label"/>
                                                 </xsl:value-of>
                                             </button>
                                         </li>
                                         <li>
-                                            <button data-for-class="&dh;Item" href="{ldh:href(ac:absolute-path(ldh:base-uri(.)), ldh:build-query(xs:anyURI('&ac;ModalMode'), xs:anyURI('&dh;Item')))}" type="button" class="btn add-constructor" title="&dh;Item" id="{generate-id()}-remote-rdf-item">
+                                            <button data-for-class="&dh;Item" type="button" class="btn add-constructor" title="&dh;Item" id="{generate-id()}-remote-rdf-item">
                                                 <xsl:value-of>
                                                     <xsl:apply-templates select="key('resources', '&dh;Item', document(ac:document-uri('&dh;')))" mode="ac:label"/>
                                                 </xsl:value-of>

--- a/src/main/webapp/static/com/atomgraph/linkeddatahub/xsl/bootstrap/2.3.2/client/modal.xsl
+++ b/src/main/webapp/static/com/atomgraph/linkeddatahub/xsl/bootstrap/2.3.2/client/modal.xsl
@@ -1547,6 +1547,8 @@ LIMIT   10
                 <xsl:call-template name="ldh:DocumentNavigate">
                     <xsl:with-param name="doc-uri" select="$doc-uri"/>
                     <xsl:with-param name="fragment" select="()"/>
+                    <!-- carry the active layout mode over the reload, but only when reloading the document the page currently displays (a PUT overwrite lands here too, with $doc-uri pointing at a different document); ?version/?timemap must not survive the save — they would pin the pre-edit snapshot -->
+                    <xsl:with-param name="query-params" select="if ($doc-uri = ldh:parse-href(ldh:request-uri())?doc-uri and exists(ldh:query-params()?mode)) then map{ 'mode': ldh:query-params()?mode } else map{}"/>
                 </xsl:call-template>
             </xsl:when>
             <xsl:when test="$status = 201 and map:contains($response?headers, 'location')">

--- a/src/main/webapp/static/com/atomgraph/linkeddatahub/xsl/bootstrap/2.3.2/document.xsl
+++ b/src/main/webapp/static/com/atomgraph/linkeddatahub/xsl/bootstrap/2.3.2/document.xsl
@@ -804,9 +804,6 @@ extension-element-prefixes="ixsl"
         <xsl:param name="canvas-id" as="xs:string"/>
         <xsl:param name="canvas-class" select="'chart-canvas'" as="xs:string?"/>
         <xsl:param name="method" select="'post'" as="xs:string"/>
-        <xsl:param name="doc-type" select="xs:anyURI('&dh;Item')" as="xs:anyURI"/>
-        <xsl:param name="type" select="xs:anyURI('&ldh;GraphChart')" as="xs:anyURI"/>
-        <xsl:param name="action" select="ac:build-uri(resolve-uri('charts/', ldt:base()), map{ 'forClass': string($type) })" as="xs:anyURI" tunnel="yes"/>
         <xsl:param name="id" as="xs:string?"/>
         <xsl:param name="class" select="'form-horizontal'" as="xs:string?"/>
         <xsl:param name="button-class" select="'btn'" as="xs:string?"/>
@@ -839,7 +836,7 @@ extension-element-prefixes="ixsl"
         </xsl:param>
 
         <xsl:if test="$show-controls">
-            <form method="{$method}" action="{$action}">
+            <form method="{$method}">
                 <xsl:if test="$id">
                     <xsl:attribute name="id" select="$id"/>
                 </xsl:if>
@@ -968,9 +965,6 @@ extension-element-prefixes="ixsl"
         <xsl:param name="canvas-id" as="xs:string"/>
         <xsl:param name="canvas-class" select="'chart-canvas'" as="xs:string?"/>
         <xsl:param name="method" select="'post'" as="xs:string"/>
-        <xsl:param name="doc-type" select="xs:anyURI('&dh;Item')" as="xs:anyURI"/>
-        <xsl:param name="type" select="xs:anyURI('&ldh;ResultSetChart')" as="xs:anyURI"/>
-        <xsl:param name="action" select="ac:build-uri(resolve-uri('charts/', ldt:base()), map{ 'forClass': string($type) })" as="xs:anyURI" tunnel="yes"/>
         <xsl:param name="id" as="xs:string?"/>
         <xsl:param name="class" select="'form-horizontal'" as="xs:string?"/>
         <xsl:param name="button-class" select="'btn'" as="xs:string?"/>
@@ -1003,7 +997,7 @@ extension-element-prefixes="ixsl"
         </xsl:param>
         
         <xsl:if test="$show-controls">
-            <form method="{$method}" action="{$action}">
+            <form method="{$method}">
                 <xsl:if test="$id">
                     <xsl:attribute name="id" select="$id"/>
                 </xsl:if>

--- a/src/main/webapp/static/com/atomgraph/linkeddatahub/xsl/bootstrap/2.3.2/imports/default.xsl
+++ b/src/main/webapp/static/com/atomgraph/linkeddatahub/xsl/bootstrap/2.3.2/imports/default.xsl
@@ -272,15 +272,8 @@ exclude-result-prefixes="#all"
 
     <xsl:function name="ldh:build-query" as="map(xs:string, xs:string*)">
         <xsl:param name="mode" as="xs:anyURI*"/>
-        
-        <xsl:sequence select="ldh:build-query($mode, ())"/>
-    </xsl:function>
 
-    <xsl:function name="ldh:build-query" as="map(xs:string, xs:string*)">
-        <xsl:param name="mode" as="xs:anyURI*"/>
-        <xsl:param name="forClass" as="xs:anyURI?"/>
-        
-        <xsl:sequence select="map:merge((if (exists($mode)) then map{ 'mode': for $m in $mode return string($m) } else (), if ($forClass) then map{ 'forClass': string($forClass) } else ()))"/>
+        <xsl:sequence select="if (exists($mode)) then map{ 'mode': for $m in $mode return string($m) } else map{}"/>
     </xsl:function>
 
     <xsl:function name="ldh:query-result" as="document-node()">
@@ -409,7 +402,7 @@ exclude-result-prefixes="#all"
         </xsl:copy>
     </xsl:template>
 
-    <!-- Builds the pure, bnode-prototyped constructor consumed by bs2:FormControl from the two raw inputs the promise chain has fetched: $shapes (SHACL NodeShape RDF) and $constructed-doc (SPIN constructor RDF from /ns?forClass=…). Shared by every flow that ends in bs2:FormControl (ldh:render-row-form for EDIT, ldh:render-row-form-violation for violation re-render, and the Phase 4 modal/app-settings/signup renderers to come) so the merge logic lives in exactly one place. Returns the SPIN side unchanged when shapes are absent (typical for system classes like sp:Describe), returns the merged doc when both sides exist (user-defined classes like skos:Concept with both SPIN defaults and SHACL constraints), or empty if neither side provides input. -->
+    <!-- Builds the pure, bnode-prototyped constructor consumed by bs2:FormControl from the two raw inputs the promise chain has fetched: $shapes (SHACL NodeShape RDF) and $constructed-doc (SPIN constructor RDF fetched via the ns SPARQL endpoint). Shared by every flow that ends in bs2:FormControl (ldh:render-row-form for EDIT, ldh:render-row-form-violation for violation re-render, and the Phase 4 modal/app-settings/signup renderers to come) so the merge logic lives in exactly one place. Returns the SPIN side unchanged when shapes are absent (typical for system classes like sp:Describe), returns the merged doc when both sides exist (user-defined classes like skos:Concept with both SPIN defaults and SHACL constraints), or empty if neither side provides input. -->
     <xsl:function name="ldh:build-merged-constructor" as="document-node()?">
         <xsl:param name="shapes" as="document-node()?"/>
         <xsl:param name="constructed-doc" as="document-node()?"/>


### PR DESCRIPTION
Saving the document-edit modal (the `btn-edit` action-bar button) re-rendered the main content in the default layout mode, discarding whatever mode was active — e.g. `?mode=https%3A%2F%2Fw3id.org%2Fatomgraph%2Fclient%23GraphMode` fell back to ContentMode/ReadMode after the save.

`ldh:modal-form-response` navigates on 200/204 with only `doc-uri`, so `query-params` fell back to its empty default. `ldh:DocumentNavigate` then rebuilt and pushed the URL without `?mode=`, and since `ac:mode()` reads the mode off the live URL, the re-render lost it.

The mode now travels as a `query-params` entry, matching how every other navigation carries it (`ldh:build-query($mode)` merged into `$query-params`). Two deliberate constraints:

- **Guarded to same-document reloads.** `ldh:modal-form-response` is shared with the Container/Item creation flow, and a PUT that overwrites an existing document also returns 200 and lands in this branch with `doc-uri` pointing elsewhere. The current pane's mode must not leak onto navigation to a different document. `ldh:parse-href` is used rather than `ac:absolute-path` so the comparison holds for proxied external panes.
- **Snapshot params are not carried.** `?version` / `?timemap` select a *representation* rather than display state (the distinction `ldh:snapshot-params()` already encodes). Replaying `?version=N` after a successful PATCH would render the pre-edit snapshot — the one state guaranteed wrong after a write.

## Vestigial `forClass` URL param removed

Reviewing which params were safe to carry surfaced that nothing puts `forClass` in a URL anymore. The remaining producers were all dead:

- The two `add-constructor` buttons carried `href="…?mode=ModalMode&forClass=…"`. `@href` on a `<button>` is inert; the onclick reads `@data-for-class`.
- The `bs2:Chart` form's action defaulted to `charts/?forClass=…`, but `btn-save-chart` is `type="button"` and PATCHes the current document instead of submitting.
- The `ns?forClass=` constructor endpoint was replaced by `ns?query=` in `ldh:load-constructed-doc`.

Removed: the button `@href`s, the `ldh:build-query` `forClass` arity (its only callers), and `CacheInvalidationFilter`'s now-unreachable `forClass` ban branch.

The chart form loses `@action` entirely rather than being repointed. No `charts/` container exists in the app structure, and `bs2:Chart` cannot derive the host document anyway — its context node is the *data* document, whose base URI is the SPARQL request URL for CSR-fetched view/query results. An absent `@action` targets the current page URL, which is where the save actually writes. `$type` and `$doc-type` become unused and go with it.

`$ac:forClass` in `client.xsl` stays: the imported Web-Client `resource.xsl` and `document.xsl` reference it, and the Web-Client `layout.xsl` that declares it is not in the CSR import tree.

## Testing

XSLT changes verified well-formed. Not yet exercised against a running instance — the client-side changes need SEF regeneration plus a hard reload (`/static/` is served `immutable`, 7-day max-age) to observe.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
