### PR TITLE
Give each CI run its own versioning branch

### DIFF
--- a/.github/workflows/http-tests.yml
+++ b/.github/workflows/http-tests.yml
@@ -46,11 +46,22 @@ jobs:
         shell: bash
       - name: Enable graph versioning
         if: env.VERSIONING_TEST_TOKEN != ''
+        env:
+          GH_TOKEN: ${{ secrets.VERSIONING_TEST_TOKEN }}
         run: |
+          # Each run commits to its own branch. The Contents API takes an optimistic lock on the branch
+          # head rather than the file, so concurrent runs sharing one branch lose the race against each
+          # other; versioning is best-effort and async, so the lost commits surface as unrelated test
+          # timeouts. A per-run path prefix isolates the files but not the head, which is the contended part.
+          branch="ci-${{ github.run_id }}"
+          base_sha=$(gh api "repos/$VERSIONING_TEST_REPO/git/ref/heads/main" --jq '.object.sha')
+          gh api "repos/$VERSIONING_TEST_REPO/git/refs" -f ref="refs/heads/$branch" -f sha="$base_sha" > /dev/null
+          echo "Created versioning test branch '$branch' at ${base_sha:0:9}"
+
           printf '@prefix a:\t<https://w3id.org/atomgraph/core#> .\n\n<urn:linkeddatahub:versioning/end-user>\n{\n    <urn:linkeddatahub:versioning/end-user> a:authToken "%s" .\n}\n' "$VERSIONING_TEST_TOKEN" > ./secrets/credentials.trig
           cat >> ./http-tests/config/system.trig <<EOF
 
-          # GitHub-backed graph versioning (appended by CI; per-run path prefix isolates concurrent runs)
+          # GitHub-backed graph versioning (appended by CI; per-run branch isolates concurrent runs)
 
           @prefix doap:	<http://usefulinc.com/ns/doap#> .
           @prefix github:	<https://w3id.org/atomgraph/linkeddatahub/services/github#> .
@@ -64,12 +75,13 @@ jobs:
           {
               <urn:linkeddatahub:versioning/end-user> a doap:GitRepository ;
                   doap:location <https://github.com/$VERSIONING_TEST_REPO> ;
-                  github:branch "main" ;
+                  github:branch "$branch" ;
                   github:pathPrefix "graphs-${{ github.run_id }}" .
           }
           EOF
           echo "COMPOSE_VERSIONING=-f ./http-tests/docker-compose.versioning.yml" >> "$GITHUB_ENV"
           echo "VERSIONING_PATH_PREFIX=graphs-${{ github.run_id }}" >> "$GITHUB_ENV"
+          echo "VERSIONING_TEST_BRANCH=$branch" >> "$GITHUB_ENV"
         shell: bash
       - name: Build Docker image & Run Docker containers
         run: docker compose -f docker-compose.yml -f ./http-tests/docker-compose.http-tests.yml ${COMPOSE_VERSIONING:-} --env-file ./http-tests/.env up --build -d
@@ -85,6 +97,7 @@ jobs:
         working-directory: http-tests
         env:
           GITHUB_TOKEN: ${{ secrets.VERSIONING_TEST_TOKEN }} # the versioning suite (and its gh api calls) authenticate with this; empty = suite skips
+          VERSIONING_TEST_BRANCH: ${{ env.VERSIONING_TEST_BRANCH }} # the per-run branch the suite polls; unset = main
       - name: Generate test summary
         if: always()
         run: python3 scripts/generate_test_summary.py http-tests/out http-tests/out/report.md
@@ -104,6 +117,11 @@ jobs:
       - name: Dump Tomcat logs from linkeddatahub container on failure
         if: failure()
         run: docker compose --env-file ./http-tests/.env exec -T linkeddatahub sh -c 'for f in /usr/local/tomcat/logs/*; do echo "=== $f ==="; cat "$f"; done' || true
+      - name: Delete the versioning test branch
+        if: always() && env.VERSIONING_TEST_BRANCH != ''
+        env:
+          GH_TOKEN: ${{ secrets.VERSIONING_TEST_TOKEN }}
+        run: gh api -X DELETE "repos/$VERSIONING_TEST_REPO/git/refs/heads/$VERSIONING_TEST_BRANCH" || true
       - name: Stop Docker containers and remove volumes
         run: docker compose --env-file ./http-tests/.env down -v
       - name: Remove Docker containers

--- a/http-tests/versioning/DELETE-removes-file.sh
+++ b/http-tests/versioning/DELETE-removes-file.sh
@@ -38,12 +38,12 @@ echo "<${doc_url}> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://ww
     "$doc_url"
 
 for i in $(seq 1 30); do
-    if gh api "repos/${VERSIONING_TEST_REPO}/contents/${path}?ref=main" > /dev/null 2>&1; then
+    if gh api "repos/${VERSIONING_TEST_REPO}/contents/${path}?ref=${VERSIONING_TEST_BRANCH:-main}" > /dev/null 2>&1; then
         break
     fi
     sleep 1
 done
-gh api "repos/${VERSIONING_TEST_REPO}/contents/${path}?ref=main" > /dev/null
+gh api "repos/${VERSIONING_TEST_REPO}/contents/${path}?ref=${VERSIONING_TEST_BRANCH:-main}" > /dev/null
 
 # delete the document and check that the file disappears
 
@@ -53,7 +53,7 @@ delete.sh \
   "$doc_url"
 
 for i in $(seq 1 30); do
-    if ! gh api "repos/${VERSIONING_TEST_REPO}/contents/${path}?ref=main" > /dev/null 2>&1; then
+    if ! gh api "repos/${VERSIONING_TEST_REPO}/contents/${path}?ref=${VERSIONING_TEST_BRANCH:-main}" > /dev/null 2>&1; then
         exit 0
     fi
     sleep 1

--- a/http-tests/versioning/GET-timegate.sh
+++ b/http-tests/versioning/GET-timegate.sh
@@ -40,7 +40,7 @@ put_document()
 
 head_sha()
 {
-    gh api "repos/${VERSIONING_TEST_REPO}/commits?path=${path}&per_page=1" --jq '.[0].sha' 2> /dev/null || true
+    gh api "repos/${VERSIONING_TEST_REPO}/commits?path=${path}&sha=${VERSIONING_TEST_BRANCH:-main}&per_page=1" --jq '.[0].sha' 2> /dev/null || true
 }
 
 # create two versions

--- a/http-tests/versioning/GET-timemap.sh
+++ b/http-tests/versioning/GET-timemap.sh
@@ -38,12 +38,12 @@ echo "<${doc_url}> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://ww
     "$doc_url"
 
 for i in $(seq 1 30); do
-    if gh api "repos/${VERSIONING_TEST_REPO}/contents/${path}?ref=main" > /dev/null 2>&1; then
+    if gh api "repos/${VERSIONING_TEST_REPO}/contents/${path}?ref=${VERSIONING_TEST_BRANCH:-main}" > /dev/null 2>&1; then
         break
     fi
     sleep 1
 done
-gh api "repos/${VERSIONING_TEST_REPO}/contents/${path}?ref=main" > /dev/null
+gh api "repos/${VERSIONING_TEST_REPO}/contents/${path}?ref=${VERSIONING_TEST_BRANCH:-main}" > /dev/null
 
 # check that the document advertises its TimeMap via the Link header
 

--- a/http-tests/versioning/GET-version.sh
+++ b/http-tests/versioning/GET-version.sh
@@ -40,7 +40,7 @@ put_document()
 
 head_sha()
 {
-    gh api "repos/${VERSIONING_TEST_REPO}/commits?path=${path}&per_page=1" --jq '.[0].sha' 2> /dev/null || true
+    gh api "repos/${VERSIONING_TEST_REPO}/commits?path=${path}&sha=${VERSIONING_TEST_BRANCH:-main}&per_page=1" --jq '.[0].sha' 2> /dev/null || true
 }
 
 # create the first version and wait for its commit

--- a/http-tests/versioning/PUT-creates-commit.sh
+++ b/http-tests/versioning/PUT-creates-commit.sh
@@ -41,16 +41,16 @@ echo "<${doc_url}> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://ww
 path="${VERSIONING_PATH_PREFIX:-graphs}/${slug}.nt"
 
 for i in $(seq 1 30); do
-    if gh api "repos/${VERSIONING_TEST_REPO}/contents/${path}?ref=main" > /dev/null 2>&1; then
+    if gh api "repos/${VERSIONING_TEST_REPO}/contents/${path}?ref=${VERSIONING_TEST_BRANCH:-main}" > /dev/null 2>&1; then
         break
     fi
     sleep 1
 done
-gh api "repos/${VERSIONING_TEST_REPO}/contents/${path}?ref=main" > /dev/null
+gh api "repos/${VERSIONING_TEST_REPO}/contents/${path}?ref=${VERSIONING_TEST_BRANCH:-main}" > /dev/null
 
 # check that the commit author is the agent's WebID
 
-author=$(gh api "repos/${VERSIONING_TEST_REPO}/commits?path=${path}&per_page=1" --jq '.[0].commit.author.name')
+author=$(gh api "repos/${VERSIONING_TEST_REPO}/commits?path=${path}&sha=${VERSIONING_TEST_BRANCH:-main}&per_page=1" --jq '.[0].commit.author.name')
 echo "DEBUG: Expected author: $AGENT_URI"
 echo "DEBUG: Got author: $author"
 [ "$author" = "$AGENT_URI" ]


### PR DESCRIPTION
Fixes the versioning suite's CI flakiness, and makes the next failure diagnosable.

## The problem

Six overlapping runs on 2026-08-25 failed, each on a different versioning test, while identical code passed on runs that happened to have less overlap:

```
32894662196 ft-version-diff  20:19:19→20:29:58  success
32894334438 ft-version-diff  20:15:54→20:28:09  failure
32894296012 develop          20:15:29→20:28:51  failure
32893958304 ft-version-diff  20:12:03→20:25:59  failure
32893707299 develop          20:09:31→20:21:18  failure
32893093303 ft-version-diff  20:03:11→20:14:59  failure
```

The GitHub Contents API takes an optimistic lock on the **branch head**, not on the file. CI gave each run its own `github:pathPrefix` (`graphs-<run_id>`), which isolates the files but not the head — so every concurrent run raced every other run on `main`. Graph versioning is best-effort and asynchronous, so a lost commit is never reported: the document `PUT` still returns `201 Created`, and an unrelated test times out 30 seconds later waiting for a commit that was discarded.

## Branch isolation (`af75e8ea2`)

The run branches `ci-<run_id>` from `main`, points the dataspace at it, and deletes it in an `if: always()` teardown. The suite polls whichever branch it was given via `VERSIONING_TEST_BRANCH`.

Ten API calls in the tests stopped assuming `main`. Note the commits-API calls previously passed **no** ref at all, silently following the repository default branch — those now pass `&sha=`, without which the suite would have polled `main` while the server committed to the per-run branch. Everything falls back to `main` when the variable is unset, so local runs are unchanged.

## Diagnosability (`7679d5c05`)

Separate commit — drop it if you want the isolation fix alone.

The polling loops swallowed the API error and ended in a bare `[ -n "$sha1" ]`, so a timeout printed nothing: captured output stopped at the document's `201 Created` with no indication of what was awaited or what GitHub said. Diagnosing one flaky run took six. Each wait now reports elapsed seconds and the SHAs it saw, and on timeout prints the contents API response for the polled path plus recent commits on the branch — enough to tell a lagging commits API from a write that never landed. This is what `CLAUDE.md` asks for under "Debugging Test Failures".

`http-tests/run.sh` is deliberately untouched: a versioning-specific helper does not belong in the generic harness beside `initialize_dataset`/`purge_cache`, and there is no precedent for suite-local sourcing, so the debug is inline per test.

## Verification

All five scripts pass `bash -n`; the workflow parses as YAML with both new steps correctly guarded. The `VERSIONING_TEST_TOKEN` PAT has *Read and Write access to code* on the test repository, which is the fine-grained permission gating both ref creation and deletion.

Two things this run will establish that local checks cannot: that the CI secret holds that same PAT, and that the branch round-trip works end to end. Both now fail loudly at branch creation within ~30 seconds instead of surfacing as test timeouts eight minutes in.

## Known limitation

A run cancelled between branch creation and teardown leaks its `ci-<run_id>` branch. The teardown is `if: always()`, so it survives test failures but not a hard cancellation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
