### PR TITLE
Restore a document to an earlier version from the history modal

### DIFF
--- a/src/main/webapp/static/com/atomgraph/linkeddatahub/xsl/bootstrap/2.3.2/client/memento.xsl
+++ b/src/main/webapp/static/com/atomgraph/linkeddatahub/xsl/bootstrap/2.3.2/client/memento.xsl
@@ -38,20 +38,38 @@ version="3.0"
         <ixsl:set-style name="cursor" select="'progress'" object="ixsl:page()//body"/>
 
         <xsl:variable name="request" select="map{ 'method': 'GET', 'href': $timemap-uri, 'headers': map{ 'Accept': 'application/rdf+xml' } }" as="map(*)"/>
-        <xsl:variable name="context" select="map{ 'request': $request, 'timemap-uri': $timemap-uri, 'container': $container }" as="map(*)"/>
+        <!-- ac:absolute-path() drops the ?version= that distinguishes a memento from the document it specializes -->
+        <xsl:variable name="context" select="map{ 'request': $request, 'timemap-uri': $timemap-uri, 'doc-uri': ac:absolute-path(ldh:request-uri()), 'container': $container }" as="map(*)"/>
         <ixsl:promise select="
           ixsl:http-request($context('request'))
             => ixsl:then(ldh:rethread-response($context, ?))
             => ixsl:then(ldh:handle-response#1)
+            => ixsl:then(ldh:load-document-modes#1)
             => ixsl:then(ldh:timemap-response#1)
         " on-failure="ldh:promise-failure#1"/>
     </xsl:template>
+
+    <!-- reads the live document's access modes, which decide whether a version can be restored.
+         Neither the memento nor the TimeMap response can answer this: both are snapshot views and
+         ResponseHeadersFilter caps them at acl:Read, so the modes are read from the document itself. -->
+    <xsl:function name="ldh:load-document-modes" as="item()*" ixsl:updating="yes">
+        <xsl:param name="context" as="map(*)"/>
+
+        <xsl:variable name="request" select="map{ 'method': 'HEAD', 'href': ldh:href($context('doc-uri')), 'headers': map{ 'Accept': 'application/rdf+xml' } }" as="map(*)"/>
+        <xsl:sequence select="
+          ixsl:http-request($request)
+            => ixsl:then(ldh:rethread-response($context, ?, 'doc-response'))
+        "/>
+    </xsl:function>
 
     <!-- renders the version history modal from the TimeMap RDF response -->
     <xsl:function name="ldh:timemap-response" as="item()?" ixsl:updating="yes">
         <xsl:param name="context" as="map(*)"/>
         <xsl:variable name="response" select="$context('response')" as="map(*)"/>
         <xsl:variable name="container" select="$context('container')" as="element()"/>
+        <!-- same Link header parse as client.xsl uses to seed acl:mode(), but against the live document's response -->
+        <xsl:variable name="acl-modes" select="tokenize($context('doc-response')?headers?link, ',')[contains(., '&acl;mode')] ! xs:anyURI(substring-before(substring-after(substring-before(., ';'), '&lt;'), '&gt;'))" as="xs:anyURI*"/>
+        <xsl:variable name="writable" select="$acl-modes = '&acl;Write'" as="xs:boolean"/>
 
         <xsl:for-each select="$response">
             <ixsl:set-style name="cursor" select="'default'" object="ixsl:page()//body"/>
@@ -83,9 +101,6 @@ version="3.0"
                                     <!-- preselect the viewed version as the diff target and its predecessor as the diff source (the viewed version itself when there is none) -->
                                     <xsl:variable name="from-memento" select="(xs:anyURI($sorted-mementos[$current-index - 1]/@rdf:about), $current-memento)[1]" as="xs:anyURI?"/>
                                     <form id="form-version-diff">
-                                        <!-- a restore rewrites the live document, so it needs acl:Write there. On a ?version= view the
-                                             response advertises acl:Read at most, so the restore buttons only appear from the live document. -->
-                                        <xsl:variable name="writable" select="acl:mode() = '&acl;Write'" as="xs:boolean"/>
                                         <table class="table table-striped">
                                             <colgroup>
                                                 <col style="width: 38%;"/>

--- a/src/main/webapp/static/com/atomgraph/linkeddatahub/xsl/bootstrap/2.3.2/client/memento.xsl
+++ b/src/main/webapp/static/com/atomgraph/linkeddatahub/xsl/bootstrap/2.3.2/client/memento.xsl
@@ -6,6 +6,7 @@
     <!ENTITY rdf     "http://www.w3.org/1999/02/22-rdf-syntax-ns#">
     <!ENTITY prov    "http://www.w3.org/ns/prov#">
     <!ENTITY sp      "http://spinrdf.org/sp#">
+    <!ENTITY acl     "http://www.w3.org/ns/auth/acl#">
 ]>
 <xsl:stylesheet
 xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
@@ -18,6 +19,7 @@ xmlns:ac="&ac;"
 xmlns:rdf="&rdf;"
 xmlns:prov="&prov;"
 xmlns:sp="&sp;"
+xmlns:acl="&acl;"
 xmlns:bs2="http://graphity.org/xsl/bootstrap/2.3.2"
 xmlns:xhtml="http://www.w3.org/1999/xhtml"
 exclude-result-prefixes="#all"
@@ -81,12 +83,16 @@ version="3.0"
                                     <!-- preselect the viewed version as the diff target and its predecessor as the diff source (the viewed version itself when there is none) -->
                                     <xsl:variable name="from-memento" select="(xs:anyURI($sorted-mementos[$current-index - 1]/@rdf:about), $current-memento)[1]" as="xs:anyURI?"/>
                                     <form id="form-version-diff">
+                                        <!-- a restore rewrites the live document, so it needs acl:Write there. On a ?version= view the
+                                             response advertises acl:Read at most, so the restore buttons only appear from the live document. -->
+                                        <xsl:variable name="writable" select="acl:mode() = '&acl;Write'" as="xs:boolean"/>
                                         <table class="table table-striped">
                                             <colgroup>
-                                                <col style="width: 45%;"/>
-                                                <col style="width: 25%;"/>
-                                                <col style="width: 15%;"/>
-                                                <col style="width: 15%;"/>
+                                                <col style="width: 38%;"/>
+                                                <col style="width: 22%;"/>
+                                                <col style="width: 12%;"/>
+                                                <col style="width: 12%;"/>
+                                                <col style="width: 16%;"/>
                                             </colgroup>
                                             <thead>
                                                 <tr>
@@ -111,6 +117,8 @@ version="3.0"
                                                             <xsl:apply-templates select="key('resources', 'to', document(resolve-uri('static/com/atomgraph/linkeddatahub/xsl/bootstrap/2.3.2/translations.rdf', $lapp:origin)))" mode="ac:label"/>
                                                         </xsl:value-of>
                                                     </th>
+                                                    <!-- the restore column has no heading: the buttons name the action themselves -->
+                                                    <th></th>
                                                 </tr>
                                             </thead>
                                             <tbody>
@@ -119,6 +127,7 @@ version="3.0"
                                                     <xsl:with-param name="current-memento" select="$current-memento"/>
                                                     <xsl:with-param name="from-memento" select="$from-memento"/>
                                                     <xsl:with-param name="to-memento" select="$current-memento"/>
+                                                    <xsl:with-param name="writable" select="$writable"/>
                                                 </xsl:apply-templates>
                                             </tbody>
                                         </table>
@@ -171,6 +180,88 @@ version="3.0"
             </xsl:call-template>
         </xsl:if>
     </xsl:template>
+
+    <!-- restores a version: reads it back and writes it to the live document, which the versioning filter
+         records as a new commit. The memento itself is never written to, so it stays immutable per RFC 7089. -->
+    <xsl:template match="button[contains-token(@class, 'btn-restore')]" mode="ixsl:onclick">
+        <xsl:sequence select="ixsl:call(ixsl:event(), 'preventDefault', [])"/>
+        <xsl:variable name="memento-uri" select="xs:anyURI(ixsl:get(., 'value'))" as="xs:anyURI"/>
+        <!-- ac:absolute-path() drops the ?version= that distinguishes a memento from the document it specializes -->
+        <xsl:variable name="doc-uri" select="ac:absolute-path(ldh:request-uri())" as="xs:anyURI"/>
+        <xsl:variable name="modal" select="ancestor::div[contains-token(@class, 'modal')]" as="element()?"/>
+
+        <xsl:if test="ixsl:call(ixsl:window(), 'confirm', [ ac:label(key('resources', 'are-you-sure', document(resolve-uri('static/com/atomgraph/linkeddatahub/xsl/bootstrap/2.3.2/translations.rdf', $lapp:origin)))) ])">
+            <ixsl:set-style name="cursor" select="'progress'" object="ixsl:page()//body"/>
+
+            <xsl:variable name="request" select="map{ 'method': 'GET', 'href': $memento-uri, 'headers': map{ 'Accept': 'application/rdf+xml' } }" as="map(*)"/>
+            <xsl:variable name="context" select="map{ 'request': $request, 'doc-uri': $doc-uri, 'modal': $modal }" as="map(*)"/>
+            <ixsl:promise select="
+              ixsl:http-request($context('request'))
+                => ixsl:then(ldh:rethread-response($context, ?))
+                => ixsl:then(ldh:handle-response#1)
+                => ixsl:then(ldh:restore-version#1)
+            " on-failure="ldh:promise-failure#1"/>
+        </xsl:if>
+    </xsl:template>
+
+    <!-- writes the retrieved version back to the live document -->
+    <xsl:function name="ldh:restore-version" as="item()*" ixsl:updating="yes">
+        <xsl:param name="context" as="map(*)"/>
+        <xsl:variable name="response" select="$context('response')" as="map(*)"/>
+
+        <xsl:choose>
+            <xsl:when test="$response?status = 200 and exists($response?body)">
+                <!-- the graph store takes the document node directly; the server restamps dct:modified -->
+                <xsl:variable name="request" select="map{ 'method': 'PUT', 'href': ldh:href($context('doc-uri')), 'media-type': 'application/rdf+xml', 'body': $response?body, 'headers': map{ 'Accept': 'application/rdf+xml' } }" as="map(*)"/>
+                <xsl:sequence select="
+                  ixsl:http-request($request)
+                    => ixsl:then(ldh:rethread-response(map:remove($context, 'response'), ?))
+                    => ixsl:then(ldh:restored-version#1)"/>
+            </xsl:when>
+            <xsl:otherwise>
+                <ixsl:set-style name="cursor" select="'default'" object="ixsl:page()//body"/>
+                <xsl:sequence select="ldh:restore-failed($context, 'Could not read the selected version')"/>
+            </xsl:otherwise>
+        </xsl:choose>
+    </xsl:function>
+
+    <!-- dismisses the modal and re-renders the document, whose newest version is now the restored one -->
+    <xsl:function name="ldh:restored-version" as="item()*" ixsl:updating="yes">
+        <xsl:param name="context" as="map(*)"/>
+        <xsl:variable name="response" select="$context('response')" as="map(*)"/>
+
+        <ixsl:set-style name="cursor" select="'default'" object="ixsl:page()//body"/>
+
+        <xsl:choose>
+            <xsl:when test="$response?status = (200, 201, 204)">
+                <xsl:for-each select="$context('modal')">
+                    <xsl:sequence select="ixsl:call(., 'remove', [])[current-date() lt xs:date('2000-01-01')]"/>
+                </xsl:for-each>
+
+                <!-- land on the live document rather than the ?version= view the restore was started from, which is now stale -->
+                <xsl:call-template name="ldh:DocumentNavigate">
+                    <xsl:with-param name="doc-uri" select="$context('doc-uri')"/>
+                </xsl:call-template>
+            </xsl:when>
+            <xsl:otherwise>
+                <xsl:sequence select="ldh:restore-failed($context, 'Could not restore this version')"/>
+            </xsl:otherwise>
+        </xsl:choose>
+    </xsl:function>
+
+    <!-- reports a failed restore inside the modal, so the agent keeps the version list they were working from -->
+    <xsl:function name="ldh:restore-failed" as="item()?" ixsl:updating="yes">
+        <xsl:param name="context" as="map(*)"/>
+        <xsl:param name="message" as="xs:string"/>
+
+        <xsl:for-each select="$context('modal')/div[contains-token(@class, 'modal-body')]">
+            <xsl:result-document href="?." method="ixsl:prepend-content">
+                <div class="alert alert-error">
+                    <xsl:value-of select="$message || ' (HTTP ' || $context('response')?status || ')'"/>
+                </div>
+            </xsl:result-document>
+        </xsl:for-each>
+    </xsl:function>
 
     <!-- fetches the ?diff= comparison version when the context carries a diff request; passes the context through otherwise -->
     <xsl:function name="ldh:load-diff-version" as="item()*" ixsl:updating="yes">

--- a/src/main/webapp/static/com/atomgraph/linkeddatahub/xsl/bootstrap/2.3.2/imports/memento.xsl
+++ b/src/main/webapp/static/com/atomgraph/linkeddatahub/xsl/bootstrap/2.3.2/imports/memento.xsl
@@ -3,12 +3,14 @@
     <!ENTITY rdf     "http://www.w3.org/1999/02/22-rdf-syntax-ns#">
     <!ENTITY prov    "http://www.w3.org/ns/prov#">
     <!ENTITY dct     "http://purl.org/dc/terms/">
+    <!ENTITY lapp    "https://w3id.org/atomgraph/linkeddatahub/apps#">
 ]>
 <xsl:stylesheet version="3.0"
 xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
 xmlns:xs="http://www.w3.org/2001/XMLSchema"
 xmlns:map="http://www.w3.org/2005/xpath-functions/map"
 xmlns:ldh="https://w3id.org/atomgraph/linkeddatahub#"
+xmlns:lapp="&lapp;"
 xmlns:ac="https://w3id.org/atomgraph/client#"
 xmlns:rdf="&rdf;"
 xmlns:prov="&prov;"
@@ -26,6 +28,8 @@ exclude-result-prefixes="#all"
         <!-- preselected diff endpoints: the version being viewed and its predecessor -->
         <xsl:param name="from-memento" as="xs:anyURI?"/>
         <xsl:param name="to-memento" as="xs:anyURI?"/>
+        <!-- whether the agent can write the live document, which is what a restore rewrites -->
+        <xsl:param name="writable" select="false()" as="xs:boolean"/>
 
         <tr>
             <td>
@@ -59,6 +63,17 @@ exclude-result-prefixes="#all"
                         <xsl:attribute name="checked" select="'checked'"/>
                     </xsl:if>
                 </input>
+            </td>
+            <td>
+                <!-- restoring is a point action on one version, unlike the From/To pair that bounds a comparison.
+                     The version being viewed is skipped: writing it back would only commit identical content. -->
+                <xsl:if test="$writable and not(@rdf:about = $current-memento)">
+                    <button type="button" class="btn btn-restore" value="{@rdf:about}">
+                        <xsl:value-of>
+                            <xsl:apply-templates select="key('resources', 'restore', document(resolve-uri('static/com/atomgraph/linkeddatahub/xsl/bootstrap/2.3.2/translations.rdf', $lapp:origin)))" mode="ac:label"/>
+                        </xsl:value-of>
+                    </button>
+                </xsl:if>
             </td>
         </tr>
     </xsl:template>

--- a/src/main/webapp/static/com/atomgraph/linkeddatahub/xsl/bootstrap/2.3.2/translations.rdf
+++ b/src/main/webapp/static/com/atomgraph/linkeddatahub/xsl/bootstrap/2.3.2/translations.rdf
@@ -565,4 +565,8 @@
         <rdfs:label xml:lang="en-US">changed</rdfs:label>
         <rdfs:label xml:lang="es-ES">modificado</rdfs:label>
     </rdf:Description>
+    <rdf:Description rdf:nodeID="restore">
+        <rdfs:label xml:lang="en-US">Restore</rdfs:label>
+        <rdfs:label xml:lang="es-ES">Restaurar</rdfs:label>
+    </rdf:Description>
 </rdf:RDF>


### PR DESCRIPTION
Adds rollback to the versioning feature — the last of the P2.2 remainder listed in the audit roadmap alongside the reconciliation sweep. History was readable but there was no way to act on it.

## Restore is a per-row action

Not a button beside **Compare**. The From/To radios bound a comparison *range*, while restoring acts on a *single* version — putting Restore in `form-actions` would leave it ambiguous which endpoint was being restored. A per-row button says which version it acts on, keeps the radios meaning only "what am I comparing", and matches the pattern from MediaWiki and most CMS history views.

| Version | Agent | From | To | |
|---|---|---|---|---|
| 25 Aug 2026 21:08 | John Doe | ○ | ● | *(current — no button)* |
| 18 Aug 2026 10:28 | this | ● | ○ | **Restore** |

## No new server surface

The client reads the memento back and writes it to the live document:

```
GET  <doc>?version=<sha>   (application/rdf+xml)
PUT  <doc>                 (the returned document node)
```

The existing `VersioningFilter` turns that PUT into a new commit, so a restore **rolls forward** rather than rewriting history — the versions rolled past stay in the TimeMap, and the restore itself becomes the newest version. The memento is never written to, so it stays immutable as RFC 7089 requires and `checkSnapshotReadOnly()` keeps rejecting writes to `?version=`.

A server-side `POST <doc>?version=<sha>` would have been one round trip instead of two, but it would mean carving a hole in the read-only rule and inventing write semantics on a Memento URI. Not worth it for one saved request.

## Permission comes from the live document

`acl:mode()` reflects the *current* response, and `ResponseHeadersFilter` deliberately caps snapshot views at `acl:Read` so the UI disables edit affordances on a historical version. The TimeMap response is capped for the same reason — so neither can say whether the live document is writable, and gating on `acl:mode()` hid the buttons precisely where they are most wanted: looking at an old version, deciding to bring it back.

Opening the modal now also HEADs the live document and parses its `acl:mode` links, reusing the parse `client.xsl:424-425` uses to seed `acl:mode()`. It follows the existing `ldh:load-diff-version` shape — an extra promise step stashing its result under its own context key via the 3-arg `ldh:rethread-response`, leaving the TimeMap response intact. Costs one HEAD per modal open.

## Guards

- rendered only where the agent holds `acl:Write` on the live document
- never on the version already being viewed, which would commit identical content
- `confirm()` before writing, reusing the shared `are-you-sure` label
- a failed read or write renders `alert-error` inside the modal, so the agent keeps the version list they were working from

## Testing

Verified end to end against a live instance: restoring the 18 August version of a document works, and the result was checked against the versioning repository rather than taken on trust.

**Roll-forward holds.** The restore lands as a new commit (`PUT <doc>`) with every prior version intact — nothing is rewritten, and the versions rolled past stay in the TimeMap:

```
4410105fd  2026-08-25T21:25:25Z  PUT     ← the restore
4edd36332  2026-08-25T19:08:31Z  PATCH
8b7dade75  2026-08-18T08:28:25Z  PATCH
e1af014e3  2026-08-18T08:28:18Z  POST    ← the version restored
```

**Content is faithful.** Every content triple in the result is identical to the restored version, XMLLiterals included — so the parsed `document-node()` does survive the round trip into the PUT body, which was the main risk in this approach.

`make sef` compiles and `riot` validates `translations.rdf`. CI exercises the server and this change is entirely client-side XSLT, so a green run means nothing regressed server-side, not that Restore works.

## Known limitation

Two versions committed in the same minute are **indistinguishable in the modal**. The datetime renders through Web-Client's generic `xsd:dateTime` template (`imports/default.xsl:394`), whose picture is `[D] [MNn] [Y] [H01]:[m01]` — no seconds. The document used for testing has two versions seven seconds apart, both displayed as "18 August 2026 10:28".

Adding seconds would mean changing a formatter shared by every date in the application, in a sibling repository. The contained fix is to show the short commit SHA alongside the datetime in this row only — it is already present in the memento URI (`<doc>?version=<sha>`), so it discloses nothing the row does not already carry. Not done here.

## Observed while verifying — not introduced by this PR

Writes accumulate document metadata. Across the restore, `dct:creator` and `acl:owner` each went from one value to two (the restoring agent added alongside the original), and `dct:created` grew from 201 values to 209 — the earliest dating to June, so that accumulation long predates this change. Whether the creator/owner duplication is specific to restore or happens on every PUT has not been established, and is worth its own investigation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
