### PR TITLE
Give the owner and secretary authorizations stable slugs

### DIFF
--- a/http-tests/root-owner.trig.template
+++ b/http-tests/root-owner.trig.template
@@ -55,15 +55,15 @@
     <acl/groups/owners/#this> foaf:member <${OWNER_URI}> .
 }
 
-<acl/authorizations/${OWNER_KEY_UUID}/> # TO-DO: use $OWNER_AUTH_UUID
+<acl/authorizations/owner-webid/>
 {
 
-    <acl/authorizations/${OWNER_KEY_UUID}/> a dh:Item ;
-        foaf:primaryTopic <acl/authorizations/${OWNER_KEY_UUID}/#auth> ;
+    <acl/authorizations/owner-webid/> a dh:Item ;
+        foaf:primaryTopic <acl/authorizations/owner-webid/#auth> ;
         sioc:has_container <acl/authorizations/> ;
         dct:title "Public owner's WebID" .
 
-    <acl/authorizations/${OWNER_KEY_UUID}/#auth> a acl:Authorization ;
+    <acl/authorizations/owner-webid/#auth> a acl:Authorization ;
         acl:accessTo <${OWNER_DOC_URI}>, <acl/public-keys/${OWNER_KEY_UUID}/> ;
         acl:mode acl:Read ;
         acl:agentClass foaf:Agent, acl:AuthenticatedAgent .

--- a/platform/entrypoint.sh
+++ b/platform/entrypoint.sh
@@ -908,8 +908,9 @@ for app in "${apps[@]}"; do
             owner_auth_dataset_path="/var/linkeddatahub/datasets/${app_folder}/owner-authorization.trig"
             mkdir -p "$(dirname "$owner_auth_dataset_path")"
 
-            OWNER_AUTH_UUID=$(uuidgen | tr '[:upper:]' '[:lower:]')
-            OWNER_AUTH_DOC_URI="${app_origin}/acl/authorizations/${OWNER_AUTH_UUID}/"
+            # a stable slug, like every authorization bundled in admin.trig: a fresh UUID per run made this
+            # document new every time, so each container recreate left another copy of the same grant behind
+            OWNER_AUTH_DOC_URI="${app_origin}/acl/authorizations/owner-webid/"
             OWNER_AUTH_URI="${OWNER_AUTH_DOC_URI}#auth"
 
             export OWNER_URI OWNER_DOC_URI OWNER_KEY_DOC_URI OWNER_AUTH_DOC_URI OWNER_AUTH_URI
@@ -923,8 +924,7 @@ for app in "${apps[@]}"; do
             secretary_auth_dataset_path="/var/linkeddatahub/datasets/${app_folder}/secretary-authorization.trig"
             mkdir -p "$(dirname "$secretary_auth_dataset_path")"
 
-            SECRETARY_AUTH_UUID=$(uuidgen | tr '[:upper:]' '[:lower:]')
-            SECRETARY_AUTH_DOC_URI="${app_origin}/acl/authorizations/${SECRETARY_AUTH_UUID}/"
+            SECRETARY_AUTH_DOC_URI="${app_origin}/acl/authorizations/secretary-webid/"
             SECRETARY_AUTH_URI="${SECRETARY_AUTH_DOC_URI}#auth"
 
             export SECRETARY_URI SECRETARY_DOC_URI SECRETARY_KEY_DOC_URI SECRETARY_AUTH_DOC_URI SECRETARY_AUTH_URI


### PR DESCRIPTION
The entrypoint minted a fresh UUID for the owner and secretary authorization documents on every run that loads datasets, so each container recreate left another copy of the same grant behind. A development instance had **60** of them — 30 identical "Public owner's WebID" authorizations and 30 for the secretary — against 24 real ones.

Same shape of bug as #368: an install step that isn't idempotent. There the non-idempotent part was a timestamp; here it is the identifier.

## The fix

```diff
-OWNER_AUTH_UUID=$(uuidgen | tr '[:upper:]' '[:lower:]')
-OWNER_AUTH_DOC_URI="${app_origin}/acl/authorizations/${OWNER_AUTH_UUID}/"
+OWNER_AUTH_DOC_URI="${app_origin}/acl/authorizations/owner-webid/"
```

Every authorization bundled in `admin.trig` is named for what it is — `public/`, `sign-up/`, `full-control/`, `oauth2-login/`. These two now follow that convention, which makes re-running the load a no-op **by construction**: same document URI, same triples, and RDF is a set. No check required, which is exactly why `public/` and `sign-up/` never accumulated.

## Why UUIDs were there

Not a decision so much as idiom inheritance. They arrived with #246 ("Auth isolated by dataspace"), which made authorizations per-dataspace and introduced these templates. The entrypoint already had four `uuidgen` calls — `OWNER_UUID`, `SECRETARY_UUID`, `OWNER_KEY_UUID`, `SECRETARY_KEY_UUID` — and the new documents followed the pattern already in the file.

For those four a UUID is right: they are per-install *identities*, and they are effectively minted once, since existing owner metadata is read back from the dataset rather than regenerated. These two are fixed *role grants* regenerated on every load, which is what turns a random identifier into an accumulation bug. They are left alone.

## Scope

`${OWNER_DOC_URI}` and friends stay variables, and deliberately. The owner's document is only at `acl/agents/${OWNER_UUID}/` when the entrypoint just minted it — on an existing install it is read back from the dataset (`entrypoint.sh:655`), and `OWNER_URI` can be an external WebID entirely (`entrypoint.sh:565`). The distinction the change relies on: identifiers we *mint* can take stable slugs, identifiers we are *told* cannot.

The second commit retires a standing `# TO-DO: use $OWNER_AUTH_UUID` in `http-tests/root-owner.trig.template`, which named its authorization after the owner's *key* UUID. It now uses the same slug, so the fixture and the generated authorization describe one document instead of two granting identical access under different URIs. The key document keeps its UUID.

## Verification

Nothing else depends on the generated URIs: the only references to `OWNER_AUTH_DOC_URI` / `SECRETARY_AUTH_URI` are the templates that consume them. The ACL queries filter by dataspace base (`strstarts(str(?g), str($base))`), not by slug, so #246's isolation is unaffected, and each app still gets its own `${app_origin}/acl/authorizations/owner-webid/`. Neither slug collides with the 12 bundled names.

The edited template was rendered with `envsubst` and validated with `riot`, producing the expected graphs.

## Migration

Existing deployments keep their UUID-named documents — redundant grants to the same agents, harmless but permanent. A cleanup matching on both the template title and a UUID-shaped URI removes them; matching on URI shape alone would be unsafe, since user-created authorizations get UUID slugs too.

**Order matters:** these grant public read to the owner and secretary WebID documents, so rebuild first, confirm `owner-webid/` and `secretary-webid/` exist, and only then delete the old ones — otherwise the grant is briefly absent. A plain restart will not recreate them, since dataset loading only runs when `based-datasets/` is missing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
