### PR TITLE
Chain versioning commits per branch and retry conflicts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -63,6 +63,9 @@
 - Nested cards no longer draw doubled borders, and `dl` column placement is corrected
 - The DataTable converters recognise the derived numeric and dateTime types
 - The violation renderer fails on an absent form again, rather than falling back to the rejected rendering
+- Concurrent writes to a versioned application silently lost commits: the commit chain was keyed by file path, while the GitHub Contents API takes its optimistic lock on the branch head — two documents committing at once conflicted and the loser was dropped with only a log line. Commits to one branch now share a single chain
+- A conflicting write is retried with a re-read blob SHA (`MAX_CONFLICT_RETRIES`) instead of being abandoned, so a writer outside this JVM no longer costs a version
+- A rate-limited commit retried with an empty request body: the builder had already been spent by the first attempt, and `JsonObjectBuilder` yields its object only once
 - `release.sh` published to Maven Central before its `git checkout master`, so a failed checkout left 5.10.0 on Central with no tag: the switches are now proven possible first, and once published the trap prints recovery steps instead of deleting the tag that records what was published
 - `release.sh`'s clean check could not see `skip-worktree`/`assume-unchanged` files — git reports them as matching the index whatever is on disk, while a branch switch refuses to overwrite them; they are now warned about at startup and checked precisely before publishing
 - `release.sh` derived the release and snapshot commits positionally (`git log -2`), which breaks as soon as anything else commits in between; they are derived from an anchor taken before `release:prepare`

--- a/src/main/java/com/atomgraph/linkeddatahub/client/GitHubClient.java
+++ b/src/main/java/com/atomgraph/linkeddatahub/client/GitHubClient.java
@@ -61,6 +61,10 @@ public class GitHubClient
     public static final String AUTHOR_EMAIL = "noreply@linkeddatahub.invalid";
     /** Maximum retries on rate-limited requests */
     public static final int MAX_RETRIES = 2;
+    /** Maximum retries on conflicting writes */
+    public static final int MAX_CONFLICT_RETRIES = 3;
+    /** Delay before the first conflict retry, multiplied by the attempt number on subsequent ones */
+    public static final long CONFLICT_RETRY_DELAY_MILLIS = 200;
     /** Commits requested per page when walking a file's history */
     public static final int COMMITS_PER_PAGE = 100;
     /** Maximum history pages retrieved, bounding the API calls a single TimeMap request can make */
@@ -94,7 +98,8 @@ public class GitHubClient
 
     /**
      * Creates or updates a file on the branch.
-     * The current blob SHA is fetched first, as the Contents API requires it for updates (optimistic locking).
+     * The current blob SHA is fetched first, as the Contents API requires it for updates (optimistic locking);
+     * a conflicting write is retried with a re-read SHA, up to {@link #MAX_CONFLICT_RETRIES} times.
      *
      * @param path file path within the repository
      * @param content file content
@@ -104,32 +109,43 @@ public class GitHubClient
      */
     public Commit putFile(String path, byte[] content, String message, String authorName)
     {
-        Optional<String> sha = getFileSha(path);
-
-        JsonObjectBuilder json = Json.createObjectBuilder().
-            add("message", message).
-            add("content", Base64.getEncoder().encodeToString(content)).
-            add("branch", branch).
-            add("author", author(authorName));
-        sha.ifPresent(s -> json.add("sha", s));
-
-        try (Response response = invoke(() -> contents(path).
-                request(GITHUB_JSON).
-                header(HttpHeaders.AUTHORIZATION, authorization).
-                buildPut(Entity.entity(json.build(), MediaType.APPLICATION_JSON_TYPE))))
+        for (int attempt = 0; ; attempt++)
         {
-            if (response.getStatus() == Response.Status.OK.getStatusCode() || response.getStatus() == Response.Status.CREATED.getStatusCode())
-            {
-                JsonObject result = response.readEntity(JsonObject.class);
-                return new Commit(result.getJsonObject("commit").getString("sha"), result.getJsonObject("content").getString("sha"));
-            }
+            Optional<String> sha = getFileSha(path); // re-probed on every attempt: a conflict means this SHA has moved
 
-            throw new RuntimeException("GitHub commit of '" + path + "' to " + owner + "/" + repo + " failed with status " + response.getStatus());
+            JsonObjectBuilder builder = Json.createObjectBuilder().
+                add("message", message).
+                add("content", Base64.getEncoder().encodeToString(content)).
+                add("branch", branch).
+                add("author", author(authorName));
+            sha.ifPresent(s -> builder.add("sha", s));
+            JsonObject json = builder.build(); // built once: a builder yields its object only to the first build()
+
+            try (Response response = invoke(() -> contents(path).
+                    request(GITHUB_JSON).
+                    header(HttpHeaders.AUTHORIZATION, authorization).
+                    buildPut(Entity.entity(json, MediaType.APPLICATION_JSON_TYPE))))
+            {
+                if (response.getStatus() == Response.Status.OK.getStatusCode() || response.getStatus() == Response.Status.CREATED.getStatusCode())
+                {
+                    JsonObject result = response.readEntity(JsonObject.class);
+                    return new Commit(result.getJsonObject("commit").getString("sha"), result.getJsonObject("content").getString("sha"));
+                }
+
+                if (response.getStatus() == Response.Status.CONFLICT.getStatusCode() && attempt < MAX_CONFLICT_RETRIES)
+                {
+                    backOff(attempt, path);
+                    continue;
+                }
+
+                throw new RuntimeException("GitHub commit of '" + path + "' to " + owner + "/" + repo + " failed with status " + response.getStatus());
+            }
         }
     }
 
     /**
      * Deletes a file from the branch. A no-op if the file does not exist.
+     * A conflicting write is retried with a re-read SHA, up to {@link #MAX_CONFLICT_RETRIES} times.
      *
      * @param path file path within the repository
      * @param message commit message
@@ -137,28 +153,38 @@ public class GitHubClient
      */
     public void deleteFile(String path, String message, String authorName)
     {
-        Optional<String> sha = getFileSha(path);
-        if (sha.isEmpty())
+        for (int attempt = 0; ; attempt++)
         {
-            if (log.isDebugEnabled()) log.debug("File '{}' not found in {}/{}, nothing to delete", path, owner, repo);
-            return;
-        }
+            Optional<String> sha = getFileSha(path); // re-probed on every attempt: a conflict means this SHA has moved
+            if (sha.isEmpty())
+            {
+                if (log.isDebugEnabled()) log.debug("File '{}' not found in {}/{}, nothing to delete", path, owner, repo);
+                return;
+            }
 
-        JsonObject json = Json.createObjectBuilder().
-            add("message", message).
-            add("sha", sha.get()).
-            add("branch", branch).
-            add("author", author(authorName)).
-            build();
+            JsonObject json = Json.createObjectBuilder().
+                add("message", message).
+                add("sha", sha.get()).
+                add("branch", branch).
+                add("author", author(authorName)).
+                build();
 
-        try (Response response = invoke(() -> contents(path).
-                request(GITHUB_JSON).
-                property(ClientProperties.SUPPRESS_HTTP_COMPLIANCE_VALIDATION, true). // the Contents API requires a body on DELETE
-                header(HttpHeaders.AUTHORIZATION, authorization).
-                build("DELETE", Entity.entity(json, MediaType.APPLICATION_JSON_TYPE))))
-        {
-            if (response.getStatus() != Response.Status.OK.getStatusCode())
+            try (Response response = invoke(() -> contents(path).
+                    request(GITHUB_JSON).
+                    property(ClientProperties.SUPPRESS_HTTP_COMPLIANCE_VALIDATION, true). // the Contents API requires a body on DELETE
+                    header(HttpHeaders.AUTHORIZATION, authorization).
+                    build("DELETE", Entity.entity(json, MediaType.APPLICATION_JSON_TYPE))))
+            {
+                if (response.getStatus() == Response.Status.OK.getStatusCode()) return;
+
+                if (response.getStatus() == Response.Status.CONFLICT.getStatusCode() && attempt < MAX_CONFLICT_RETRIES)
+                {
+                    backOff(attempt, path);
+                    continue;
+                }
+
                 throw new RuntimeException("GitHub deletion of '" + path + "' from " + owner + "/" + repo + " failed with status " + response.getStatus());
+            }
         }
     }
 
@@ -273,6 +299,36 @@ public class GitHubClient
         }
     }
 
+    /**
+     * Returns the repository owner.
+     *
+     * @return owner name
+     */
+    public String getOwner()
+    {
+        return owner;
+    }
+
+    /**
+     * Returns the repository name.
+     *
+     * @return repository name
+     */
+    public String getRepo()
+    {
+        return repo;
+    }
+
+    /**
+     * Returns the branch that commits are made on.
+     *
+     * @return branch name
+     */
+    public String getBranch()
+    {
+        return branch;
+    }
+
     private WebTarget contents(String path)
     {
         return endpoint.path("repos/{owner}/{repo}/contents/{path}").
@@ -321,6 +377,24 @@ public class GitHubClient
 
         return response.getStatus() == Response.Status.FORBIDDEN.getStatusCode() &&
             (response.getHeaderString("Retry-After") != null || "0".equals(response.getHeaderString("x-ratelimit-remaining")));
+    }
+
+    /**
+     * Sleeps before retrying a write that conflicted, backing off linearly to give the competing writer time to finish.
+     */
+    private void backOff(int attempt, String path)
+    {
+        if (log.isWarnEnabled()) log.warn("Conflicting write of '{}' to {}/{} on branch '{}', retrying", path, owner, repo, branch);
+
+        try
+        {
+            Thread.sleep(CONFLICT_RETRY_DELAY_MILLIS * (attempt + 1));
+        }
+        catch (InterruptedException ex)
+        {
+            Thread.currentThread().interrupt();
+            throw new RuntimeException(ex);
+        }
     }
 
     private long retryAfter(Response response)

--- a/src/main/java/com/atomgraph/linkeddatahub/server/util/GraphVersioningService.java
+++ b/src/main/java/com/atomgraph/linkeddatahub/server/util/GraphVersioningService.java
@@ -61,8 +61,9 @@ import org.slf4j.LoggerFactory;
  * Mirrors named graphs of versioning-enabled applications into GitHub repositories.
  * The unit of work is reconciliation: a task re-reads the graph from the application's
  * SPARQL service at execution time and makes the repository file match — including deleting
- * the file when the graph is gone. Tasks for the same file are chained sequentially so
- * commits never race the GitHub Contents API's SHA-based optimistic locking.
+ * the file when the graph is gone. Tasks for the same repository branch are chained sequentially:
+ * the GitHub Contents API takes its optimistic lock on the branch head rather than on the file, so
+ * commits to one branch conflict with each other no matter which files they touch.
  * Versioning is best-effort: task failures are logged, never propagated.
  *
  * @author Martynas Jusevičius {@literal <martynas@atomgraph.com>}
@@ -79,7 +80,7 @@ public class GraphVersioningService
     public record Repository(GitHubClient client, String pathPrefix) { }
 
     private final Map<String, Repository> repositories;
-    private final Map<String, CompletableFuture<Void>> commitChains = new ConcurrentHashMap<>();
+    private final Map<String, CompletableFuture<Void>> commitChains = new ConcurrentHashMap<>(); // keyed by repository branch
     private final ExecutorService executor = Executors.newFixedThreadPool(4);
 
     /**
@@ -149,7 +150,7 @@ public class GraphVersioningService
 
     /**
      * Schedules asynchronous reconciliation of a graph's repository file with its current store state.
-     * Chained per file path; returns immediately.
+     * Chained per repository branch; returns immediately.
      *
      * @param serviceContext deployment context of the application's SPARQL service
      * @param appURI application URI
@@ -165,8 +166,10 @@ public class GraphVersioningService
 
         String path = path(repository.pathPrefix(), appBase, graphURI);
         String message = method + " " + graphURI;
+        // all commits to a branch share one chain: two files committed concurrently would race the branch head
+        String repositoryBranch = repository.client().getOwner() + "/" + repository.client().getRepo() + "/" + repository.client().getBranch();
 
-        commitChains.compute(path, (key, chain) ->
+        commitChains.compute(repositoryBranch, (key, chain) ->
         {
             CompletableFuture<Void> previous = chain != null ? chain : CompletableFuture.completedFuture(null);
             CompletableFuture<Void> next = previous.thenRunAsync(() -> reconcile(serviceContext, repository, path, graphURI, message, agentWebID), executor).

--- a/src/test/java/com/atomgraph/linkeddatahub/client/GitHubClientTest.java
+++ b/src/test/java/com/atomgraph/linkeddatahub/client/GitHubClientTest.java
@@ -39,6 +39,9 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
@@ -60,6 +63,7 @@ public class GitHubClientTest
     private String fileSha = null; // null = file does not exist on the fake server
     private byte[] fileContent = null;
     private int rateLimitResponses = 0; // number of upcoming requests to answer with 429
+    private int conflictResponses = 0; // number of upcoming writes to answer with 409
     private int commitCount = 2; // number of commits in the fake file history
 
     private static Optional<String> queryParam(String query, String name)
@@ -136,6 +140,13 @@ public class GitHubClientTest
                 }
                 case "PUT" ->
                 {
+                    if (conflictResponses > 0)
+                    {
+                        conflictResponses--;
+                        fileSha = "blob-conflict-" + received.size(); // the competing write moved the file, which is what the conflict reports
+                        respond(exchange, 409, "{\"message\": \"" + fileSha + " does not match the supplied SHA\"}");
+                        return;
+                    }
                     JsonObject json = Json.createReader(new ByteArrayInputStream(body.getBytes(StandardCharsets.UTF_8))).readObject();
                     boolean creating = fileSha == null;
                     fileContent = Base64.getDecoder().decode(json.getString("content"));
@@ -147,6 +158,13 @@ public class GitHubClientTest
                 }
                 case "DELETE" ->
                 {
+                    if (conflictResponses > 0)
+                    {
+                        conflictResponses--;
+                        fileSha = "blob-conflict-" + received.size(); // the competing write moved the file, which is what the conflict reports
+                        respond(exchange, 409, "{\"message\": \"" + fileSha + " does not match the supplied SHA\"}");
+                        return;
+                    }
                     fileSha = null;
                     fileContent = null;
                     respond(exchange, 200, "{}");
@@ -269,6 +287,54 @@ public class GitHubClientTest
         gitHubClient.deleteFile("graphs/missing.nt", "DELETE", "agent");
 
         assertEquals(1, received.size()); // only the SHA probe, no DELETE
+    }
+
+    @Test
+    public void testConflictingCommitIsRetriedWithRefreshedSha()
+    {
+        gitHubClient.putFile("graphs/doc.nt", "v1".getBytes(StandardCharsets.UTF_8), "PUT", "agent");
+        received.clear();
+        conflictResponses = 1;
+
+        GitHubClient.Commit commit = gitHubClient.putFile("graphs/doc.nt", "v2".getBytes(StandardCharsets.UTF_8), "PUT", "agent");
+
+        // SHA probe + conflicting PUT, then a fresh probe + the PUT that succeeds
+        assertEquals(4, received.size());
+        assertEquals("GET", received.get(2).method());
+        assertEquals("PUT", received.get(3).method());
+        assertArrayEquals("v2".getBytes(StandardCharsets.UTF_8), fileContent);
+        assertEquals(fileSha, commit.blobSha());
+
+        // the retried request carries the SHA read after the conflict, not the one it conflicted on
+        JsonObject conflicted = Json.createReader(new ByteArrayInputStream(received.get(1).body().getBytes(StandardCharsets.UTF_8))).readObject();
+        JsonObject retried = Json.createReader(new ByteArrayInputStream(received.get(3).body().getBytes(StandardCharsets.UTF_8))).readObject();
+        assertNotEquals(conflicted.getString("sha"), retried.getString("sha"));
+    }
+
+    @Test
+    public void testConflictingDeletionIsRetried()
+    {
+        gitHubClient.putFile("graphs/doc.nt", "v1".getBytes(StandardCharsets.UTF_8), "PUT", "agent");
+        received.clear();
+        conflictResponses = 1;
+
+        gitHubClient.deleteFile("graphs/doc.nt", "DELETE", "agent");
+
+        assertEquals(4, received.size()); // probe + conflicting DELETE, then probe + the DELETE that succeeds
+        assertEquals("DELETE", received.get(3).method());
+        assertNull(fileSha);
+    }
+
+    @Test
+    public void testConflictFailsWhenRetriesAreExhausted()
+    {
+        gitHubClient.putFile("graphs/doc.nt", "v1".getBytes(StandardCharsets.UTF_8), "PUT", "agent");
+        received.clear();
+        conflictResponses = GitHubClient.MAX_CONFLICT_RETRIES + 1;
+
+        // a lost commit is the caller's to log: versioning is best-effort, but it must not be silent
+        assertThrows(RuntimeException.class, () -> gitHubClient.putFile("graphs/doc.nt", "v2".getBytes(StandardCharsets.UTF_8), "PUT", "agent"));
+        assertEquals(2 * (GitHubClient.MAX_CONFLICT_RETRIES + 1), received.size()); // probe + PUT per attempt
     }
 
     @Test


### PR DESCRIPTION
## Problem

Concurrent writes to a versioned application silently lost commits.

`GraphVersioningService` chained commit tasks by **file path**, then ran them on a 4-thread pool — so two documents written at once reconciled in parallel. The GitHub Contents API takes its optimistic lock on the **branch head**, not on the blob it was handed, so whichever `PUT` arrived second got a `409`. Versioning is best-effort, so the loser was dropped with a log line and nothing else.

[CI run 33618323291](https://github.com/AtomGraph/LinkedDataHub/actions/runs/33618323291) lost eight commits that way:

```
ERROR GraphVersioningService:175 - Failed to version graph <.../397a3664-.../> as
'graphs-33618323291/397a3664-....nt': GitHub commit ... failed with status 409
```

`versioning/PUT-creates-commit.sh` and `versioning/GET-timemap.sh` then timed out polling for files that were never going to appear (`gh: Not Found (HTTP 404)`).

## Changes

- **Chain per repository branch.** The chain key is `owner/repo/branch` instead of the file path, so every commit to a branch runs in one sequence. Different repositories still commit in parallel, and the reconcile design — re-read the graph at execution time, make the file match — already tolerates a task waiting in a queue.
- **Retry conflicts.** Serialization alone leaves the head open to writers outside this JVM, so `putFile`/`deleteFile` retry up to `MAX_CONFLICT_RETRIES` times with a linear backoff, re-reading the blob SHA on each attempt. The stale SHA is what the conflict is about, so replaying the same request would only conflict again.
- **Build the PUT body once.** It was built inside the `invoke()` supplier, and `JsonObjectBuilder` yields its object only to the first `build()` — a rate-limited commit retried with `{}` as its body.

Queued tasks for one path are deliberately left uncoalesced: `GET-version.sh` writes one document twice and asserts two distinct commits, so collapsing them would erase a version from the TimeMap.

## Tests

`GitHubClientTest` gains a `conflictResponses` counter alongside `rateLimitResponses`; the fake server moves `fileSha` when it answers `409`, so the retry provably re-reads rather than replays.

- `testConflictingCommitIsRetriedWithRefreshedSha`
- `testConflictingDeletionIsRetried`
- `testConflictFailsWhenRetriesAreExhausted`

`mvn test` is green (14 in `GitHubClientTest`, 11 in `GraphVersioningServiceTest`).

## Follow-ups, not in this PR

- The versioning suite still commits to a shared live repository — ~115 commits per run — so it is skipped on forks and on every local `make tests`. A local GitHub-API-compatible backend (or JGit against a plain git remote) would make it hermetic.
- Serialization lengthens the per-branch queue while the tests poll for 30 s, and the imports suite bursts ~100 commits right before the versioning suite. If timeouts persist, scoping versioning to the `test.localhost` dataspace cuts the volume rather than lengthening the poll.
- Pre-existing: `commitChains.compute(...)` attaches `whenComplete` that calls `commitChains.remove(key, next)`, which is a recursive update on the same key if `next` is already complete — `ConcurrentHashMap` throws `IllegalStateException` for that. Practically only reachable when the executor rejects a task at shutdown.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0184W2B82P2wUBntUPie223L