### PR TITLE
SSRF-harden the CSV/RDF import path (validate ldh:file + spin:query)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -92,6 +92,9 @@ Bootstrap 2 is gone, and with it the class vocabulary application stylesheets we
 - The property-list grid keys on the wrapped `dt`/`dd` shape, leaving prose `dl`s to their own layout
 - An error page renders without the action bar, which had nothing left to act on
 
+### Security
+- CSV/RDF imports now validate the `ldh:file` source and `spin:query` URIs via `URLValidator` before fetching, closing a previously unguarded SSRF surface on the import path (same class as LNK-002; the import client carries delegation/client-cert). Loopback stays allowed; `ALLOW_INTERNAL_URLS` remains the escape hatch
+
 ### Known limitations
 - The in-place editor edits tab-group content but cannot create tab groups: while a region is edited every tab panel is shown stacked and editable, and the markup round-trips intact, but there is no gesture that inserts a new tab group — that markup is authored via the HTTP API (e.g. `ldh put`) for now
 

--- a/http-tests/imports/import-internal-url-400.sh
+++ b/http-tests/imports/import-internal-url-400.sh
@@ -1,0 +1,57 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+initialize_dataset "$END_USER_BASE_URL" "$TMP_END_USER_DATASET" "$END_USER_ENDPOINT_URL"
+initialize_dataset "$ADMIN_BASE_URL" "$TMP_ADMIN_DATASET" "$ADMIN_ENDPOINT_URL"
+purge_cache "$END_USER_VARNISH_SERVICE"
+purge_cache "$ADMIN_VARNISH_SERVICE"
+purge_cache "$FRONTEND_VARNISH_SERVICE"
+
+# create the import target item
+
+item=$(create-item.sh \
+  -f "$OWNER_CERT_FILE" \
+  -p "$OWNER_CERT_PWD" \
+  -b "$END_USER_BASE_URL" \
+  --title "RDF import" \
+  --container "$END_USER_BASE_URL")
+
+# POST an ldh:RDFImport with the given ldh:file / spin:query and assert 400 Bad Request:
+# the import URIs must be SSRF-validated before the server dereferences them (loopback stays allowed)
+
+post_import()
+{
+    file="$1"
+    query="$2"
+
+    body="@prefix ldh:  <https://w3id.org/atomgraph/linkeddatahub#> .
+@prefix dct:  <http://purl.org/dc/terms/> .
+@prefix spin: <http://spinrdf.org/spin#> .
+_:import a ldh:RDFImport ;
+    dct:title \"SSRF test\" ;
+    ldh:file <${file}> ."
+
+    if [ -n "$query" ]; then
+        body="${body}
+_:import spin:query <${query}> ."
+    fi
+
+    curl -k -w "%{http_code}\n" -o /dev/null -s \
+      -E "$OWNER_CERT_FILE":"$OWNER_CERT_PWD" \
+      -X POST \
+      -H "Content-Type: text/turtle" \
+      --data-binary "$body" \
+      "$item" \
+    | grep -q "$STATUS_BAD_REQUEST"
+}
+
+# SSRF via ldh:file: link-local (169.254/16) and RFC-1918 (10/8, 172.16/12, 192.168/16) sources must be rejected
+
+post_import "http://169.254.1.1/data.ttl" ""
+post_import "http://10.0.0.1/data.ttl" ""
+post_import "http://172.16.0.0/data.ttl" ""
+post_import "http://192.168.1.1/data.ttl" ""
+
+# SSRF via spin:query: a valid (loopback) file but an internal transform-query URI must also be rejected
+
+post_import "http://127.0.0.1/data.ttl" "http://10.0.0.1/query#this"

--- a/src/main/java/com/atomgraph/linkeddatahub/imports/ImportExecutor.java
+++ b/src/main/java/com/atomgraph/linkeddatahub/imports/ImportExecutor.java
@@ -109,6 +109,10 @@ public class ImportExecutor
         if (csvImport == null) throw new IllegalArgumentException("CSVImport cannot be null");
         if (log.isDebugEnabled()) log.debug("Submitting new import to thread pool: {}", csvImport.toString());
 
+        // LNK-002: validate the attacker-controlled import URIs to prevent SSRF before dereferencing them
+        system.getURLValidator().validate(URI.create(csvImport.getFile().getURI()));
+        system.getURLValidator().validate(URI.create(csvImport.getQuery().getURI())); // query is required on CSVImport
+
         Resource provImport = ModelFactory.createDefaultModel().createResource(csvImport.getURI()).
                 addProperty(PROV.startedAtTime, csvImport.getModel().createTypedLiteral(Calendar.getInstance()));
 
@@ -119,7 +123,6 @@ public class ImportExecutor
         final Query query = pss.asQuery();
 
         Supplier<Response> fileSupplier = new ClientResponseSupplier(gsc, CSV_MEDIA_TYPES, URI.create(csvImport.getFile().getURI()));
-        // skip validation because it will be done during final POST anyway
         CompletableFuture.supplyAsync(fileSupplier, getExecutorService()).thenApplyAsync(getStreamRDFOutputWriter(service, adminService, system,
                 gsc, queryBaseURI, query, csvImport), getExecutorService()).
             thenAcceptAsync(success(service, system, csvImport, provImport), getExecutorService()).
@@ -141,6 +144,10 @@ public class ImportExecutor
         if (rdfImport == null) throw new IllegalArgumentException("RDFImport cannot be null");
         if (log.isDebugEnabled()) log.debug("Submitting new import to thread pool: {}", rdfImport.toString());
 
+        // LNK-002: validate the attacker-controlled import URIs to prevent SSRF before dereferencing them
+        system.getURLValidator().validate(URI.create(rdfImport.getFile().getURI()));
+        if (rdfImport.getQuery() != null) system.getURLValidator().validate(URI.create(rdfImport.getQuery().getURI())); // query is optional on RDFImport
+
         Resource provImport = ModelFactory.createDefaultModel().createResource(rdfImport.getURI()).
                 addProperty(PROV.startedAtTime, rdfImport.getModel().createTypedLiteral(Calendar.getInstance()));
 
@@ -157,7 +164,6 @@ public class ImportExecutor
             query = null;
 
         Supplier<Response> fileSupplier = new ClientResponseSupplier(gsc, RDF_MEDIA_TYPES, URI.create(rdfImport.getFile().getURI()));
-        // skip validation because it will be done during final POST anyway
         CompletableFuture.supplyAsync(fileSupplier, getExecutorService()).thenApplyAsync(getStreamRDFOutputWriter(service, adminService, system,
                 gsc, queryBaseURI, query, rdfImport), getExecutorService()).
             thenAcceptAsync(success(service, system, rdfImport, provImport), getExecutorService()).


### PR DESCRIPTION
The import mechanism dereferenced attacker-controlled `ldh:file` (source) and `spin:query` URIs from posted RDF server-side via the credentialed `importClient` (delegation + client cert), with no URL validation — the same SSRF shape the deleted `/transform` had, but unguarded. Not covered by any LNK-* pen-test finding. Imports stay server-side/async by design (large data), so the fix is the guard, not client-orchestration.

**Fix:** `ImportExecutor.start()` (both overloads) validates the file and query URIs via `getURLValidator()` before the fetch, mirroring the deleted `Transform.java`. Internal/private targets throw `InternalURLException` → 400 (`InternalURLExceptionMapper`), synchronously on the request thread. Loopback stays allowed, so legitimate `${base}uploads/<sha1>` imports are unaffected; `ALLOW_INTERNAL_URLS` remains the escape hatch.

**Test:** adds `http-tests/imports/import-internal-url-400.sh` (link-local + RFC-1918 `ldh:file`, and an internal `spin:query`), picked up automatically by `run.sh`'s `imports` suite. Note the script has not yet executed against a live stack — the CI run on this PR's merge is its first real exercise.

**Rebase note:** originally authored 2026-08-11 on a base ~300 commits back; transplanted onto current `develop` as a single commit. Two stale `/ns`-label commits that sat beneath it were dropped — they targeted the retired `xsl/bootstrap/2.3.2/` tree and were superseded by `6b1f83eda`. `ImportExecutor.java` applied conflict-free (untouched on `develop` since the old base); the CHANGELOG entry moved into the `[6.0.0]` section as a `### Security` subsection. Compiles clean against current `develop`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NSvgJqLDCaU5aMpmPjan9e