### PR TITLE
Fix PATCHed ldh:import not joining the ontology closure (stale app model)

### DIFF
--- a/http-tests/misc/PATCH-settings-package-ontology.sh
+++ b/http-tests/misc/PATCH-settings-package-ontology.sh
@@ -20,81 +20,72 @@ query='SELECT ?text WHERE { <http://www.w3.org/2004/02/skos/core#Concept> <http:
 # feature of the package, and the thing that goes silent if the import stops being composed
 view_query='SELECT ?view WHERE { VALUES ?property { <http://www.w3.org/2004/02/skos/core#broader> <http://www.w3.org/2004/02/skos/core#narrower> } ?property <https://w3id.org/atomgraph/linkeddatahub#view> ?view . }'
 
-ns_result_count() {
-  curl -k -f -s -G \
+# Probe /ns with a query in one shot. Sets NS_STATUS, NS_BODY, NS_COUNT. Never fails the shell
+# (no -f), so even a 5xx from a broken closure still yields diagnostics instead of aborting.
+ns_probe() {
+  local body
+  body=$(curl -k -s -G -w $'\n%{http_code}' \
     -E "$OWNER_CERT_FILE":"$OWNER_CERT_PWD" \
     -H "Accept: application/sparql-results+xml" \
     "${END_USER_BASE_URL}ns" \
-    --data-urlencode "query=${1}" \
-  | xmllint --xpath "count(//*[local-name() = 'result'])" -
+    --data-urlencode "query=${1}") || true
+  NS_STATUS="${body##*$'\n'}"
+  NS_BODY="${body%$'\n'*}"
+  NS_COUNT=$(printf '%s' "$NS_BODY" | xmllint --xpath "count(//*[local-name() = 'result'])" - 2>/dev/null || echo "ERR")
 }
 
-constructor_count() {
-  ns_result_count "$query"
+# assert NS_COUNT for a phase; on mismatch dump the raw response and exit 1
+assert_count() {
+  local phase="$1" q="$2" expected="$3" note="$4"
+  ns_probe "$q"
+  echo "DEBUG: [$phase] Expected: $expected  Got: $NS_COUNT  (HTTP $NS_STATUS)"
+  if [ "$NS_COUNT" != "$expected" ]; then
+    echo "DEBUG: [$phase] $note" >&2
+    echo "DEBUG: [$phase] raw /ns response body:" >&2
+    printf '%s\n' "$NS_BODY" >&2
+    exit 1
+  fi
 }
 
-view_count() {
-  ns_result_count "$view_query"
+# PATCH /settings and assert no-content; on mismatch report the status
+patch_settings() {
+  local phase="$1" update="$2" status
+  status=$(curl -k -w "%{http_code}" -o /dev/null -s \
+    -X PATCH \
+    -E "$OWNER_CERT_FILE":"$OWNER_CERT_PWD" \
+    -H "Content-Type: application/sparql-update" \
+    -d "$update" \
+    "${END_USER_BASE_URL}settings")
+  echo "DEBUG: [$phase] Expected: $STATUS_NO_CONTENT  Got: $status"
+  if ! grep -qE "^(${STATUS_NO_CONTENT})$" <<< "$status"; then
+    echo "DEBUG: [$phase] PATCH of ldh:import did not return no-content" >&2
+    exit 1
+  fi
 }
 
-# the skos:Concept constructor is not in the app ontology closure initially
-count=$(constructor_count)
-if [ "$count" != "0" ]; then
-  exit 1
-fi
-
-views=$(view_count)
-if [ "$views" != "0" ]; then
-  exit 1
-fi
+# the skos:Concept constructor / views are not in the app ontology closure initially
+assert_count "pre-import constructor"  "$query"      0 "package leaked into closure before import?"
+assert_count "pre-import views"        "$view_query" 0 "package leaked into closure before import?"
 
 # declare the package import
-(
-curl -k -w "%{http_code}\n" -o /dev/null -s \
-  -X PATCH \
-  -E "$OWNER_CERT_FILE":"$OWNER_CERT_PWD" \
-  -H "Content-Type: application/sparql-update" \
-  -d "INSERT { <${app_uri}> <https://w3id.org/atomgraph/linkeddatahub#import> <${package_uri}> . } WHERE { }" \
-  "${END_USER_BASE_URL}settings"
-) \
-| grep -q "$STATUS_NO_CONTENT"
+patch_settings "import PATCH" \
+  "INSERT { <${app_uri}> <https://w3id.org/atomgraph/linkeddatahub#import> <${package_uri}> . } WHERE { }"
 
 # the /ns query URL is identical across the phases, so evict any cached response
 purge_cache "$END_USER_VARNISH_SERVICE"
 purge_cache "$FRONTEND_VARNISH_SERVICE"
 
 # the package ontology joined the closure - no restart, no sleep
-count=$(constructor_count)
-if [ "$count" != "1" ]; then
-  exit 1
-fi
-
-views=$(view_count)
-if [ "$views" != "2" ]; then
-  exit 1
-fi
+assert_count "post-import constructor" "$query"      1 "constructor missing - package ontology (${package_uri}) did not join the closure"
+assert_count "post-import views"       "$view_query" 2 "views missing - ldh:view declarations did not join the closure"
 
 # remove the package import
-(
-curl -k -w "%{http_code}\n" -o /dev/null -s \
-  -X PATCH \
-  -E "$OWNER_CERT_FILE":"$OWNER_CERT_PWD" \
-  -H "Content-Type: application/sparql-update" \
-  -d "DELETE { <${app_uri}> <https://w3id.org/atomgraph/linkeddatahub#import> <${package_uri}> . } WHERE { }" \
-  "${END_USER_BASE_URL}settings"
-) \
-| grep -q "$STATUS_NO_CONTENT"
+patch_settings "remove PATCH" \
+  "DELETE { <${app_uri}> <https://w3id.org/atomgraph/linkeddatahub#import> <${package_uri}> . } WHERE { }"
 
 purge_cache "$END_USER_VARNISH_SERVICE"
 purge_cache "$FRONTEND_VARNISH_SERVICE"
 
 # the package ontology left the closure
-views=$(view_count)
-if [ "$views" != "0" ]; then
-  exit 1
-fi
-
-count=$(constructor_count)
-if [ "$count" != "0" ]; then
-  exit 1
-fi
+assert_count "post-remove views"       "$view_query" 0 "views still present - package ontology did not leave the closure"
+assert_count "post-remove constructor" "$query"      0 "constructor still present - package ontology did not leave the closure"

--- a/src/main/java/com/atomgraph/linkeddatahub/resource/admin/ClearOntology.java
+++ b/src/main/java/com/atomgraph/linkeddatahub/resource/admin/ClearOntology.java
@@ -125,7 +125,13 @@ public class ClearOntology
             }
             
             // !!! we need to reload the ontology model before returning a response, to make sure the next request already gets the new version !!!
-            getSystem().getOntologyGraphs().put(ontologyURI, OntologyFilter.loadOntology(repository, ontologyURI, getSystem().getPackageOntologies(endUserApp)));
+            // The request-scoped endUserApp is a snapshot ApplicationFilter captured before Settings.updateApp
+            // swapped the context dataset copy-on-write, so on a PATCH /settings that just added an ldh:import
+            // its import set is stale. Re-read the app from the current (post-write) dataspace model -
+            // getDataspaceModel reads the volatile contextDataset fresh, keyed by URI - so the rebuilt closure
+            // reflects the persisted import set rather than the pre-write snapshot.
+            com.atomgraph.linkeddatahub.apps.model.Application currentApp = getSystem().getDataspaceModel(endUserApp).getResource(endUserApp.getURI()).as(com.atomgraph.linkeddatahub.apps.model.Application.class);
+            getSystem().getOntologyGraphs().put(ontologyURI, OntologyFilter.loadOntology(repository, ontologyURI, getSystem().getPackageOntologies(currentApp)));
         }
         
         if (referer != null) return Response.seeOther(referer).build();


### PR DESCRIPTION
## Problem

`http-tests/misc/PATCH-settings-package-ontology.sh` has been a standing red. A `PATCH /settings` that adds an `ldh:import` returns `204`, `/ns` responds `200` — but the imported package's ontology never joins the imports closure, so the SKOS `spin:constructor` and `ldh:view` declarations stay invisible. Instrumenting the test (first commit) pinned it exactly:

```
[import PATCH]            Expected: 204  Got: 204
[post-import constructor] Expected: 1  Got: 0  (HTTP 200)   ← valid, empty <results>
```

## Root cause: the closure rebuild reads a stale, request-scoped Application model

- `ApplicationFilter` (`@PreMatching`) matches the app **once** at request-matching time via `Application.getContextModel()` — a read-only view over the volatile `contextDataset` *at that instant* — and injects that snapshot into the resource.
- `Settings.patch` builds `mutableModel` (settings + the new `ldh:import`), persists it via `updateApp`, which **copy-on-write swaps `contextDataset` to a new `Dataset` instance**, then delegates to `ClearOntology.post`.
- `ClearOntology` rebuilt the closure from `getPackageOntologies(endUserApp)`, where `endUserApp` derives from the **pre-swap snapshot**. Its `getImportedPackages()` still omits the just-added package → no `owl:imports` injected → closure rebuilt without the package ontology → constructor count `0`.

The cold path (first `/ns` GET after the PATCH) was already correct — that GET is a fresh request whose snapshot includes the import. Only the warm path (ontology already cached from a prior GET, so `ClearOntology` rebuilds) was broken.

## Fix (one statement, in `ClearOntology`)

Re-read the app from the **current** dataspace model before computing package ontologies. `getDataspaceModel` reads the volatile `contextDataset` fresh, keyed by URI, so after `updateApp` it returns the graph carrying the new import triple; the app personality is registered globally, so `.as(...)` works over it. The rebuilt closure now reflects the persisted import set.

Nothing else in `ClearOntology.post` changes — the cache gate, repository/graph eviction, and proxy/xkey purges key off app identity and `ldt:service`, which a package import does not alter. The admin `/clear` path is unaffected (it already reads current config there — superset-safe).

## Ruled out (red herrings during diagnosis)

- The develop-branch `ac:stylesheet` — never fetched for a SPARQL response (`XsltExecutableFilter` only loads it for X/HTML), and a valid `200` regardless.
- Location/prefix mapping of the package/ontology URIs — `PrefixGraphRepository.resolve` longest-prefix match handles the `#this` fragment; the package loads locally.

## Verification

The instrumented `PATCH-settings-package-ontology.sh` is the end-to-end guard: after this fix it must go green (`constructor` `0→1→0`, `views` `0→2→0`), and the ontology-reload tests (`GET-ns-constructors.sh`, `POST-remote-ns-constructors.sh`, `PATCH-proxied-constructor-update.sh`) must stay green, confirming admin `/clear` didn't regress. Requires an image rebuild (the WAR bakes the server half).

## Notes

Pre-existing bug, independent of the auth work in #378. #378 should rebase on `develop` after this merges — its duplicated instrumentation commit drops out as an identical patch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
https://claude.ai/code/session_01NSvgJqLDCaU5aMpmPjan9e