### PR TITLE
Fix import-internal-url-400: the SSRF import test never reached the server

### DIFF
--- a/http-tests/imports/import-internal-url-400.sh
+++ b/http-tests/imports/import-internal-url-400.sh
@@ -14,15 +14,28 @@ item=$(create-item.sh \
   -p "$OWNER_CERT_PWD" \
   -b "$END_USER_BASE_URL" \
   --title "RDF import" \
-  --container "$END_USER_BASE_URL")
+  --container "$END_USER_BASE_URL" 2>/tmp/create-item.err) || {
+    echo "DEBUG: create-item.sh FAILED (exit $?)" >&2
+    echo "DEBUG: create-item.sh stderr:" >&2
+    cat /tmp/create-item.err >&2
+    exit 1
+  }
+echo "DEBUG: created import target item = [$item]"
+if [ -z "$item" ] || [[ "$item" != http* ]]; then
+  echo "DEBUG: item is not a URL - create-item.sh emitted something unexpected on stdout" >&2
+  echo "DEBUG: create-item.sh stderr:" >&2
+  cat /tmp/create-item.err >&2
+  exit 1
+fi
 
 # POST an ldh:RDFImport with the given ldh:file / spin:query and assert 400 Bad Request:
 # the import URIs must be SSRF-validated before the server dereferences them (loopback stays allowed)
 
 post_import()
 {
-    file="$1"
-    query="$2"
+    label="$1"
+    file="$2"
+    query="$3"
 
     body="@prefix ldh:  <https://w3id.org/atomgraph/linkeddatahub#> .
 @prefix dct:  <http://purl.org/dc/terms/> .
@@ -36,22 +49,32 @@ _:import a ldh:RDFImport ;
 _:import spin:query <${query}> ."
     fi
 
-    curl -k -w "%{http_code}\n" -o /dev/null -s \
+    # capture status + body separately so a non-400 shows what the server actually returned
+    response=$(curl -k -s -w $'\n%{http_code}' \
       -E "$OWNER_CERT_FILE":"$OWNER_CERT_PWD" \
       -X POST \
       -H "Content-Type: text/turtle" \
       --data-binary "$body" \
-      "$item" \
-    | grep -q "$STATUS_BAD_REQUEST"
+      "$item") || true
+    status="${response##*$'\n'}"
+    resp_body="${response%$'\n'*}"
+
+    echo "DEBUG: [$label] file=${file} query=${query:-<none>}  Expected: $STATUS_BAD_REQUEST  Got: $status"
+    if ! grep -qE "^(${STATUS_BAD_REQUEST})$" <<< "$status"; then
+        echo "DEBUG: [$label] SSRF import was NOT rejected with $STATUS_BAD_REQUEST - server accepted an internal URL" >&2
+        echo "DEBUG: [$label] response body:" >&2
+        printf '%s\n' "$resp_body" >&2
+        exit 1
+    fi
 }
 
 # SSRF via ldh:file: link-local (169.254/16) and RFC-1918 (10/8, 172.16/12, 192.168/16) sources must be rejected
 
-post_import "http://169.254.1.1/data.ttl" ""
-post_import "http://10.0.0.1/data.ttl" ""
-post_import "http://172.16.0.0/data.ttl" ""
-post_import "http://192.168.1.1/data.ttl" ""
+post_import "link-local ldh:file"   "http://169.254.1.1/data.ttl" ""
+post_import "rfc1918-10 ldh:file"    "http://10.0.0.1/data.ttl"    ""
+post_import "rfc1918-172 ldh:file"   "http://172.16.0.0/data.ttl"  ""
+post_import "rfc1918-192 ldh:file"   "http://192.168.1.1/data.ttl" ""
 
 # SSRF via spin:query: a valid (loopback) file but an internal transform-query URI must also be rejected
 
-post_import "http://127.0.0.1/data.ttl" "http://10.0.0.1/query#this"
+post_import "internal spin:query"    "http://127.0.0.1/data.ttl"   "http://10.0.0.1/query#this"

--- a/http-tests/imports/import-internal-url-400.sh
+++ b/http-tests/imports/import-internal-url-400.sh
@@ -49,12 +49,15 @@ _:import a ldh:RDFImport ;
 _:import spin:query <${query}> ."
     fi
 
-    # capture status + body separately so a non-400 shows what the server actually returned
-    response=$(curl -k -s -w $'\n%{http_code}' \
+    # capture status + body separately so a non-400 shows what the server actually returned.
+    # feed the Turtle body via stdin (--data-binary @-): the body starts with "@prefix", and
+    # curl reads a leading @ in --data-binary "<arg>" as a filename ("error encountered when
+    # reading a file"), aborting before it ever sends the request
+    response=$(printf '%s' "$body" | curl -k -s -w $'\n%{http_code}' \
       -E "$OWNER_CERT_FILE":"$OWNER_CERT_PWD" \
       -X POST \
       -H "Content-Type: text/turtle" \
-      --data-binary "$body" \
+      --data-binary @- \
       "$item") || true
     status="${response##*$'\n'}"
     resp_body="${response%$'\n'*}"


### PR DESCRIPTION
## Problem

`http-tests/imports/import-internal-url-400.sh` has been failing since it was added in #377, printing only:

```
./imports/import-internal-url-400.sh   failed
```

Bare `grep -q` pipes gave no way to tell whether the harness broke, which assertion got a non-400, or what the server actually returned.

## Diagnosis

The first commit instruments the test — capturing `create-item.sh`'s stdout/stderr/exit status, and each import POST's status and body, with `Expected`/`Got` per assertion. CI then said it outright:

```
DEBUG: created import target item = [https://localhost:4443/67cb1c3b-.../]
curl: option --data-binary: error encountered when reading a file
DEBUG: [link-local ldh:file] file=http://169.254.1.1/data.ttl  Expected: 400  Got:
```

The harness was fine. The RDFImport body starts with `@prefix`, and **curl reads a leading `@` in `--data-binary "<arg>"` as a filename to slurp** — so curl aborted before sending anything, the status came back empty, and the request never reached the server.

This footgun was in the test as originally written, which means **the SSRF validation it guards has never actually been exercised**.

## Fix

Send the Turtle body via stdin instead:

```bash
printf '%s' "$body" | curl ... --data-binary @-
```

The server side was correct all along and needed no change: `ImportExecutor.start` runs `URLValidator.validate` on the request thread *before* the async `CompletableFuture`, and `InternalURLException` maps to 400 — so link-local/RFC-1918 `ldh:file` and an internal `spin:query` now get the expected `400`.

Sole instance of the pattern: every other `--data-binary "$var"` in `http-tests` is a SPARQL update/query (never a leading `@`).

## Verification

CI on this branch: `./imports/import-internal-url-400.sh   ok` — all five SSRF assertions now return 400, exercising #377's validator for the first time.

The 9 `system/` failures in that same run are pre-existing on `develop` (the ACL tests from `984789947` are on develop, but their fix — the fail-closed `VALUES ?Type` default — is only on #378) and are unrelated to this change; they clear when #378 merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NSvgJqLDCaU5aMpmPjan9e