### PR TITLE
DRY audit of top-level XSL params and accessor functions

### DIFF
--- a/http-tests/misc/PATCH-settings-package-import.sh
+++ b/http-tests/misc/PATCH-settings-package-import.sh
@@ -14,21 +14,32 @@ purge_cache "$FRONTEND_VARNISH_SERVICE"
 app_uri="urn:linkeddatahub:apps/end-user"
 package_uri="https://packages.linkeddatahub.com/skos/#this"
 
-# stylesheet marker injected into every page by the SKOS package layout.xsl
-marker="com/linkeddatahub/demo/skos/css/bootstrap.css"
+slug="skos-package-probe"
+doc="${END_USER_BASE_URL}${slug}/"
+concept="${doc}#this"
 
-# The rendered homepage is tens of KiB and the marker sits in <head>, within its first
-# 2 KiB. Assertions therefore read the response from a here-string rather than piping
-# curl into `grep -q`: `grep -q` closes the pipe on its first match, and with
-# `set -o pipefail` the SIGPIPE'd curl fails the whole pipeline. That only happens when
-# curl is still writing at the moment grep exits, which made this test fail randomly.
+# The package's rule is that the SKOS hierarchy predicates render as the concept tree rather than
+# as statement rows: it binds skos:narrower/broader/related/member to an empty ac:PropertyEditor
+# template. The object of the concept's skos:broader is therefore the marker - present in the
+# rendered document while the package is not imported, absent while it is.
+#
+# The concept is a resource of its own that the document describes, not the document itself. A
+# dh:Item carrying skos:broader directly renders nothing: the property list belongs to the
+# described resource, so with no foaf:primaryTopic there is nothing for ac:PropertyEditor to emit
+# and the assertion would pass in both directions.
+marker="http://example.org/skos-broader-probe"
 
-function homepage()
+# The rendered document is tens of KiB. Assertions therefore read the response from a here-string
+# rather than piping curl into `grep -q`: `grep -q` closes the pipe on its first match, and with
+# `set -o pipefail` the SIGPIPE'd curl fails the whole pipeline. That only happens when curl is
+# still writing at the moment grep exits, which made this test fail randomly.
+
+function document()
 {
   curl -k -s \
     -H "Accept: text/html" \
     -E "$OWNER_CERT_FILE":"$OWNER_CERT_PWD" \
-    "$END_USER_BASE_URL"
+    "$doc"
 }
 
 function patch_settings()
@@ -51,37 +62,65 @@ function remove_import()
 
 trap remove_import EXIT
 
-# verify the homepage is not rendered with the package stylesheet initially
-response=$(homepage)
+# a document describing a SKOS concept that has a broader concept
 
-if grep -qF "$marker" <<< "$response"; then
+curl -k -w "%{http_code}\n" -o /dev/null -f -s \
+  -E "$OWNER_CERT_FILE":"$OWNER_CERT_PWD" \
+  -X PUT \
+  -H "Content-Type: application/n-triples" \
+  --data-binary @- \
+  "$doc" <<EOF \
+| grep -q "$STATUS_CREATED"
+<${doc}> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://www.w3.org/ns/ldt/document-hierarchy#Item> .
+<${doc}> <http://purl.org/dc/terms/title> "SKOS package probe" .
+<${doc}> <http://rdfs.org/sioc/ns#has_container> <${END_USER_BASE_URL}> .
+<${doc}> <http://xmlns.com/foaf/0.1/primaryTopic> <${concept}> .
+<${concept}> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
+<${concept}> <http://www.w3.org/2004/02/skos/core#prefLabel> "Probe concept" .
+<${concept}> <http://www.w3.org/2004/02/skos/core#broader> <${marker}> .
+EOF
+
+# without the package, the broader statement renders as a property row
+
+response=$(document)
+
+if ! grep -qF "$marker" <<< "$response"; then
+  echo "DEBUG: broader row missing before import - the fixture does not exercise the package rule" >&2
   exit 1
 fi
 
 # declare the package import
+
 status=$(patch_settings "INSERT { <${app_uri}> <https://w3id.org/atomgraph/linkeddatahub#import> <${package_uri}> . } WHERE { }")
 
 if [[ ! "$status" =~ ^($STATUS_NO_CONTENT)$ ]]; then
+  echo "DEBUG: Expected: $STATUS_NO_CONTENT  Got: $status" >&2
   exit 1
 fi
 
-# verify the homepage is rendered with the package stylesheet — no restart, no sleep
-response=$(homepage)
+# the package suppresses it — on the very next request, no restart and no sleep
 
-if ! grep -qF "$marker" <<< "$response"; then
+response=$(document)
+
+if grep -qF "$marker" <<< "$response"; then
+  echo "DEBUG: broader row still rendered after import - the package stylesheet did not compose" >&2
   exit 1
 fi
 
 # remove the package import
+
 status=$(patch_settings "DELETE { <${app_uri}> <https://w3id.org/atomgraph/linkeddatahub#import> <${package_uri}> . } WHERE { }")
 
 if [[ ! "$status" =~ ^($STATUS_NO_CONTENT)$ ]]; then
+  echo "DEBUG: Expected: $STATUS_NO_CONTENT  Got: $status" >&2
   exit 1
 fi
 
-# verify the homepage is no longer rendered with the package stylesheet
-response=$(homepage)
+# and the row is back
 
-if grep -qF "$marker" <<< "$response"; then
+response=$(document)
+
+if ! grep -qF "$marker" <<< "$response"; then
+  echo "DEBUG: broader row still suppressed after the import was removed" >&2
   exit 1
 fi

--- a/src/main/java/com/atomgraph/linkeddatahub/Application.java
+++ b/src/main/java/com/atomgraph/linkeddatahub/Application.java
@@ -117,7 +117,6 @@ import com.atomgraph.linkeddatahub.server.util.MessageBuilder;
 import com.atomgraph.linkeddatahub.server.util.URLValidator;
 import com.atomgraph.linkeddatahub.vocabulary.ACL;
 import com.atomgraph.linkeddatahub.vocabulary.FOAF;
-import com.atomgraph.linkeddatahub.vocabulary.LDH;
 import com.atomgraph.linkeddatahub.vocabulary.LDHC;
 import com.atomgraph.linkeddatahub.vocabulary.Google;
 import com.atomgraph.linkeddatahub.vocabulary.ORCID;
@@ -209,9 +208,7 @@ import net.jodah.expiringmap.ExpirationPolicy;
 import net.jodah.expiringmap.ExpiringMap;
 import net.sf.saxon.om.TreeInfo;
 import net.sf.saxon.s9api.Processor;
-import net.sf.saxon.s9api.QName;
 import net.sf.saxon.s9api.SaxonApiException;
-import net.sf.saxon.s9api.XdmAtomicValue;
 import net.sf.saxon.s9api.XsltCompiler;
 import net.sf.saxon.s9api.XsltExecutable;
 import org.apache.http.HttpClientConnection;
@@ -862,7 +859,6 @@ public class Application extends ResourceConfig
             }
             
             xsltComp = xsltProc.newXsltCompiler();
-            xsltComp.setParameter(new QName("ldh", LDH.base.getNameSpace(), LDH.base.getLocalName()), new XdmAtomicValue(baseURI));
             xsltComp.setURIResolver(new LocalStylesheetResolver(this, servletConfig.getServletContext(), client)); // resolves xsl:import to raw stylesheet sources, app-origin /static/ URLs locally
             xsltExec = xsltComp.compile(stylesheet);
         }

--- a/src/main/java/com/atomgraph/linkeddatahub/writer/XSLTWriterBase.java
+++ b/src/main/java/com/atomgraph/linkeddatahub/writer/XSLTWriterBase.java
@@ -129,7 +129,6 @@ public abstract class XSLTWriterBase extends com.atomgraph.client.writer.XSLTWri
                 if (log.isDebugEnabled()) log.debug("Passing $lapp:Application to XSLT: <{}>", app);
                 params.put(new QName("ldt", LDT.base.getNameSpace(), LDT.base.getLocalName()), new XdmAtomicValue(app.getBaseURI()));
                 params.put(new QName("lapp", LAPP.origin.getNameSpace(), LAPP.origin.getLocalName()), new XdmAtomicValue(app.getOriginURI()));
-                params.put(new QName("ldt", LDT.ontology.getNameSpace(), LDT.ontology.getLocalName()), new XdmAtomicValue(URI.create(app.getOntology().getURI())));
             }
             
             if (getSecurityContext() != null && getSecurityContext().getUserPrincipal() instanceof Agent)
@@ -157,13 +156,6 @@ public abstract class XSLTWriterBase extends com.atomgraph.client.writer.XSLTWri
             }
             params.put(new QName("ldh", LDH.httpHeaders.getNameSpace(), LDH.httpHeaders.getLocalName()), responseHeaders);
 
-            if (getHttpHeaders().getRequestHeader(HttpHeaders.REFERER) != null)
-            {
-                URI referer = URI.create(getHttpHeaders().getRequestHeader(HttpHeaders.REFERER).get(0));
-                if (log.isDebugEnabled()) log.debug("Passing $Referer URI to XSLT: {}", referer);
-                params.put(new QName("", "", "Referer"), new XdmAtomicValue(referer)); // TO-DO: move to ac: namespace
-            }
-            
             params.put(new QName("ldhc", LDHC.enableWebIDSignUp.getNameSpace(), LDHC.enableWebIDSignUp.getLocalName()), new XdmAtomicValue(getSystem().isEnableWebIDSignUp()));
             if (getSystem().getProperty(Google.clientID.getURI()) != null)
                 params.put(new QName("google", Google.clientID.getNameSpace(), Google.clientID.getLocalName()), new XdmAtomicValue((String)getSystem().getProperty(Google.clientID.getURI())));

--- a/src/main/java/com/atomgraph/linkeddatahub/writer/XSLTWriterBase.java
+++ b/src/main/java/com/atomgraph/linkeddatahub/writer/XSLTWriterBase.java
@@ -25,7 +25,6 @@ import com.atomgraph.linkeddatahub.vocabulary.LDHT;
 import com.atomgraph.linkeddatahub.vocabulary.Google;
 import com.atomgraph.linkeddatahub.vocabulary.ORCID;
 import com.atomgraph.linkeddatahub.vocabulary.LAPP;
-import com.atomgraph.client.vocabulary.LDT;
 import com.atomgraph.core.util.Link;
 import com.atomgraph.linkeddatahub.server.security.AuthorizationContext;
 import com.atomgraph.linkeddatahub.vocabulary.FOAF;
@@ -127,7 +126,6 @@ public abstract class XSLTWriterBase extends com.atomgraph.client.writer.XSLTWri
             {
                 com.atomgraph.linkeddatahub.apps.model.Application app = appOpt.get();
                 if (log.isDebugEnabled()) log.debug("Passing $lapp:Application to XSLT: <{}>", app);
-                params.put(new QName("ldt", LDT.base.getNameSpace(), LDT.base.getLocalName()), new XdmAtomicValue(app.getBaseURI()));
                 params.put(new QName("lapp", LAPP.origin.getNameSpace(), LAPP.origin.getLocalName()), new XdmAtomicValue(app.getOriginURI()));
             }
             

--- a/src/main/webapp/static/com/atomgraph/linkeddatahub/xsl/admin/signup.xsl
+++ b/src/main/webapp/static/com/atomgraph/linkeddatahub/xsl/admin/signup.xsl
@@ -13,7 +13,6 @@
     <!ENTITY http   "http://www.w3.org/2011/http#">
     <!ENTITY acl    "http://www.w3.org/ns/auth/acl#">
     <!ENTITY cert   "http://www.w3.org/ns/auth/cert#">
-    <!ENTITY ldt    "https://www.w3.org/ns/ldt#">
     <!ENTITY c      "https://www.w3.org/ns/ldt/core/domain#">
     <!ENTITY dh     "https://www.w3.org/ns/ldt/document-hierarchy#">
     <!ENTITY sh     "http://www.w3.org/ns/shacl#">
@@ -38,7 +37,6 @@ xmlns:srx="&srx;"
 xmlns:http="&http;"
 xmlns:acl="&acl;"
 xmlns:cert="&cert;"
-xmlns:ldt="&ldt;"
 xmlns:core="&c;"
 xmlns:dh="&dh;"
 xmlns:dct="&dct;"
@@ -48,7 +46,7 @@ xmlns:spin="&spin;"
 xmlns:map="http://www.w3.org/2005/xpath-functions/map"
 exclude-result-prefixes="#all">
 
-    <xsl:template match="rdf:RDF[ac:absolute-path(ldh:request-uri()) = resolve-uri(encode-for-uri('sign up'), ldt:base())]" mode="ldh:ContentBody" priority="2">
+    <xsl:template match="rdf:RDF[ac:absolute-path(ldh:request-uri()) = resolve-uri(encode-for-uri('sign up'), lapp:base())]" mode="ldh:ContentBody" priority="2">
         <div class="content-body">
             <xsl:apply-templates select="key('resources', ac:absolute-path(ldh:base-uri(.)))" mode="ldh:ContentList"/>
 
@@ -57,17 +55,17 @@ exclude-result-prefixes="#all">
     </xsl:template>
 
     <!-- hide "Create" button which otherwise would be shown because acl:Append is allowed for signup -->
-    <xsl:template match="rdf:RDF[ac:absolute-path(ldh:request-uri()) = resolve-uri(encode-for-uri('sign up'), ldt:base())]" mode="ac:Create" priority="2"/>
+    <xsl:template match="rdf:RDF[ac:absolute-path(ldh:request-uri()) = resolve-uri(encode-for-uri('sign up'), lapp:base())]" mode="ac:Create" priority="2"/>
 
-    <xsl:template match="rdf:RDF[ac:absolute-path(ldh:request-uri()) = resolve-uri(encode-for-uri('sign up'), ldt:base())]" mode="ac:ModeSwitcher" priority="2"/>
+    <xsl:template match="rdf:RDF[ac:absolute-path(ldh:request-uri()) = resolve-uri(encode-for-uri('sign up'), lapp:base())]" mode="ac:ModeSwitcher" priority="2"/>
 
     <!-- disable the block links popover (backlinks) -->
-    <xsl:template match="*[ac:absolute-path(ldh:request-uri()) = resolve-uri(encode-for-uri('sign up'), ldt:base())]" mode="ldh:BlockLinksPopover"/>
+    <xsl:template match="*[ac:absolute-path(ldh:request-uri()) = resolve-uri(encode-for-uri('sign up'), lapp:base())]" mode="ldh:BlockLinksPopover"/>
 
     <!-- Renders the signup form synchronously on both products: ldh:parse-query behind ldh:construct-instance is dual-declared (SPARQL.js in the browser, the ParseQuery Jena extension server-side), so the same template serves the server-rendered page and client-side re-renders -->
-    <xsl:template match="rdf:RDF[ac:absolute-path(ldh:request-uri()) = resolve-uri(encode-for-uri('sign up'), ldt:base())]" mode="ldh:BlockRow" priority="2">
+    <xsl:template match="rdf:RDF[ac:absolute-path(ldh:request-uri()) = resolve-uri(encode-for-uri('sign up'), lapp:base())]" mode="ldh:BlockRow" priority="2">
         <xsl:variable name="forClass" select="xs:anyURI('&foaf;Person')" as="xs:anyURI"/>
-        <xsl:variable name="results-uri" select="ac:build-uri(resolve-uri('ns', ldt:base()), map{ 'query': ldh:constructor-query($forClass), 'accept': 'application/sparql-results+xml' })" as="xs:anyURI"/>
+        <xsl:variable name="results-uri" select="ac:build-uri(resolve-uri('ns', lapp:base()), map{ 'query': ldh:constructor-query($forClass), 'accept': 'application/sparql-results+xml' })" as="xs:anyURI"/>
         <xsl:variable name="results" select="document(ldh:href($results-uri, map{}))" as="document-node()"/>
         <xsl:variable name="constructed-doc" select="ldh:construct-instance(distinct-values($results//srx:binding[@name = 'text']/srx:literal), $forClass)" as="document-node()"/>
 
@@ -83,16 +81,16 @@ exclude-result-prefixes="#all">
     </xsl:template>
 
     <!-- hide resources from constructed models -->
-    <xsl:template match="rdf:Description[not(rdf:type/@rdf:resource = ('&foaf;Person', '&adm;SignUp'))][ac:absolute-path(ldh:request-uri()) = resolve-uri(encode-for-uri('sign up'), ldt:base())]" mode="ldh:RowForm" priority="3"/>
+    <xsl:template match="rdf:Description[not(rdf:type/@rdf:resource = ('&foaf;Person', '&adm;SignUp'))][ac:absolute-path(ldh:request-uri()) = resolve-uri(encode-for-uri('sign up'), lapp:base())]" mode="ldh:RowForm" priority="3"/>
 
     <!-- hide type control -->
-    <xsl:template match="*[*][@rdf:about or @rdf:nodeID][ac:absolute-path(ldh:request-uri()) = resolve-uri(encode-for-uri('sign up'), ldt:base())]" mode="ldh:TypeControl" priority="2">
+    <xsl:template match="*[*][@rdf:about or @rdf:nodeID][ac:absolute-path(ldh:request-uri()) = resolve-uri(encode-for-uri('sign up'), lapp:base())]" mode="ldh:TypeControl" priority="2">
         <xsl:next-match>
             <xsl:with-param name="hidden" select="true()"/>
         </xsl:next-match>
     </xsl:template>
 
-    <xsl:template match="*[*][@rdf:about or @rdf:nodeID][ac:absolute-path(ldh:request-uri()) = resolve-uri(encode-for-uri('sign up'), ldt:base())]" mode="ac:FormControl" priority="1">
+    <xsl:template match="*[*][@rdf:about or @rdf:nodeID][ac:absolute-path(ldh:request-uri()) = resolve-uri(encode-for-uri('sign up'), lapp:base())]" mode="ac:FormControl" priority="1">
         <xsl:next-match>
             <xsl:with-param name="show-subject" select="false()" tunnel="yes"/>
             <xsl:with-param name="legend" select="false()"/>
@@ -100,7 +98,7 @@ exclude-result-prefixes="#all">
         </xsl:next-match>
     </xsl:template>
     
-    <xsl:template match="foaf:based_near/@rdf:*[ac:absolute-path(ldh:request-uri()) = resolve-uri(encode-for-uri('sign up'), ldt:base())]" mode="ac:FormControl" priority="1">
+    <xsl:template match="foaf:based_near/@rdf:*[ac:absolute-path(ldh:request-uri()) = resolve-uri(encode-for-uri('sign up'), lapp:base())]" mode="ac:FormControl" priority="1">
         <xsl:param name="id" select="generate-id()" as="xs:string"/>
         <xsl:param name="class" as="xs:string?"/>
         <xsl:param name="disabled" select="false()" as="xs:boolean"/>
@@ -139,7 +137,7 @@ exclude-result-prefixes="#all">
     </xsl:template>
         
     <!-- make properties required -->
-    <xsl:template match="foaf:givenName[ac:absolute-path(ldh:request-uri()) = resolve-uri(encode-for-uri('sign up'), ldt:base())] | foaf:familyName[ac:absolute-path(ldh:request-uri()) = resolve-uri(encode-for-uri('sign up'), ldt:base())] | foaf:mbox[ac:absolute-path(ldh:request-uri()) = resolve-uri(encode-for-uri('sign up'), ldt:base())] | cert:key[ac:absolute-path(ldh:request-uri()) = resolve-uri(encode-for-uri('sign up'), ldt:base())]" mode="ac:FormControl" priority="1">
+    <xsl:template match="foaf:givenName[ac:absolute-path(ldh:request-uri()) = resolve-uri(encode-for-uri('sign up'), lapp:base())] | foaf:familyName[ac:absolute-path(ldh:request-uri()) = resolve-uri(encode-for-uri('sign up'), lapp:base())] | foaf:mbox[ac:absolute-path(ldh:request-uri()) = resolve-uri(encode-for-uri('sign up'), lapp:base())] | cert:key[ac:absolute-path(ldh:request-uri()) = resolve-uri(encode-for-uri('sign up'), lapp:base())]" mode="ac:FormControl" priority="1">
         <xsl:param name="violations" as="element()*"/>
 
         <xsl:next-match>
@@ -148,7 +146,7 @@ exclude-result-prefixes="#all">
         </xsl:next-match>
     </xsl:template>
     
-    <xsl:template match="cert:key/@rdf:*[ac:absolute-path(ldh:request-uri()) = resolve-uri(encode-for-uri('sign up'), ldt:base())]" mode="ac:FormControl" priority="1">
+    <xsl:template match="cert:key/@rdf:*[ac:absolute-path(ldh:request-uri()) = resolve-uri(encode-for-uri('sign up'), lapp:base())]" mode="ac:FormControl" priority="1">
         <xsl:param name="type" select="'password'" as="xs:string"/>
         <xsl:param name="id" as="xs:string?"/>
         <xsl:param name="class" as="xs:string?"/>
@@ -189,10 +187,10 @@ exclude-result-prefixes="#all">
     </xsl:template>
     
     <!-- do not show secretary URI input -->
-    <xsl:template match="acl:delegates[ac:absolute-path(ldh:request-uri()) = resolve-uri(encode-for-uri('sign up'), ldt:base())]" mode="ac:FormControl" priority="1"/>
+    <xsl:template match="acl:delegates[ac:absolute-path(ldh:request-uri()) = resolve-uri(encode-for-uri('sign up'), lapp:base())]" mode="ac:FormControl" priority="1"/>
 
     <!-- do not show the email hash value -->
-    <xsl:template match="foaf:mbox_sha1sum[ac:absolute-path(ldh:request-uri()) = resolve-uri(encode-for-uri('sign up'), ldt:base())]" mode="ac:FormControl" priority="1"/>
+    <xsl:template match="foaf:mbox_sha1sum[ac:absolute-path(ldh:request-uri()) = resolve-uri(encode-for-uri('sign up'), lapp:base())]" mode="ac:FormControl" priority="1"/>
 
     <xsl:template name="lacl:password">
         <xsl:param name="this" select="xs:anyURI('&lacl;password')" as="xs:anyURI"/>
@@ -269,7 +267,7 @@ exclude-result-prefixes="#all">
     </xsl:template>
     
     <!--  hide properties -->
-    <xsl:template match="dh:slug[ac:absolute-path(ldh:request-uri()) = resolve-uri(encode-for-uri('sign up'), ldt:base())] | foaf:primaryTopic[ac:absolute-path(ldh:request-uri()) = resolve-uri(encode-for-uri('sign up'), ldt:base())] | foaf:isPrimaryTopicOf[ac:absolute-path(ldh:request-uri()) = resolve-uri(encode-for-uri('sign up'), ldt:base())] | cert:modulus[ac:absolute-path(ldh:request-uri()) = resolve-uri(encode-for-uri('sign up'), ldt:base())] | cert:exponent[ac:absolute-path(ldh:request-uri()) = resolve-uri(encode-for-uri('sign up'), ldt:base())]" mode="ac:FormControl" priority="3">
+    <xsl:template match="dh:slug[ac:absolute-path(ldh:request-uri()) = resolve-uri(encode-for-uri('sign up'), lapp:base())] | foaf:primaryTopic[ac:absolute-path(ldh:request-uri()) = resolve-uri(encode-for-uri('sign up'), lapp:base())] | foaf:isPrimaryTopicOf[ac:absolute-path(ldh:request-uri()) = resolve-uri(encode-for-uri('sign up'), lapp:base())] | cert:modulus[ac:absolute-path(ldh:request-uri()) = resolve-uri(encode-for-uri('sign up'), lapp:base())] | cert:exponent[ac:absolute-path(ldh:request-uri()) = resolve-uri(encode-for-uri('sign up'), lapp:base())]" mode="ac:FormControl" priority="3">
         <xsl:apply-templates select="." mode="xhtml:Input">
             <xsl:with-param name="type" select="'hidden'"/>
         </xsl:apply-templates>
@@ -281,13 +279,13 @@ exclude-result-prefixes="#all">
         </xsl:apply-templates>
     </xsl:template>
 
-    <xsl:template match="*[@rdf:about = '&foaf;mbox'][ac:absolute-path(ldh:request-uri()) = resolve-uri(encode-for-uri('sign up'), ldt:base())]" mode="ac:label" priority="1">
+    <xsl:template match="*[@rdf:about = '&foaf;mbox'][ac:absolute-path(ldh:request-uri()) = resolve-uri(encode-for-uri('sign up'), lapp:base())]" mode="ac:label" priority="1">
         <xsl:value-of>
             <xsl:apply-templates select="key('resources', 'email', ldh:translations())" mode="ac:label"/>
         </xsl:value-of>
     </xsl:template>
 
     <!-- turn off additional properties -->
-    <xsl:template match="*[ac:absolute-path(ldh:request-uri()) = resolve-uri(encode-for-uri('sign up'), ldt:base())]" mode="ldh:PropertyControl" priority="1"/>
+    <xsl:template match="*[ac:absolute-path(ldh:request-uri()) = resolve-uri(encode-for-uri('sign up'), lapp:base())]" mode="ldh:PropertyControl" priority="1"/>
 
 </xsl:stylesheet>

--- a/src/main/webapp/static/com/atomgraph/linkeddatahub/xsl/client.xsl
+++ b/src/main/webapp/static/com/atomgraph/linkeddatahub/xsl/client.xsl
@@ -15,7 +15,6 @@
     <!ENTITY srx        "http://www.w3.org/2005/sparql-results#">
     <!ENTITY http       "http://www.w3.org/2011/http#">
     <!ENTITY acl        "http://www.w3.org/ns/auth/acl#">
-    <!ENTITY ldt        "https://www.w3.org/ns/ldt#">
     <!ENTITY dh         "https://www.w3.org/ns/ldt/document-hierarchy#">
     <!ENTITY sd         "http://www.w3.org/ns/sparql-service-description#">
     <!ENTITY sh         "http://www.w3.org/ns/shacl#">
@@ -26,7 +25,6 @@
     <!ENTITY nfo        "http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#">
     <!ENTITY schema1    "http://schema.org/">
     <!ENTITY schema2    "https://schema.org/">
-    <!ENTITY dbpo       "http://dbpedia.org/ontology/">
 ]>
 <xsl:stylesheet version="3.0"
 xmlns="http://www.w3.org/1999/xhtml"
@@ -51,7 +49,6 @@ xmlns:rdfs="&rdfs;"
 xmlns:owl="&owl;"
 xmlns:geo="&geo;"
 xmlns:acl="&acl;"
-xmlns:ldt="&ldt;"
 xmlns:dh="&dh;"
 xmlns:srx="&srx;"
 xmlns:http="&http;"
@@ -64,7 +61,6 @@ xmlns:sioc="&sioc;"
 xmlns:skos="&skos;"
 xmlns:schema1="&schema1;"
 xmlns:schema2="&schema2;"
-xmlns:dbpo="&dbpo;"
 xmlns:rdfae="https://w3id.org/atomgraph/rdfa-editor#"
 exclude-result-prefixes="#all"
 extension-element-prefixes="ixsl"
@@ -98,12 +94,7 @@ extension-element-prefixes="ixsl"
     <xsl:param name="ldh:renderSystemResources" select="false()" as="xs:boolean"/>
     <xsl:param name="ac:contextUri" as="xs:anyURI"/>
     <xsl:param name="lapp:origin" select="lapp:origin(ldh:request-uri())" as="xs:anyURI"/> <!-- emulates the server-side writer-set param: the shell origin serving static assets, as opposed to the pane-scoped lapp:origin() -->
-    <xsl:param name="ldt:base" as="xs:anyURI?"/> <!-- used in Web-Client TO-DO: remove -->
-    <xsl:param name="ldt:ontology" as="xs:anyURI?"/> <!-- used in Web-Client TO-DO: remove -->
-    <xsl:param name="acl:agent" as="xs:anyURI?"/>
-    <xsl:param name="foaf:Agent" select="if ($acl:agent) then document(ac:document-uri($acl:agent)) else ()" as="document-node()?"/> <!-- should be in SaxonJS documentPool -->
     <xsl:param name="ac:query" select="ldh:query-params()?query" as="xs:string?"/>
-    <xsl:param name="ac:googleMapsKey" select="''" as="xs:string"/>  <!-- cannot remove yet as it's used by container.xsl in Web-Client -->
     <xsl:param name="sparql-parser" select="ixsl:call(ixsl:window(), 'Reflect.construct', [ ixsl:get(ixsl:get(ixsl:window(), '`' || 'SPARQL.js' || '`'), 'Parser'), [] ] )"/>
     <xsl:param name="sparql-generator" select="ixsl:call(ixsl:window(), 'Reflect.construct', [ ixsl:get(ixsl:get(ixsl:window(), '`' || 'SPARQL.js' || '`'), 'Generator'), [] ] )"/>
     <xsl:param name="page-size" select="20" as="xs:integer"/>
@@ -155,81 +146,7 @@ WHERE
     LIMIT   10
   }
 ]]></xsl:param>
-    <xsl:param name="constraint-query" as="xs:string">
-        <![CDATA[
-            PREFIX  ldh:  <https://w3id.org/atomgraph/linkeddatahub#>
-            PREFIX  rdfs: <http://www.w3.org/2000/01/rdf-schema#>
-            PREFIX  sp:   <http://spinrdf.org/sp#>
-            PREFIX  spin: <http://spinrdf.org/spin#>
-
-            SELECT  $Type ?property
-            WHERE
-              { $Type (rdfs:subClassOf)*/spin:constraint  ?constraint .
-                ?constraint  a             ldh:MissingPropertyValue ;
-                          sp:arg1          ?property
-              }
-        ]]>
-        <!-- VALUES $Type goes here -->
-    </xsl:param>
-    <xsl:param name="object-metadata-query" as="xs:string">
-        <![CDATA[
-            PREFIX  rdf:  <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
-            PREFIX  xsd:  <http://www.w3.org/2001/XMLSchema#>
-            PREFIX  dct:  <http://purl.org/dc/terms/>
-            PREFIX  schema2: <https://schema.org/>
-            PREFIX  schema1: <http://schema.org/>
-            PREFIX  skos: <http://www.w3.org/2004/02/skos/core#>
-            PREFIX  rdfs: <http://www.w3.org/2000/01/rdf-schema#>
-            PREFIX  foaf: <http://xmlns.com/foaf/0.1/>
-            PREFIX  sioc: <http://rdfs.org/sioc/ns#>
-            PREFIX  dc:   <http://purl.org/dc/elements/1.1/>
-
-            CONSTRUCT
-              {
-                $this ?p ?literal .
-              }
-            WHERE
-              { GRAPH ?graph
-                  { $this  ?p  ?literal
-                    FILTER ( ( datatype(?literal) = xsd:string ) || ( datatype(?literal) = rdf:langString ) )
-                    FILTER ( ?p IN (rdfs:label, dc:title, dct:title, foaf:name, foaf:givenName, foaf:familyName, sioc:name, skos:prefLabel, schema1:name, schema2:name) )
-                  }
-              }
-        ]]>
-        <!-- VALUES $this goes here -->
-    </xsl:param>
     <!-- graph-free variant of object-metadata-query for the /ns ontology endpoint: its dataset is the in-memory OntModel served as the default graph (no named graphs), so a GRAPH ?graph pattern would match nothing -->
-    <xsl:param name="object-metadata-ns-query" as="xs:string">
-        <![CDATA[
-            PREFIX  rdf:  <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
-            PREFIX  xsd:  <http://www.w3.org/2001/XMLSchema#>
-            PREFIX  dct:  <http://purl.org/dc/terms/>
-            PREFIX  schema2: <https://schema.org/>
-            PREFIX  schema1: <http://schema.org/>
-            PREFIX  skos: <http://www.w3.org/2004/02/skos/core#>
-            PREFIX  rdfs: <http://www.w3.org/2000/01/rdf-schema#>
-            PREFIX  foaf: <http://xmlns.com/foaf/0.1/>
-            PREFIX  sioc: <http://rdfs.org/sioc/ns#>
-            PREFIX  dc:   <http://purl.org/dc/elements/1.1/>
-
-            CONSTRUCT
-              {
-                $this ?p ?literal .
-              }
-            WHERE
-              { $this  ?p  ?literal
-                FILTER ( ( datatype(?literal) = xsd:string ) || ( datatype(?literal) = rdf:langString ) )
-                FILTER ( ?p IN (rdfs:label, dc:title, dct:title, foaf:name, foaf:givenName, foaf:familyName, sioc:name, skos:prefLabel, schema1:name, schema2:name) )
-              }
-        ]]>
-        <!-- VALUES $this goes here -->
-    </xsl:param>
-    <xsl:param name="property-metadata-query" as="xs:string">
-        <![CDATA[
-            DESCRIBE $Type
-        ]]>
-        <!-- VALUES $Type goes here -->
-    </xsl:param>
     <xsl:param name="body-id" select="'visible-body'" as="xs:string"/>
     
     <xsl:key name="resources" match="*[*][@rdf:about] | *[*][@rdf:nodeID]" use="@rdf:about | @rdf:nodeID"/>
@@ -415,7 +332,7 @@ WHERE
                             </xsl:call-template>
 
                             <!-- is-active is the whole visibility contract (ldh.css owns display) -->
-                            <xsl:for-each select="id('tab-content', ixsl:page())/div[contains-token(@class, 'ldh-pane')][./div[contains-token(@class, 'document-body')][starts-with(@about, lapp:origin(ldh:request-uri()) || '/')]]">
+                            <xsl:for-each select="id('tab-content', ixsl:page())/div[contains-token(@class, 'ldh-pane')][./div[contains-token(@class, 'document-body')][ldh:is-local(@about)]]">
                                 <ixsl:set-attribute name="class" select="ldh:set-token(@class, 'is-active', false())"/>
                             </xsl:for-each>
                         </xsl:if>
@@ -463,7 +380,7 @@ WHERE
                             <!-- no pane: create one with sidebar -->
                             <xsl:otherwise>
                                 <xsl:variable name="tab-body" as="element()">
-                                    <!-- inert class: ldh:ActivateTab (called from ldh:RenderTab below) is the single source of truth for the 'is-active' token. Defaulting to 'ldh-pane is-active' here would briefly leave two panes active (this one + the currently-active local one) and crash ldt:base()/sd:endpoint() in any code that runs between append and ActivateTab (e.g. ldh:DataspaceDrawer). -->
+                                    <!-- inert class: ldh:ActivateTab (called from ldh:RenderTab below) is the single source of truth for the 'is-active' token. Defaulting to 'ldh-pane is-active' here would briefly leave two panes active (this one + the currently-active local one) and crash lapp:base()/sd:endpoint() in any code that runs between append and ActivateTab (e.g. ldh:DataspaceDrawer). -->
                                     <xsl:apply-templates select="$render-results/rdf:RDF" mode="ldh:TabPanel">
                                         <xsl:with-param name="id" select="$tab-body-id"/>
                                         <xsl:with-param name="class" select="'ldh-pane'"/>
@@ -608,7 +525,7 @@ WHERE
                         </xsl:call-template>
 
                         <!-- is-active is the whole visibility contract (ldh.css owns display) -->
-                        <xsl:for-each select="id('tab-content', ixsl:page())/div[contains-token(@class, 'ldh-pane')][./div[contains-token(@class, 'document-body')][starts-with(@about, lapp:origin(ldh:request-uri()) || '/')]]">
+                        <xsl:for-each select="id('tab-content', ixsl:page())/div[contains-token(@class, 'ldh-pane')][./div[contains-token(@class, 'document-body')][ldh:is-local(@about)]]">
                             <ixsl:set-attribute name="class" select="ldh:set-token(@class, 'is-active', false())"/>
                         </xsl:for-each>
                     </xsl:if>
@@ -984,7 +901,7 @@ WHERE
 
         <!-- deactivate the local tab pane for external URIs; is-active is the whole visibility contract
              (an inline display here outlived the switch back and kept the reactivated pane hidden) -->
-        <xsl:if test="not(starts-with($doc-uri, lapp:origin(ldh:request-uri()) || '/'))">
+        <xsl:if test="not(ldh:is-local($doc-uri))">
             <xsl:for-each select="id('tab-content', ixsl:page())/div[contains-token(@class, 'ldh-pane')][./div[contains-token(@class, 'document-body')]/@about = ac:absolute-path(ldh:request-uri())]">
                 <ixsl:set-attribute name="class" select="ldh:set-token(@class, 'is-active', false())"/>
             </xsl:for-each>
@@ -1101,7 +1018,7 @@ WHERE
 
     <!-- intercept all HTML and SVG link clicks except to /uploads/ and those in the header (except breadcrumb bar, .ldh-wordmark and app list) and the footer -->
     <!-- resolve URLs against the current document URL because they can be relative -->
-    <xsl:template match="a[not(@target)][starts-with(resolve-uri(@href, ldh:base-uri(.)), 'http://') or starts-with(resolve-uri(@href, ldh:base-uri(.)), 'https://')][not(starts-with(resolve-uri(@href, ldh:base-uri(.)), resolve-uri('uploads/', ldt:base())))][ancestor::div[contains-token(@class, 'breadcrumb-nav')] or not(ancestor::div[tokenize(@class, ' ') = ('ldh-header', 'ldh-footer')])] | a[contains-token(@class, 'ldh-wordmark')] | div[button[contains-token(@class, 'btn-apps')]]/div//a | svg:a[not(@target)][starts-with(resolve-uri(@href, ldh:base-uri(.)), 'http://') or starts-with(resolve-uri(@href, ldh:base-uri(.)), 'https://')][not(starts-with(resolve-uri(@href, ldh:base-uri(.)), resolve-uri('uploads/', ldt:base())))]" mode="ixsl:onclick">
+    <xsl:template match="a[not(@target)][starts-with(resolve-uri(@href, ldh:base-uri(.)), 'http://') or starts-with(resolve-uri(@href, ldh:base-uri(.)), 'https://')][not(starts-with(resolve-uri(@href, ldh:base-uri(.)), resolve-uri('uploads/', lapp:base())))][ancestor::div[contains-token(@class, 'breadcrumb-nav')] or not(ancestor::div[tokenize(@class, ' ') = ('ldh-header', 'ldh-footer')])] | a[contains-token(@class, 'ldh-wordmark')] | div[button[contains-token(@class, 'btn-apps')]]/div//a | svg:a[not(@target)][starts-with(resolve-uri(@href, ldh:base-uri(.)), 'http://') or starts-with(resolve-uri(@href, ldh:base-uri(.)), 'https://')][not(starts-with(resolve-uri(@href, ldh:base-uri(.)), resolve-uri('uploads/', lapp:base())))]" mode="ixsl:onclick">
         <xsl:sequence select="ixsl:call(ixsl:event(), 'preventDefault', [])"/>
         <xsl:variable name="href" select="xs:anyURI(resolve-uri(@href, ldh:base-uri(.)))" as="xs:anyURI"/>
         <xsl:variable name="parsed" select="ldh:parse-href($href)" as="map(xs:string, item()?)"/>

--- a/src/main/webapp/static/com/atomgraph/linkeddatahub/xsl/client/block.xsl
+++ b/src/main/webapp/static/com/atomgraph/linkeddatahub/xsl/client/block.xsl
@@ -9,7 +9,6 @@
     <!ENTITY xsd    "http://www.w3.org/2001/XMLSchema#">
     <!ENTITY geo    "http://www.w3.org/2003/01/geo/wgs84_pos#">
     <!ENTITY acl    "http://www.w3.org/ns/auth/acl#">
-    <!ENTITY ldt    "https://www.w3.org/ns/ldt#">
     <!ENTITY dh     "https://www.w3.org/ns/ldt/document-hierarchy#">
     <!ENTITY sd     "http://www.w3.org/ns/sparql-service-description#">
     <!ENTITY sioc   "http://rdfs.org/sioc/ns#">
@@ -36,7 +35,6 @@ xmlns:rdf="&rdf;"
 xmlns:rdfs="&rdfs;"
 xmlns:geo="&geo;"
 xmlns:acl="&acl;"
-xmlns:ldt="&ldt;"
 xmlns:sioc="&sioc;"
 xmlns:sd="&sd;"
 xmlns:sp="&sp;"
@@ -197,7 +195,7 @@ exclude-result-prefixes="#all"
         <xsl:for-each select="self::div[contains-token(@class, 'ldh-block-row')][@about]/div[contains-token(@class, 'row-main')]/div[contains-token(@class, 'block')][@typeof]">
             <xsl:variable name="typeof-uris" select="tokenize(@typeof, ' ') ! xs:anyURI(.)" as="xs:anyURI*"/>
             <xsl:variable name="values-clause" select="' VALUES ?type { ' || string-join(for $t in $typeof-uris return '&lt;' || $t || '&gt;', ' ') || ' }'" as="xs:string"/>
-            <xsl:variable name="request-uri" select="ldh:href(ac:build-uri(resolve-uri('ns', ldt:base()), map{ 'query': $ontology-view-query || $values-clause }), map{})" as="xs:anyURI"/>
+            <xsl:variable name="request-uri" select="ldh:href(ac:build-uri(resolve-uri('ns', lapp:base()), map{ 'query': $ontology-view-query || $values-clause }), map{})" as="xs:anyURI"/>
             <xsl:variable name="request" select="map{ 'method': 'GET', 'href': $request-uri, 'headers': map{ 'Accept': 'application/sparql-results+xml' } }" as="map(*)"/>
             <xsl:variable name="context" as="map(*)" select="
                 map{
@@ -300,7 +298,7 @@ exclude-result-prefixes="#all"
                     <xsl:variable name="query-string" select="replace($backlinks-string, '$this', '&lt;' || $block-uri || '&gt;', 'q')" as="xs:string"/>
                     <xsl:variable name="service-uri" select="if (ixsl:contains(ixsl:get(ixsl:window(), 'LinkedDataHub.contents'), '`' || $block-uri || '`')) then (if (ixsl:contains(ixsl:get(ixsl:get(ixsl:window(), 'LinkedDataHub.contents'), '`' || $block-uri || '`'), 'service-uri')) then ixsl:get(ixsl:get(ixsl:get(ixsl:window(), 'LinkedDataHub.contents'), '`' || $block-uri || '`'), 'service-uri') else ()) else ()" as="xs:anyURI?"/>
                     <xsl:variable name="service" select="if ($service-uri) then key('resources', $service-uri, document(ldh:href(ac:document-uri($service-uri), map{ 'accept': 'application/rdf+xml' }, ()))) else ()" as="element()?"/> <!-- TO-DO: refactor asynchronously -->
-                    <xsl:variable name="endpoint" select="($service/sd:endpoint/@rdf:resource/xs:anyURI(.), sd:endpoint())[1]" as="xs:anyURI"/>
+                    <xsl:variable name="endpoint" select="ldh:service-endpoint($service)" as="xs:anyURI"/>
                     <xsl:variable name="results-uri" select="ac:build-uri($endpoint, map{ 'query': string($query-string) })" as="xs:anyURI"/>
                     <xsl:variable name="request-uri" select="ldh:href($results-uri, map{})" as="xs:anyURI"/>
 
@@ -1089,7 +1087,7 @@ exclude-result-prefixes="#all"
         <xsl:variable name="request" select="map{ 'method': 'POST', 'href': ldh:href($endpoint), 'media-type': 'application/sparql-query', 'body': $query-string, 'headers': map{ 'Accept': 'application/rdf+xml' } }" as="map(*)"/>
         <!-- second request resolves labels of object URIs that are ontology terms (rdf:type/class values etc.) from the /ns endpoint, whose graph-free query targets the in-memory ontology default graph; merged with the /sparql result by ldh:merge-object-metadata -->
         <xsl:variable name="ns-query-string" select="$object-metadata-ns-query || $values" as="xs:string"/>
-        <xsl:variable name="ns-request" select="map{ 'method': 'POST', 'href': ldh:href(resolve-uri('ns', ldt:base())), 'media-type': 'application/sparql-query', 'body': $ns-query-string, 'headers': map{ 'Accept': 'application/rdf+xml' } }" as="map(*)"/>
+        <xsl:variable name="ns-request" select="map{ 'method': 'POST', 'href': ldh:href(resolve-uri('ns', lapp:base())), 'media-type': 'application/sparql-query', 'body': $ns-query-string, 'headers': map{ 'Accept': 'application/rdf+xml' } }" as="map(*)"/>
 
         <xsl:message>ldh:load-object-metadata</xsl:message>
 
@@ -1173,7 +1171,7 @@ exclude-result-prefixes="#all"
                        then distinct-values($response?body/rdf:RDF/rdf:Description/*/concat(namespace-uri(), local-name()))
                        else ()"/>
         <xsl:variable name="query-string" select="$property-metadata-query || ' VALUES $Type { ' || string-join(for $uri in $property-uris return '&lt;' || $uri || '&gt;', ' ') || ' }'" as="xs:string"/>
-        <xsl:variable name="request" select="map{ 'method': 'POST', 'href': ldh:href(resolve-uri('ns', ldt:base())), 'media-type': 'application/sparql-query', 'body': $query-string, 'headers': map{ 'Accept': 'application/rdf+xml' } }" as="map(*)"/>
+        <xsl:variable name="request" select="map{ 'method': 'POST', 'href': ldh:href(resolve-uri('ns', lapp:base())), 'media-type': 'application/sparql-query', 'body': $query-string, 'headers': map{ 'Accept': 'application/rdf+xml' } }" as="map(*)"/>
 
         <xsl:message>ldh:load-property-metadata</xsl:message>
 

--- a/src/main/webapp/static/com/atomgraph/linkeddatahub/xsl/client/block/chart.xsl
+++ b/src/main/webapp/static/com/atomgraph/linkeddatahub/xsl/client/block/chart.xsl
@@ -8,7 +8,6 @@
     <!ENTITY xsd    "http://www.w3.org/2001/XMLSchema#">
     <!ENTITY srx    "http://www.w3.org/2005/sparql-results#">
     <!ENTITY acl    "http://www.w3.org/ns/auth/acl#">
-    <!ENTITY ldt    "https://www.w3.org/ns/ldt#">
     <!ENTITY sd     "http://www.w3.org/ns/sparql-service-description#">
     <!ENTITY sioc   "http://rdfs.org/sioc/ns#">
     <!ENTITY sp     "http://spinrdf.org/sp#">
@@ -31,7 +30,6 @@ xmlns:lapp="&lapp;"
 xmlns:rdf="&rdf;"
 xmlns:srx="&srx;"
 xmlns:acl="&acl;"
-xmlns:ldt="&ldt;"
 xmlns:sd="&sd;"
 xmlns:sp="&sp;"
 xmlns:spin="&spin;"
@@ -565,7 +563,7 @@ exclude-result-prefixes="#all"
                         <!--<xsl:variable name="query-string" select="concat($query-string, ' LIMIT 100')" as="xs:string"/>-->
                         <xsl:variable name="service-uri" select="xs:anyURI(key('resources', $query-uri)/ldh:service/@rdf:resource)" as="xs:anyURI?"/>
                         <xsl:variable name="service" select="if ($service-uri) then key('resources', $service-uri, document(ldh:href(ac:document-uri($service-uri), map{ 'accept': 'application/rdf+xml' }, ()))) else ()" as="element()?"/> <!-- TO-DO: refactor asynchronously -->
-                        <xsl:variable name="endpoint" select="($service/sd:endpoint/@rdf:resource/xs:anyURI(.), sd:endpoint())[1]" as="xs:anyURI"/>
+                        <xsl:variable name="endpoint" select="ldh:service-endpoint($service)" as="xs:anyURI"/>
                         <xsl:variable name="request-uri" select="ldh:href($endpoint, map{})" as="xs:anyURI"/>
 
                         <!-- Mark query response as complete -->

--- a/src/main/webapp/static/com/atomgraph/linkeddatahub/xsl/client/block/object.xsl
+++ b/src/main/webapp/static/com/atomgraph/linkeddatahub/xsl/client/block/object.xsl
@@ -7,13 +7,14 @@
     <!ENTITY rdfs   "http://www.w3.org/2000/01/rdf-schema#">
     <!ENTITY xsd    "http://www.w3.org/2001/XMLSchema#">
     <!ENTITY acl    "http://www.w3.org/ns/auth/acl#">
-    <!ENTITY ldt    "https://www.w3.org/ns/ldt#">
     <!ENTITY sd     "http://www.w3.org/ns/sparql-service-description#">
     <!ENTITY foaf   "http://xmlns.com/foaf/0.1/">
+    <!ENTITY lapp   "https://w3id.org/atomgraph/linkeddatahub/apps#">
 ]>
 <xsl:stylesheet version="3.0"
 xmlns="http://www.w3.org/1999/xhtml"
 xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
+xmlns:lapp="&lapp;"
 xmlns:ixsl="http://saxonica.com/ns/interactiveXSLT"
 xmlns:prop="http://saxonica.com/ns/html-property"
 xmlns:xhtml="http://www.w3.org/1999/xhtml"
@@ -26,7 +27,6 @@ xmlns:ldh="&ldh;"
 xmlns:rdf="&rdf;"
 xmlns:rdfs="&rdfs;"
 xmlns:acl="&acl;"
-xmlns:ldt="&ldt;"
 xmlns:sd="&sd;"
 xmlns:foaf="&foaf;"
 extension-element-prefixes="ixsl"
@@ -183,13 +183,13 @@ exclude-result-prefixes="#all"
                         <xsl:choose>
                             <!-- only attempt to load object metadata for local resources -->
                             <xsl:when test="$resource">
-                                <xsl:variable name="object-uris" select="distinct-values($resource/*/@rdf:resource[starts-with(., ldt:base())][not(key('resources', ., root($resource)))])" as="xs:string*"/>
+                                <xsl:variable name="object-uris" select="distinct-values($resource/*/@rdf:resource[starts-with(., lapp:base())][not(key('resources', ., root($resource)))])" as="xs:string*"/>
                                 <xsl:variable name="values" select="' VALUES $this { ' || string-join(for $uri in $object-uris return '&lt;' || $uri || '&gt;', ' ') || ' }'" as="xs:string"/>
                                 <xsl:variable name="query-string" select="$object-metadata-query || $values" as="xs:string"/>
                                 <xsl:variable name="request" select="map{ 'method': 'POST', 'href': ldh:href(sd:endpoint()), 'media-type': 'application/sparql-query', 'body': $query-string, 'headers': map{ 'Accept': 'application/rdf+xml' } }" as="map(*)"/>
                                 <!-- second request resolves ontology-term object labels (rdf:type/class values etc.) from the /ns endpoint; merged with the /sparql result in ldh:block-object-metadata-response -->
                                 <xsl:variable name="ns-query-string" select="$object-metadata-ns-query || $values" as="xs:string"/>
-                                <xsl:variable name="ns-request" select="map{ 'method': 'POST', 'href': ldh:href(resolve-uri('ns', ldt:base())), 'media-type': 'application/sparql-query', 'body': $ns-query-string, 'headers': map{ 'Accept': 'application/rdf+xml' } }" as="map(*)"/>
+                                <xsl:variable name="ns-request" select="map{ 'method': 'POST', 'href': ldh:href(resolve-uri('ns', lapp:base())), 'media-type': 'application/sparql-query', 'body': $ns-query-string, 'headers': map{ 'Accept': 'application/rdf+xml' } }" as="map(*)"/>
                                 <xsl:sequence select="map:put(map:merge(($context, map{
                                     'object-metadata-request': $request,
                                     'ns-object-metadata-request': $ns-request,

--- a/src/main/webapp/static/com/atomgraph/linkeddatahub/xsl/client/block/query.xsl
+++ b/src/main/webapp/static/com/atomgraph/linkeddatahub/xsl/client/block/query.xsl
@@ -8,7 +8,6 @@
     <!ENTITY xsd    "http://www.w3.org/2001/XMLSchema#">
     <!ENTITY srx    "http://www.w3.org/2005/sparql-results#">
     <!ENTITY acl    "http://www.w3.org/ns/auth/acl#">
-    <!ENTITY ldt    "https://www.w3.org/ns/ldt#">
     <!ENTITY sd     "http://www.w3.org/ns/sparql-service-description#">
     <!ENTITY sioc   "http://rdfs.org/sioc/ns#">
     <!ENTITY sp     "http://spinrdf.org/sp#">
@@ -31,7 +30,6 @@ xmlns:lapp="&lapp;"
 xmlns:rdf="&rdf;"
 xmlns:srx="&srx;"
 xmlns:acl="&acl;"
-xmlns:ldt="&ldt;"
 xmlns:sd="&sd;"
 xmlns:sp="&sp;"
 xmlns:spin="&spin;"
@@ -333,7 +331,7 @@ exclude-result-prefixes="#all"
         <xsl:variable name="service-meta" select="descendant::div[contains-token(@class, 'ldh-sparql-meta')][input[@name = 'pu'][@value = '&ldh;service']]" as="element()"/>
         <xsl:variable name="service-uri" select="$service-meta/descendant::input[@name = 'ou']/ixsl:get(., 'value')" as="xs:anyURI?"/>
         <xsl:variable name="service" select="if ($service-uri) then key('resources', $service-uri, document(ldh:href(ac:document-uri($service-uri), map{ 'accept': 'application/rdf+xml' }, ()))) else ()" as="element()?"/> <!-- TO-DO: refactor asynchronously -->
-        <xsl:variable name="endpoint" select="($service/sd:endpoint/@rdf:resource/xs:anyURI(.), sd:endpoint())[1]" as="xs:anyURI"/>
+        <xsl:variable name="endpoint" select="ldh:service-endpoint($service)" as="xs:anyURI"/>
         <xsl:variable name="block" select="ancestor::div[contains-token(@class, 'block')][1]" as="element()"/>
         <xsl:variable name="container" select="$block" as="element()"/> <!-- since we're not in content mode -->
         <xsl:variable name="block-id" select="ldh:block-id($block)" as="xs:string"/>
@@ -624,7 +622,7 @@ exclude-result-prefixes="#all"
         <xsl:variable name="query-string" select="ixsl:call($yasqe, 'getValue', [])" as="xs:string?"/> <!-- get query string from YASQE -->
         <xsl:variable name="service-uri" select="ancestor::form[1]/descendant::div[contains-token(@class, 'ldh-sparql-meta')]/descendant::input[@name = 'ou']/ixsl:get(., 'value')" as="xs:anyURI?"/>
         <xsl:variable name="service" select="if ($service-uri) then key('resources', $service-uri, document(ldh:href(ac:document-uri($service-uri), map{ 'accept': 'application/rdf+xml' }, ()))) else ()" as="element()?"/> <!-- TO-DO: refactor asynchronously -->
-        <xsl:variable name="endpoint" select="($service/sd:endpoint/@rdf:resource/xs:anyURI(.), sd:endpoint())[1]" as="xs:anyURI"/>
+        <xsl:variable name="endpoint" select="ldh:service-endpoint($service)" as="xs:anyURI"/>
         <xsl:variable name="query-type" select="ldh:query-type($query-string)" as="xs:string?"/>
 
         <xsl:choose>

--- a/src/main/webapp/static/com/atomgraph/linkeddatahub/xsl/client/block/view.xsl
+++ b/src/main/webapp/static/com/atomgraph/linkeddatahub/xsl/client/block/view.xsl
@@ -9,7 +9,6 @@
     <!ENTITY xsd    "http://www.w3.org/2001/XMLSchema#">
     <!ENTITY srx    "http://www.w3.org/2005/sparql-results#">
     <!ENTITY acl    "http://www.w3.org/ns/auth/acl#">
-    <!ENTITY ldt    "https://www.w3.org/ns/ldt#">
     <!ENTITY sd     "http://www.w3.org/ns/sparql-service-description#">
     <!ENTITY sp     "http://spinrdf.org/sp#">
     <!ENTITY spin   "http://spinrdf.org/spin#">
@@ -33,7 +32,6 @@ xmlns:rdf="&rdf;"
 xmlns:rdfs="&rdfs;"
 xmlns:srx="&srx;"
 xmlns:acl="&acl;"
-xmlns:ldt="&ldt;"
 xmlns:sd="&sd;"
 xmlns:sp="&sp;"
 xmlns:spin="&spin;"
@@ -2637,7 +2635,7 @@ exclude-result-prefixes="#all"
                         <xsl:variable name="focus-var-name" select="$initial-var-name" as="xs:string"/>
                         <!-- service can be explicitly specified on content using ldh:service -->
                         <xsl:variable name="service" select="if ($service-uri) then key('resources', $service-uri, document(ldh:href(ac:document-uri($service-uri), map{ 'accept': 'application/rdf+xml' }, ()))) else ()" as="element()?"/> <!-- TO-DO: refactor asynchronously -->
-                        <xsl:variable name="endpoint" select="($service/sd:endpoint/@rdf:resource/xs:anyURI(.), sd:endpoint())[1]" as="xs:anyURI"/>
+                        <xsl:variable name="endpoint" select="ldh:service-endpoint($service)" as="xs:anyURI"/>
 
                         <xsl:choose>
                             <!-- service URI is not specified or specified and can be loaded -->
@@ -2929,7 +2927,7 @@ exclude-result-prefixes="#all"
 
                             <xsl:variable name="values" select="' VALUES $this { ' || string-join(distinct-values($links ! ('&lt;' || ?predicate || '&gt;')), ' ') || ' }'" as="xs:string"/>
                             <xsl:variable name="query-string" select="$object-metadata-ns-query || $values" as="xs:string"/>
-                            <xsl:variable name="request" select="map{ 'method': 'POST', 'href': ldh:href(resolve-uri('ns', ldt:base())), 'media-type': 'application/sparql-query', 'body': $query-string, 'headers': map{ 'Accept': 'application/rdf+xml' } }" as="map(*)"/>
+                            <xsl:variable name="request" select="map{ 'method': 'POST', 'href': ldh:href(resolve-uri('ns', lapp:base())), 'media-type': 'application/sparql-query', 'body': $query-string, 'headers': map{ 'Accept': 'application/rdf+xml' } }" as="map(*)"/>
                             <xsl:variable name="context" select="map:merge((
                               $context,
                               map{
@@ -3064,7 +3062,7 @@ exclude-result-prefixes="#all"
                                             <xsl:variable name="value-result" select="." as="element()"/>
                                             <!-- DESCRIBE the class over the application's /ns ontology endpoint (ACL-enforced) instead of proxying its vocab document -->
                                             <xsl:variable name="query-string" select="$property-metadata-query || ' VALUES $Type { &lt;' || $object-type || '&gt; }'" as="xs:string"/>
-                                            <xsl:variable name="request" select="map{ 'method': 'POST', 'href': ldh:href(resolve-uri('ns', ldt:base())), 'media-type': 'application/sparql-query', 'body': $query-string, 'headers': map{ 'Accept': 'application/rdf+xml' } }" as="map(*)"/>
+                                            <xsl:variable name="request" select="map{ 'method': 'POST', 'href': ldh:href(resolve-uri('ns', lapp:base())), 'media-type': 'application/sparql-query', 'body': $query-string, 'headers': map{ 'Accept': 'application/rdf+xml' } }" as="map(*)"/>
                                             <xsl:variable name="context" as="map(*)" select="
                                               map{
                                                 'request': $request,

--- a/src/main/webapp/static/com/atomgraph/linkeddatahub/xsl/client/combobox.xsl
+++ b/src/main/webapp/static/com/atomgraph/linkeddatahub/xsl/client/combobox.xsl
@@ -8,7 +8,6 @@
     <!ENTITY sparql     "http://www.w3.org/2005/sparql-results#">
     <!ENTITY xsd        "http://www.w3.org/2001/XMLSchema#">
     <!ENTITY sd         "http://www.w3.org/ns/sparql-service-description#">
-    <!ENTITY ldt        "https://www.w3.org/ns/ldt#">
     <!ENTITY c          "https://www.w3.org/ns/ldt/core/domain#">
     <!ENTITY dct        "http://purl.org/dc/terms/">
     <!ENTITY foaf       "http://xmlns.com/foaf/0.1/">
@@ -27,7 +26,6 @@ xmlns:rdfs="&rdfs;"
 xmlns:owl="&owl;"
 xmlns:sparql="&sparql;"
 xmlns:sd="&sd;"
-xmlns:ldt="&ldt;"
 xmlns:c="&c;"
 xmlns:dct="&dct;"
 xmlns:foaf="&foaf;"

--- a/src/main/webapp/static/com/atomgraph/linkeddatahub/xsl/client/constructor.xsl
+++ b/src/main/webapp/static/com/atomgraph/linkeddatahub/xsl/client/constructor.xsl
@@ -8,7 +8,6 @@
     <!ENTITY xsd    "http://www.w3.org/2001/XMLSchema#">
     <!ENTITY owl    "http://www.w3.org/2002/07/owl#">
     <!ENTITY srx    "http://www.w3.org/2005/sparql-results#">
-    <!ENTITY ldt    "https://www.w3.org/ns/ldt#">
     <!ENTITY spin   "http://spinrdf.org/spin#">
 ]>
 <xsl:stylesheet version="3.0"
@@ -28,7 +27,6 @@ xmlns:lapp="&lapp;"
 xmlns:rdf="&rdf;"
 xmlns:rdfs="&rdfs;"
 xmlns:srx="&srx;"
-xmlns:ldt="&ldt;"
 xmlns:spin="&spin;"
 extension-element-prefixes="ixsl"
 exclude-result-prefixes="#all"
@@ -131,7 +129,7 @@ exclude-result-prefixes="#all"
                                                 <xsl:apply-templates select="key('resources', 'constructor', ldh:translations())" mode="ac:label"/>
                                             </span>
                                             <h2 class="ac-modal-title" id="modal-title-{generate-id()}">
-                                                <xsl:variable name="request-uri" select="ldh:href(ac:build-uri(resolve-uri('ns', ldt:base()), map{ 'query': 'DESCRIBE &lt;' || $type || '&gt;', 'accept': 'application/rdf+xml' }), map{})" as="xs:anyURI"/>
+                                                <xsl:variable name="request-uri" select="ldh:href(ac:build-uri(resolve-uri('ns', lapp:base()), map{ 'query': 'DESCRIBE &lt;' || $type || '&gt;', 'accept': 'application/rdf+xml' }), map{})" as="xs:anyURI"/>
 
                                                 <xsl:apply-templates select="key('resources', $type, document(ac:document-uri($request-uri)))" mode="ac:label"/>
                                             </h2>
@@ -216,7 +214,7 @@ exclude-result-prefixes="#all"
         <div class="ctor-pred">
             <xsl:choose>
                 <xsl:when test="$predicate">
-                    <xsl:variable name="request-uri" select="ldh:href(ac:build-uri(resolve-uri('ns', ldt:base()), map{ 'query': 'DESCRIBE &lt;' || $predicate || '&gt;', 'accept': 'application/rdf+xml' }), map{})" as="xs:anyURI"/>
+                    <xsl:variable name="request-uri" select="ldh:href(ac:build-uri(resolve-uri('ns', lapp:base()), map{ 'query': 'DESCRIBE &lt;' || $predicate || '&gt;', 'accept': 'application/rdf+xml' }), map{})" as="xs:anyURI"/>
                     <xsl:variable name="ontology-doc-uri" select="ac:document-uri($predicate)" as="xs:anyURI"/>
                     <!-- /ns DESCRIBE resolves predicates from the app's ontology import closure (typically user-defined classes);
                          ixsl:doc-fetched picks up predicates whose ontology doc the page already pulled into the SaxonJS pool (typically system vocabularies) -->
@@ -315,7 +313,7 @@ exclude-result-prefixes="#all"
             <div class="ldh-ctor-card-head">
                 <span class="ttl">
                     <a href="{$constructor-uri}" title="{$constructor-uri}" target="_blank">
-                        <xsl:variable name="request-uri" select="ldh:href(ac:build-uri(resolve-uri('ns', ldt:base()), map{ 'query': 'DESCRIBE &lt;' || $constructor-uri || '&gt;', 'accept': 'application/rdf+xml' }), map{})" as="xs:anyURI"/>
+                        <xsl:variable name="request-uri" select="ldh:href(ac:build-uri(resolve-uri('ns', lapp:base()), map{ 'query': 'DESCRIBE &lt;' || $constructor-uri || '&gt;', 'accept': 'application/rdf+xml' }), map{})" as="xs:anyURI"/>
                         <xsl:apply-templates select="key('resources', $constructor-uri, document($request-uri))" mode="ac:label"/>
                     </a>
                 </span>
@@ -408,7 +406,7 @@ exclude-result-prefixes="#all"
 
         <xsl:choose>
             <xsl:when test="$object-type">
-                <xsl:variable name="request-uri" select="ldh:href(ac:build-uri(resolve-uri('ns', ldt:base()), map{ 'query': 'DESCRIBE &lt;' || $object-type || '&gt;', 'accept': 'application/rdf+xml' }), map{})" as="xs:anyURI"/>
+                <xsl:variable name="request-uri" select="ldh:href(ac:build-uri(resolve-uri('ns', lapp:base()), map{ 'query': 'DESCRIBE &lt;' || $object-type || '&gt;', 'accept': 'application/rdf+xml' }), map{})" as="xs:anyURI"/>
 
                 <xsl:apply-templates select="key('resources', $object-type, document($request-uri))" mode="ldh:ComboboxChip">
                     <xsl:with-param name="class" select="'cb-chip-btn add-combobox add-class-combobox'"/>
@@ -443,7 +441,7 @@ exclude-result-prefixes="#all"
     <!-- classes and properties are looked up in the <ns> endpoint -->
     <xsl:template match="input[contains-token(@class, 'class-combobox')] | input[contains-token(@class, 'property-combobox')]" mode="ixsl:onkeyup" priority="1">
         <xsl:next-match>
-            <xsl:with-param name="endpoint" select="resolve-uri('ns', ldt:base())"/>
+            <xsl:with-param name="endpoint" select="resolve-uri('ns', lapp:base())"/>
             <xsl:with-param name="select-string" select="$select-labelled-string"/>
         </xsl:next-match>
     </xsl:template>
@@ -524,7 +522,7 @@ exclude-result-prefixes="#all"
         <xsl:variable name="button-div" select="." as="element()"/> <!-- the addctor strip button itself; new cards insert before it -->
         <xsl:variable name="type" select="ancestor::form/@about" as="xs:anyURI"/> <!-- the URI of the class that constructors are attached to -->
         <xsl:variable name="query-string" select="replace($type-graph-query, '$Type', '&lt;' || $type || '&gt;', 'q')" as="xs:string"/>
-        <xsl:variable name="admin-base-uri" select="xs:anyURI(replace(ldt:base(), '^(https?://)', '$1admin.'))" as="xs:anyURI"/>
+        <xsl:variable name="admin-base-uri" select="xs:anyURI(replace(lapp:base(), '^(https?://)', '$1admin.'))" as="xs:anyURI"/>
         <xsl:variable name="results-uri" select="ac:build-uri(resolve-uri('sparql', $admin-base-uri), map{ 'query': $query-string })" as="xs:anyURI"/>
         <xsl:variable name="request-uri" select="ldh:href($results-uri, map{})" as="xs:anyURI"/>
 
@@ -631,7 +629,7 @@ exclude-result-prefixes="#all"
                 <xsl:sequence select="ixsl:call($form-data, 'append', [ 'uri', ac:document-uri($constructor-uri) ])[current-date() lt xs:date('2000-01-01')]"/>
 
                 <!-- clear the constructor's host ontology (the document the PATCH targeted) first, then proceed to clear the namespace ontology -->
-                <xsl:variable name="admin-base-uri" select="xs:anyURI(replace(ldt:base(), '^(https?://)', '$1admin.'))" as="xs:anyURI"/>
+                <xsl:variable name="admin-base-uri" select="xs:anyURI(replace(lapp:base(), '^(https?://)', '$1admin.'))" as="xs:anyURI"/>
                 <xsl:variable name="clear-uri" select="resolve-uri('clear', $admin-base-uri)" as="xs:anyURI"/>
                 <xsl:variable name="request-uri" select="ldh:href($clear-uri)" as="xs:anyURI"/>
                 <ixsl:schedule-action http-request="map{ 'method': 'POST', 'href': $request-uri, 'media-type': 'application/x-www-form-urlencoded', 'body': $form-data, 'headers': map{ 'Accept': 'application/rdf+xml' } }">
@@ -703,11 +701,11 @@ exclude-result-prefixes="#all"
     </xsl:template>
     
     <xsl:template name="ldh:ClearNamespace">
-        <xsl:param name="ontology-uri" select="resolve-uri('ns#', ldt:base())" as="xs:anyURI"/>
+        <xsl:param name="ontology-uri" select="resolve-uri('ns#', lapp:base())" as="xs:anyURI"/>
         <xsl:variable name="form-data" select="ixsl:new('URLSearchParams', [ ixsl:new('FormData', []) ])"/>
         <xsl:sequence select="ixsl:call($form-data, 'append', [ 'uri', $ontology-uri ])[current-date() lt xs:date('2000-01-01')]"/>
 
-        <xsl:variable name="admin-base-uri" select="xs:anyURI(replace(ldt:base(), '^(https?://)', '$1admin.'))" as="xs:anyURI"/>
+        <xsl:variable name="admin-base-uri" select="xs:anyURI(replace(lapp:base(), '^(https?://)', '$1admin.'))" as="xs:anyURI"/>
         <xsl:variable name="clear-uri" select="resolve-uri('clear', $admin-base-uri)" as="xs:anyURI"/>
         <xsl:variable name="request-uri" select="ldh:href($clear-uri)" as="xs:anyURI"/>
         <ixsl:schedule-action http-request="map{ 'method': 'POST', 'href': $request-uri, 'media-type': 'application/x-www-form-urlencoded', 'body': $form-data, 'headers': map{ 'Accept': 'application/rdf+xml' } }">

--- a/src/main/webapp/static/com/atomgraph/linkeddatahub/xsl/client/form.xsl
+++ b/src/main/webapp/static/com/atomgraph/linkeddatahub/xsl/client/form.xsl
@@ -9,7 +9,6 @@
     <!ENTITY xsd        "http://www.w3.org/2001/XMLSchema#">
     <!ENTITY owl        "http://www.w3.org/2002/07/owl#">
     <!ENTITY http       "http://www.w3.org/2011/http#">
-    <!ENTITY ldt        "https://www.w3.org/ns/ldt#">
     <!ENTITY dh         "https://www.w3.org/ns/ldt/document-hierarchy#">
     <!ENTITY acl        "http://www.w3.org/ns/auth/acl#">
     <!ENTITY cert       "http://www.w3.org/ns/auth/cert#">
@@ -38,7 +37,6 @@ xmlns:lapp="&lapp;"
 xmlns:rdf="&rdf;"
 xmlns:rdfs="&rdfs;"
 xmlns:dct="&dct;"
-xmlns:ldt="&ldt;"
 xmlns:acl="&acl;"
 xmlns:foaf="&foaf;"
 xmlns:sd="&sd;"
@@ -71,34 +69,7 @@ WHERE
   }
 ]]>
     </xsl:param>
-    <xsl:param name="constructor-query" as="xs:string">
-        <![CDATA[
-            PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
-            PREFIX sp:   <http://spinrdf.org/sp#>
-            PREFIX spin: <http://spinrdf.org/spin#>
-
-            SELECT  $Type ?constructor ?construct
-            WHERE
-              { $Type (rdfs:subClassOf)*/spin:constructor  ?constructor .
-                ?constructor sp:text ?construct .
-              }
-        ]]>
-    </xsl:param>
-    <xsl:param name="shape-query" as="xs:string">
-        <![CDATA[
-            PREFIX  sh:   <http://www.w3.org/ns/shacl#>
-
-            DESCRIBE $Shape ?property
-            WHERE
-              { $Shape  sh:targetClass  $Type
-                OPTIONAL
-                  { $Shape  sh:property  ?property }
-              }
-        ]]>
-    </xsl:param>
     
-    <xsl:key name="violations-by-value" match="*" use="ldh:violationValue/text()"/>
-    <xsl:key name="violations-by-focus-node" match="*" use="sh:focusNode/@rdf:resource | sh:focusNode/@rdf:nodeID"/>
 
     <!-- types of the violation/response machinery resources that accompany form submissions - suppressed from form rendering and excluded from instance type harvesting -->
     <xsl:variable name="system-types" select="('&spin;ConstraintViolation', '&sh;ValidationResult', '&sh;ValidationReport', '&http;Response')" as="xs:string*"/>
@@ -805,7 +776,7 @@ WHERE
         <xsl:param name="context" as="map(*)"/>
         <xsl:variable name="types" select="$context('types')" as="xs:anyURI*"/>
         <xsl:variable name="query-string" select="'DESCRIBE $Type VALUES $Type { ' || string-join(for $t in $types return '&lt;' || $t || '&gt;', ' ') || ' }'" as="xs:string"/>
-        <xsl:variable name="request" select="map{ 'method': 'POST', 'href': ldh:href(resolve-uri('ns', ldt:base())), 'media-type': 'application/sparql-query', 'body': $query-string, 'headers': map{ 'Accept': 'application/rdf+xml' } }" as="map(*)"/>
+        <xsl:variable name="request" select="map{ 'method': 'POST', 'href': ldh:href(resolve-uri('ns', lapp:base())), 'media-type': 'application/sparql-query', 'body': $query-string, 'headers': map{ 'Accept': 'application/rdf+xml' } }" as="map(*)"/>
         <xsl:sequence select="map:merge(($context, map{ 'type-metadata-request': $request }))"/>
     </xsl:function>
 
@@ -815,7 +786,7 @@ WHERE
         <xsl:param name="context" as="map(*)"/>
         <xsl:variable name="types" select="$context('types')" as="xs:anyURI*"/>
         <xsl:variable name="query-string" select="$constraint-query || ' VALUES $Type { ' || string-join(for $t in $types return '&lt;' || $t || '&gt;', ' ') || ' }'" as="xs:string"/>
-        <xsl:variable name="request" select="map{ 'method': 'POST', 'href': ldh:href(resolve-uri('ns', ldt:base())), 'media-type': 'application/sparql-query', 'body': $query-string, 'headers': map{ 'Accept': 'application/sparql-results+xml' } }" as="map(*)"/>
+        <xsl:variable name="request" select="map{ 'method': 'POST', 'href': ldh:href(resolve-uri('ns', lapp:base())), 'media-type': 'application/sparql-query', 'body': $query-string, 'headers': map{ 'Accept': 'application/sparql-results+xml' } }" as="map(*)"/>
         <xsl:sequence select="map:merge(($context, map{ 'constraints-request': $request }))"/>
     </xsl:function>
 
@@ -860,7 +831,7 @@ WHERE
                         <xsl:variable name="resource" select="key('resources', $about)" as="element()"/> <!-- TO-DO: handle error -->
                         <xsl:variable name="types" select="distinct-values($resource/rdf:type/@rdf:resource)" as="xs:anyURI*"/>
                         <xsl:variable name="query-string" select="'DESCRIBE $Type VALUES $Type { ' || string-join(for $type in $types return '&lt;' || $type || '&gt;', ' ') || ' }'" as="xs:string"/>
-                        <xsl:variable name="results-uri" select="ac:build-uri(resolve-uri('ns', ldt:base()), map{ 'query': $query-string, 'accept': 'application/rdf+xml' })" as="xs:anyURI"/>
+                        <xsl:variable name="results-uri" select="ac:build-uri(resolve-uri('ns', lapp:base()), map{ 'query': $query-string, 'accept': 'application/rdf+xml' })" as="xs:anyURI"/>
                         <xsl:variable name="request-uri" select="ldh:href($results-uri, map{})" as="xs:anyURI"/>
                         <xsl:variable name="http-request" select="map{ 'method': 'GET', 'href': $request-uri, 'headers': map{ 'Accept': 'application/rdf+xml' } }" as="map(*)"/>
                         <!-- 'document' = raw response body; the renderer handles per-Description suppression via ldh:DocumentForm match templates. 'action' defaults to the response document's URL if the caller didn't set it. property-uris/object-uris seed the downstream ldh:load-property-metadata / ldh:load-object-metadata steps. 'forClass' seeds ldh:load-constructed-doc / ldh:load-shapes / ldh:load-constructors / ldh:load-constraints — same shape as the CREATE chains, so the EDIT promise chain can include the constructor fetch and produce the same pure-constructor input to ac:FormControl as CREATE. -->
@@ -909,7 +880,7 @@ WHERE
         <xsl:param name="context" as="map(*)"/>
         <xsl:variable name="types" select="$context('types')" as="xs:anyURI*"/>
         <xsl:variable name="query-string" select="$constructor-query || ' VALUES $Type { ' || string-join(for $type in $types return '&lt;' || $type || '&gt;', ' ') || ' }'" as="xs:string"/>
-        <xsl:variable name="request" select="map{ 'method': 'POST', 'href': ldh:href(resolve-uri('ns', ldt:base())), 'media-type': 'application/sparql-query', 'body': $query-string, 'headers': map{ 'Accept': 'application/sparql-results+xml' } }" as="map(*)"/>
+        <xsl:variable name="request" select="map{ 'method': 'POST', 'href': ldh:href(resolve-uri('ns', lapp:base())), 'media-type': 'application/sparql-query', 'body': $query-string, 'headers': map{ 'Accept': 'application/sparql-results+xml' } }" as="map(*)"/>
         <xsl:sequence select="map:merge(($context, map{ 'constructors-request': $request }))"/>
     </xsl:function>
 
@@ -934,7 +905,7 @@ WHERE
         <xsl:param name="context" as="map(*)"/>
         <xsl:variable name="types" select="$context('types')" as="xs:anyURI*"/>
         <xsl:variable name="query-string" select="$shape-query || ' VALUES $Type { ' || string-join(for $type in $types return '&lt;' || $type || '&gt;', ' ') || ' }'" as="xs:string"/>
-        <xsl:variable name="request" select="map{ 'method': 'POST', 'href': ldh:href(resolve-uri('ns', ldt:base())), 'media-type': 'application/sparql-query', 'body': $query-string, 'headers': map{ 'Accept': 'application/rdf+xml' } }" as="map(*)"/>
+        <xsl:variable name="request" select="map{ 'method': 'POST', 'href': ldh:href(resolve-uri('ns', lapp:base())), 'media-type': 'application/sparql-query', 'body': $query-string, 'headers': map{ 'Accept': 'application/rdf+xml' } }" as="map(*)"/>
         <xsl:sequence select="map:merge(($context, map{ 'shapes-request': $request }))"/>
     </xsl:function>
 
@@ -995,16 +966,16 @@ WHERE
         <xsl:variable name="row-form" as="element()">
             <!-- TO-DO: refactor remaining synchronous document() calls (type-metadata, property-metadata, constraints) into load/set pairs -->
             <xsl:variable name="query-string" select="'DESCRIBE $Type VALUES $Type { ' || string-join(for $type in $types return '&lt;' || $type || '&gt;', ' ') || ' }'" as="xs:string"/>
-            <xsl:variable name="request-uri" select="ldh:href(ac:build-uri(resolve-uri('ns', ldt:base()), map{ 'query': $query-string, 'accept': 'application/rdf+xml' }), map{})" as="xs:anyURI"/>
+            <xsl:variable name="request-uri" select="ldh:href(ac:build-uri(resolve-uri('ns', lapp:base()), map{ 'query': $query-string, 'accept': 'application/rdf+xml' }), map{})" as="xs:anyURI"/>
             <xsl:variable name="type-metadata" select="if (exists($types)) then document($request-uri) else ()" as="document-node()?"/>
 
             <xsl:variable name="property-uris" select="distinct-values($resource/*/concat(namespace-uri(), local-name()))" as="xs:string*"/>
             <xsl:variable name="query-string" select="'DESCRIBE $Type VALUES $Type { ' || string-join(for $uri in $property-uris return '&lt;' || $uri || '&gt;', ' ') || ' }'" as="xs:string"/>
-            <xsl:variable name="request-uri" select="ldh:href(ac:build-uri(resolve-uri('ns', ldt:base()), map{ 'query': $query-string, 'accept': 'application/rdf+xml' }), map{})" as="xs:anyURI"/>
+            <xsl:variable name="request-uri" select="ldh:href(ac:build-uri(resolve-uri('ns', lapp:base()), map{ 'query': $query-string, 'accept': 'application/rdf+xml' }), map{})" as="xs:anyURI"/>
             <xsl:variable name="property-metadata" select="document($request-uri)" as="document-node()"/>
 
             <xsl:variable name="query-string" select="$constraint-query || ' VALUES $Type { ' || string-join(for $type in $types return '&lt;' || $type || '&gt;', ' ') || ' }'" as="xs:string"/>
-            <xsl:variable name="request-uri" select="ldh:href(ac:build-uri(resolve-uri('ns', ldt:base()), map{ 'query': $query-string, 'accept': 'application/sparql-results+xml' }), map{})" as="xs:anyURI"/>
+            <xsl:variable name="request-uri" select="ldh:href(ac:build-uri(resolve-uri('ns', lapp:base()), map{ 'query': $query-string, 'accept': 'application/sparql-results+xml' }), map{})" as="xs:anyURI"/>
             <xsl:variable name="constraints" select="if (exists($types)) then document($request-uri) else ()" as="document-node()?"/>
 
             <xsl:apply-templates select="$resource" mode="ldh:RowForm">
@@ -1790,7 +1761,7 @@ WHERE
     <!-- types (classes with constructors) are looked up in the <ns> endpoint -->
     <xsl:template match="input[contains-token(@class, 'type-combobox')]" mode="ixsl:onkeyup" priority="1">
         <xsl:next-match>
-            <xsl:with-param name="endpoint" select="resolve-uri('ns', ldt:base())"/>
+            <xsl:with-param name="endpoint" select="resolve-uri('ns', lapp:base())"/>
             <xsl:with-param name="select-string" select="$select-labelled-class-or-shape-string"/>
             <!-- undefine $type-var-name in order not to set apply FILTER($Type) on the SPARQL query (since it's absent in the above query) -->
             <xsl:with-param name="type-var-name" select="()"/>

--- a/src/main/webapp/static/com/atomgraph/linkeddatahub/xsl/client/functions.xsl
+++ b/src/main/webapp/static/com/atomgraph/linkeddatahub/xsl/client/functions.xsl
@@ -8,7 +8,6 @@
     <!ENTITY xsd    "http://www.w3.org/2001/XMLSchema#">
     <!ENTITY srx    "http://www.w3.org/2005/sparql-results#">
     <!ENTITY acl    "http://www.w3.org/ns/auth/acl#">
-    <!ENTITY ldt    "https://www.w3.org/ns/ldt#">
     <!ENTITY sd     "http://www.w3.org/ns/sparql-service-description#">
     <!ENTITY sioc   "http://rdfs.org/sioc/ns#">
 ]>
@@ -29,7 +28,6 @@ xmlns:ldh="&ldh;"
 xmlns:rdf="&rdf;"
 xmlns:srx="&srx;"
 xmlns:acl="&acl;"
-xmlns:ldt="&ldt;"
 xmlns:sd="&sd;"
 xmlns:sioc="&sioc;"
 extension-element-prefixes="ixsl"
@@ -85,8 +83,14 @@ exclude-result-prefixes="#all"
         </xsl:choose>
     </xsl:function>
     
-    <xsl:function name="ldt:base" as="xs:anyURI">
-        <xsl:variable name="active-pane" select="id('tab-content', ixsl:page())/div[contains-token(@class, 'ldh-pane')][contains-token(@class, 'is-active')]" as="element()?"/>
+    <!-- the pane a dataspace is browsed in carries its base and endpoint as dataset attributes; both
+         lapp:base() and sd:endpoint() read the active one, so the lookup lives here once -->
+    <xsl:function name="ldh:active-pane" as="element()?">
+        <xsl:sequence select="id('tab-content', ixsl:page())/div[contains-token(@class, 'ldh-pane')][contains-token(@class, 'is-active')]"/>
+    </xsl:function>
+
+    <xsl:function name="lapp:base" as="xs:anyURI">
+        <xsl:variable name="active-pane" select="ldh:active-pane()" as="element()?"/>
         <xsl:sequence select="if ($active-pane and ixsl:contains($active-pane, 'dataset.base')) then xs:anyURI(ixsl:get($active-pane, 'dataset.base')) else xs:anyURI(lapp:origin(ldh:request-uri()) || '/')"/>
     </xsl:function>
 
@@ -100,8 +104,8 @@ exclude-result-prefixes="#all"
     </xsl:function>
 
     <xsl:function name="sd:endpoint" as="xs:anyURI">
-        <xsl:variable name="active-pane" select="id('tab-content', ixsl:page())/div[contains-token(@class, 'ldh-pane')][contains-token(@class, 'is-active')]" as="element()?"/>
-        <xsl:sequence select="if ($active-pane and ixsl:contains($active-pane, 'dataset.endpoint')) then xs:anyURI(ixsl:get($active-pane, 'dataset.endpoint')) else resolve-uri('sparql', ldt:base())"/>
+        <xsl:variable name="active-pane" select="ldh:active-pane()" as="element()?"/>
+        <xsl:sequence select="if ($active-pane and ixsl:contains($active-pane, 'dataset.endpoint')) then xs:anyURI(ixsl:get($active-pane, 'dataset.endpoint')) else resolve-uri('sparql', lapp:base())"/>
     </xsl:function>
 
     <xsl:function name="lapp:application" as="xs:anyURI?">
@@ -119,7 +123,7 @@ exclude-result-prefixes="#all"
     </xsl:function>
 
     <xsl:function name="lapp:origin" as="xs:anyURI">
-        <xsl:sequence select="lapp:origin(ldt:base())"/>
+        <xsl:sequence select="lapp:origin(lapp:base())"/>
     </xsl:function>
 
     <xsl:function name="ldh:label-document" as="document-node()?">
@@ -545,7 +549,7 @@ exclude-result-prefixes="#all"
     <xsl:function name="ldh:load-constructed-doc" as="map(*)" ixsl:updating="yes">
         <xsl:param name="context" as="map(*)"/>
         <xsl:variable name="forClass" select="$context('forClass')" as="xs:anyURI*"/>
-        <xsl:variable name="results-uri" select="ac:build-uri(resolve-uri('ns', ldt:base()), map{ 'query': ldh:constructor-query($forClass), 'accept': 'application/sparql-results+xml' })" as="xs:anyURI"/>
+        <xsl:variable name="results-uri" select="ac:build-uri(resolve-uri('ns', lapp:base()), map{ 'query': ldh:constructor-query($forClass), 'accept': 'application/sparql-results+xml' })" as="xs:anyURI"/>
         <xsl:variable name="request-uri" select="ldh:href($results-uri, map{})" as="xs:anyURI"/>
         <xsl:variable name="request" select="map{ 'method': 'GET', 'href': $request-uri, 'headers': map{ 'Accept': 'application/sparql-results+xml' } }" as="map(*)"/>
         <xsl:sequence select="map:merge(($context, map{ 'constructed-doc-request': $request }))"/>
@@ -782,14 +786,6 @@ exclude-result-prefixes="#all"
                 <xsl:sequence select="ldh:error-detail($detail)"/>
             </xsl:result-document>
         </xsl:for-each>
-    </xsl:function>
-
-    <!-- target URIs of the Link header entries whose parameters contain $marker (e.g. a rel URI or 'rel=timemap') -->
-    <xsl:function name="ldh:link-targets" as="xs:anyURI*">
-        <xsl:param name="link-header" as="xs:string?"/>
-        <xsl:param name="marker" as="xs:string"/>
-
-        <xsl:sequence select="tokenize($link-header, ',')[contains(., $marker)] ! xs:anyURI(substring-before(substring-after(substring-before(., ';'), '&lt;'), '&gt;'))"/>
     </xsl:function>
 
 </xsl:stylesheet>

--- a/src/main/webapp/static/com/atomgraph/linkeddatahub/xsl/client/graph3d.xsl
+++ b/src/main/webapp/static/com/atomgraph/linkeddatahub/xsl/client/graph3d.xsl
@@ -145,7 +145,7 @@ WHERE
                 <xsl:variable name="query-string" select="replace($backlinks-graph-string, '$this', '&lt;' || $node-id || '&gt;', 'q')" as="xs:string"/>
                 <xsl:variable name="service-uri" select="if (ixsl:contains(ixsl:get(ixsl:window(), 'LinkedDataHub.contents'), '`' || $node-id || '`')) then (if (ixsl:contains(ixsl:get(ixsl:get(ixsl:window(), 'LinkedDataHub.contents'), '`' || $node-id || '`'), 'service-uri')) then ixsl:get(ixsl:get(ixsl:get(ixsl:window(), 'LinkedDataHub.contents'), '`' || $node-id || '`'), 'service-uri') else ()) else ()" as="xs:anyURI?"/>
                 <xsl:variable name="service" select="if ($service-uri) then key('resources', $service-uri, document(ldh:href(ac:document-uri($service-uri), map{ 'accept': 'application/rdf+xml' }, ()))) else ()" as="element()?"/>
-                <xsl:variable name="endpoint" select="($service/sd:endpoint/@rdf:resource/xs:anyURI(.), sd:endpoint())[1]" as="xs:anyURI"/>
+                <xsl:variable name="endpoint" select="ldh:service-endpoint($service)" as="xs:anyURI"/>
                 <xsl:variable name="results-uri" select="ac:build-uri($endpoint, map{ 'query': string($query-string) })" as="xs:anyURI"/>
                 <xsl:variable name="request-uri" select="ldh:href($results-uri, map{})" as="xs:anyURI"/>
 

--- a/src/main/webapp/static/com/atomgraph/linkeddatahub/xsl/client/map.xsl
+++ b/src/main/webapp/static/com/atomgraph/linkeddatahub/xsl/client/map.xsl
@@ -5,7 +5,6 @@
     <!ENTITY ac     "https://w3id.org/atomgraph/client#">
     <!ENTITY rdf    "http://www.w3.org/1999/02/22-rdf-syntax-ns#">
     <!ENTITY geo    "http://www.w3.org/2003/01/geo/wgs84_pos#">
-    <!ENTITY ldt    "https://www.w3.org/ns/ldt#">
     <!ENTITY lapp   "https://w3id.org/atomgraph/linkeddatahub/apps#">
     <!ENTITY gs     "http://www.opengis.net/ont/geosparql#">
 ]>
@@ -25,7 +24,6 @@ xmlns:ldh="&ldh;"
 xmlns:lapp="&lapp;"
 xmlns:rdf="&rdf;"
 xmlns:geo="&geo;"
-xmlns:ldt="&ldt;"
 xmlns:gs="&gs;"
 extension-element-prefixes="ixsl"
 exclude-result-prefixes="#all"

--- a/src/main/webapp/static/com/atomgraph/linkeddatahub/xsl/client/modal.xsl
+++ b/src/main/webapp/static/com/atomgraph/linkeddatahub/xsl/client/modal.xsl
@@ -10,7 +10,6 @@
     <!ENTITY owl    "http://www.w3.org/2002/07/owl#">
     <!ENTITY srx    "http://www.w3.org/2005/sparql-results#">
     <!ENTITY acl    "http://www.w3.org/ns/auth/acl#">
-    <!ENTITY ldt    "https://www.w3.org/ns/ldt#">
     <!ENTITY dh     "https://www.w3.org/ns/ldt/document-hierarchy#">
     <!ENTITY sd     "http://www.w3.org/ns/sparql-service-description#">
     <!ENTITY sioc   "http://rdfs.org/sioc/ns#">
@@ -37,7 +36,6 @@ xmlns:rdf="&rdf;"
 xmlns:owl="&owl;"
 xmlns:acl="&acl;"
 xmlns:srx="&srx;"
-xmlns:ldt="&ldt;"
 xmlns:sd="&sd;"
 xmlns:sioc="&sioc;"
 xmlns:dct="&dct;"
@@ -715,8 +713,8 @@ LIMIT   10
         <xsl:next-match/>
         
         <!-- set a cookie to never show it again. path=/ is scoped to the page origin (cookies are
-             always scoped to the page origin anyway); using ldt:base() here previously broke in proxy
-             mode where ldt:base() is the proxied app's base, not the page's. -->
+             always scoped to the page origin anyway); using lapp:base() here previously broke in proxy
+             mode where lapp:base() is the proxied app's base, not the page's. -->
         <ixsl:set-property name="cookie" select="'LinkedDataHub.first-time-message=true; path=/; expires=Fri, 31 Dec 9999 23:59:59 GMT'" object="ixsl:page()"/>
     </xsl:template>
 
@@ -1066,7 +1064,7 @@ LIMIT   10
         <xsl:call-template name="ldh:ShowModalForm">
             <xsl:with-param name="form" as="element()">
                 <xsl:call-template name="ldh:AddDataForm">
-                    <xsl:with-param name="query" select="resolve-uri('queries/construct-constructors/#this', ldt:base())"/>
+                    <xsl:with-param name="query" select="resolve-uri('queries/construct-constructors/#this', lapp:base())"/>
                     <xsl:with-param name="legend-label" select="ac:label(key('resources', 'import-ontology', ldh:translations()))"/>
                 </xsl:call-template>
             </xsl:with-param>
@@ -1359,7 +1357,7 @@ LIMIT   10
                 <xsl:variable name="query-uri" select="fieldset/input[@name = 'pu'][@value = '&spin;query']/following-sibling::input[@name = 'ou'][1]/@value" as="xs:anyURI"/>
                 <xsl:choose>
                     <!-- the target must be local because the constructor derivation runs on the local /sparql endpoint scoped to the target graph via ?default-graph-uri= - another instance's graphs are invisible to it (the add/clone variant below has no such constraint and accepts foreign targets) -->
-                    <xsl:when test="not(starts-with($target, lapp:origin(ldh:request-uri()) || '/'))">
+                    <xsl:when test="not(ldh:is-local($target))">
                         <xsl:sequence select="ldh:add-data-form-error(map{ 'form': $form }, 'target-must-be-local')"/>
                     </xsl:when>
                     <xsl:otherwise>
@@ -1372,7 +1370,7 @@ LIMIT   10
                             'source-uri': $source,
                             'target-uri': $target,
                             'query-uri': $query-uri,
-                            'scratch-uri': resolve-uri(ac:uuid() || '/', ldt:base())
+                            'scratch-uri': resolve-uri(ac:uuid() || '/', lapp:base())
                           }"/>
                         <ixsl:promise select="
                           ixsl:http-request($context('request'))
@@ -1486,7 +1484,7 @@ LIMIT   10
         <xsl:variable name="service-uri" select="$context('service-uri')" as="xs:anyURI?"/>
         <xsl:choose>
             <xsl:when test="$service-uri">
-                <xsl:variable name="request" select="map{ 'method': 'GET', 'href': ldh:href(ac:build-uri(ldt:base(), map{ 'uri': ac:document-uri($service-uri), 'accept': 'application/rdf+xml' })), 'headers': map{ 'Accept': 'application/rdf+xml' } }" as="map(*)"/>
+                <xsl:variable name="request" select="map{ 'method': 'GET', 'href': ldh:href(ac:build-uri(lapp:base(), map{ 'uri': ac:document-uri($service-uri), 'accept': 'application/rdf+xml' })), 'headers': map{ 'Accept': 'application/rdf+xml' } }" as="map(*)"/>
                 <xsl:sequence select="
                   ixsl:http-request($request)
                     => ixsl:then(ldh:rethread-response($context, ?))
@@ -2058,7 +2056,7 @@ LIMIT   10
                         <rdf:RDF>
                             <rdf:Description rdf:about="{$scratch-uri}">
                                 <rdf:type rdf:resource="&dh;Item"/>
-                                <sioc:has_container rdf:resource="{ldt:base()}"/>
+                                <sioc:has_container rdf:resource="{lapp:base()}"/>
                                 <dct:title>Import ontology scratch</dct:title>
                             </rdf:Description>
                             <xsl:copy-of select="$response?body/rdf:RDF/*"/>
@@ -2122,7 +2120,7 @@ LIMIT   10
         <xsl:choose>
             <xsl:when test="$query-string">
                 <xsl:variable name="scratch-uri" select="$context('scratch-uri')" as="xs:anyURI"/>
-                <xsl:variable name="endpoint" select="ac:build-uri(resolve-uri('sparql', ldt:base()), map{ 'default-graph-uri': string($scratch-uri) })" as="xs:anyURI"/>
+                <xsl:variable name="endpoint" select="ac:build-uri(resolve-uri('sparql', lapp:base()), map{ 'default-graph-uri': string($scratch-uri) })" as="xs:anyURI"/>
                 <xsl:variable name="request" select="map{ 'method': 'POST', 'href': $endpoint, 'media-type': 'application/sparql-query', 'body': $query-string, 'headers': map{ 'Accept': 'application/rdf+xml' } }" as="map(*)"/>
                 <xsl:variable name="construct-context" select="map:put($context, 'request', $request)" as="map(*)"/>
                 <xsl:sequence select="
@@ -2236,7 +2234,7 @@ LIMIT   10
             <xsl:when test="$response?status = (200, 204)">
                 <!-- the admin app manages its parent dataspace's end-user app, whose ontology is <ns#> on the parent origin -->
                 <xsl:variable name="ontology-uri" select="resolve-uri('ns#', ldh:parent-origin(ldh:request-uri()))" as="xs:anyURI"/>
-                <xsl:variable name="request" select="map{ 'method': 'POST', 'href': resolve-uri('clear', ldt:base()), 'media-type': 'application/x-www-form-urlencoded', 'body': 'uri=' || encode-for-uri($ontology-uri), 'headers': map{ 'Accept': 'application/rdf+xml' } }" as="map(*)"/>
+                <xsl:variable name="request" select="map{ 'method': 'POST', 'href': resolve-uri('clear', lapp:base()), 'media-type': 'application/x-www-form-urlencoded', 'body': 'uri=' || encode-for-uri($ontology-uri), 'headers': map{ 'Accept': 'application/rdf+xml' } }" as="map(*)"/>
                 <xsl:variable name="clear-context" select="map:put($context, 'request', $request)" as="map(*)"/>
                 <xsl:sequence select="
                   ixsl:http-request($request)

--- a/src/main/webapp/static/com/atomgraph/linkeddatahub/xsl/client/navigation.xsl
+++ b/src/main/webapp/static/com/atomgraph/linkeddatahub/xsl/client/navigation.xsl
@@ -7,7 +7,6 @@
     <!ENTITY rdf    "http://www.w3.org/1999/02/22-rdf-syntax-ns#">
     <!ENTITY xsd    "http://www.w3.org/2001/XMLSchema#">
     <!ENTITY srx    "http://www.w3.org/2005/sparql-results#">
-    <!ENTITY ldt    "https://www.w3.org/ns/ldt#">
     <!ENTITY sd     "http://www.w3.org/ns/sparql-service-description#">
     <!ENTITY sp     "http://spinrdf.org/sp#">
     <!ENTITY sioc   "http://rdfs.org/sioc/ns#">
@@ -27,7 +26,6 @@ xmlns:ldh="&ldh;"
 xmlns:lapp="&lapp;"
 xmlns:rdf="&rdf;"
 xmlns:srx="&srx;"
-xmlns:ldt="&ldt;"
 xmlns:sd="&sd;"
 xmlns:sp="&sp;"
 xmlns:sioc="&sioc;"
@@ -93,7 +91,7 @@ ORDER BY DESC(?created)
     <!-- TEMPLATES -->
     
     <xsl:template name="ldh:DataspaceDrawer">
-        <xsl:param name="base" select="ldt:base()" as="xs:anyURI"/>
+        <xsl:param name="base" select="lapp:base()" as="xs:anyURI"/>
         <xsl:param name="id" as="xs:string?"/>
         <xsl:param name="class" select="'left-sidebar ldh-sidebar'" as="xs:string?"/>
 
@@ -817,7 +815,7 @@ ORDER BY DESC(?created)
                             <xsl:when test="exists($type-uris)">
                                 <!-- build DESCRIBE query with VALUES clause -->
                                 <xsl:variable name="query-string" select="'DESCRIBE ?type WHERE { VALUES ?type { ' || string-join(for $uri in $type-uris return '&lt;' || $uri || '&gt;', ' ') || ' } }'" as="xs:string"/>
-                                <xsl:variable name="ns-uri" select="resolve-uri('ns', ldt:base())" as="xs:anyURI"/>
+                                <xsl:variable name="ns-uri" select="resolve-uri('ns', lapp:base())" as="xs:anyURI"/>
                                 <xsl:variable name="results-uri" select="ac:build-uri($ns-uri, map{ 'query': $query-string })" as="xs:anyURI"/>
                                 <xsl:variable name="request-uri" select="ldh:href($results-uri, map{})" as="xs:anyURI"/>
                                 <xsl:variable name="request" select="map{ 'method': 'GET', 'href': $request-uri, 'headers': map{ 'Accept': 'application/rdf+xml' } }" as="map(*)"/>

--- a/src/main/webapp/static/com/atomgraph/linkeddatahub/xsl/client/navigation.xsl
+++ b/src/main/webapp/static/com/atomgraph/linkeddatahub/xsl/client/navigation.xsl
@@ -523,7 +523,7 @@ ORDER BY DESC(?created)
                             <xsl:variable name="content" select="*" as="element()*"/>
                             <!-- we want to prepend the parent resource to the beginning of the breadcrumb list -->
                             <xsl:result-document href="?." method="ixsl:replace-content">
-                                <xsl:apply-templates select="$resource" mode="ac:BreadcrumbItem">
+                                <xsl:apply-templates select="$resource" mode="ldh:BreadcrumbItem">
                                     <xsl:with-param name="leaf" select="$leaf"/>
                                 </xsl:apply-templates>
 

--- a/src/main/webapp/static/com/atomgraph/linkeddatahub/xsl/common.xsl
+++ b/src/main/webapp/static/com/atomgraph/linkeddatahub/xsl/common.xsl
@@ -14,6 +14,7 @@ exclude-result-prefixes="#all">
     <xsl:import href="merge-rdfxml.xsl"/>
     <xsl:import href="imports/default.xsl"/>
     <xsl:import href="resource.xsl"/>
+    <xsl:import href="imports/sh.xsl"/>
     <xsl:import href="imports/ac.xsl"/>
     <xsl:import href="imports/acl.xsl"/>
     <xsl:import href="imports/cert.xsl"/>

--- a/src/main/webapp/static/com/atomgraph/linkeddatahub/xsl/document.xsl
+++ b/src/main/webapp/static/com/atomgraph/linkeddatahub/xsl/document.xsl
@@ -18,7 +18,6 @@
     <!ENTITY cert   "http://www.w3.org/ns/auth/cert#">
     <!ENTITY sh     "http://www.w3.org/ns/shacl#">
     <!ENTITY sd     "http://www.w3.org/ns/sparql-service-description#">
-    <!ENTITY ldt    "https://www.w3.org/ns/ldt#">
     <!ENTITY dh     "https://www.w3.org/ns/ldt/document-hierarchy#">
     <!ENTITY dct    "http://purl.org/dc/terms/">
     <!ENTITY foaf   "http://xmlns.com/foaf/0.1/">
@@ -48,7 +47,6 @@ xmlns:http="&http;"
 xmlns:acl="&acl;"
 xmlns:sd="&sd;"
 xmlns:sh="&sh;"
-xmlns:ldt="&ldt;"
 xmlns:dh="&dh;"
 xmlns:dct="&dct;"
 xmlns:foaf="&foaf;"
@@ -64,8 +62,6 @@ exclude-result-prefixes="#all"
     
     <xsl:mode name="ldh:Shape" on-no-match="deep-skip"/>
 
-    <xsl:param name="main-doc" select="/" as="document-node()"/>
-    <xsl:param name="acl:Agent" as="document-node()?"/>
 
     <!-- schema.org BREADCRUMBS -->
     
@@ -194,7 +190,7 @@ exclude-result-prefixes="#all"
     <xsl:template match="*" mode="ldh:AddData"/>
 
     <xsl:template match="*[rdf:type/@rdf:resource = '&owl;Ontology'][$foaf:Agent//@rdf:about]" mode="ac:BlockActions">
-        <form action="{resolve-uri('clear', ldt:base())}" method="post">
+        <form action="{resolve-uri('clear', lapp:base())}" method="post">
             <input type="hidden" name="uri" value="{@rdf:about}"/>
 
             <button class="ac-btn in-primary ap-solid sz-md" type="submit">
@@ -803,7 +799,7 @@ exclude-result-prefixes="#all"
         <xsl:param name="id" as="xs:string?"/>
         <xsl:param name="class" select="'ac-table is-hoverable'" as="xs:string?"/>
         <xsl:param name="property-uris" select="distinct-values(*/*/concat(namespace-uri(), local-name()))" as="xs:string*"/>
-        <xsl:param name="property-metadata" select="if (exists($property-uris)) then ldh:send-request(resolve-uri('ns', ldt:base()), 'POST', 'application/sparql-query', 'DESCRIBE $Type' || ' VALUES $Type { ' || string-join(for $uri in $property-uris return '&lt;' || $uri || '&gt;', ' ') || ' }', map{ 'Accept': 'application/rdf+xml' }) else ()" as="document-node()?" tunnel="yes"/>
+        <xsl:param name="property-metadata" select="if (exists($property-uris)) then ldh:send-request(resolve-uri('ns', lapp:base()), 'POST', 'application/sparql-query', 'DESCRIBE $Type' || ' VALUES $Type { ' || string-join(for $uri in $property-uris return '&lt;' || $uri || '&gt;', ' ') || ' }', map{ 'Accept': 'application/rdf+xml' }) else ()" as="document-node()?" tunnel="yes"/>
         <xsl:param name="predicates" as="element()*">
             <xsl:for-each-group select="*/*" group-by="concat(namespace-uri(), local-name())">
                 <xsl:sort select="if ($property-metadata) then ac:property-label(., $property-metadata) else ac:property-label(.)" order="ascending" lang="{ac:langs()[1]}"/>
@@ -1183,15 +1179,15 @@ exclude-result-prefixes="#all"
         <xsl:param name="create-resource" select="true()" as="xs:boolean"/>
         <xsl:param name="classes" as="element()*"/>
         <xsl:param name="types" select="distinct-values(rdf:Description/rdf:type/@rdf:resource)" as="xs:anyURI*"/>
-        <xsl:param name="constructors" select="if (exists($types)) then (ldh:query-result(resolve-uri('ns', ldt:base()), $constructor-query || ' VALUES $Type { ' || string-join(for $type in $types return '&lt;' || $type || '&gt;', ' ') || ' }')) else ()" as="document-node()?" tunnel="yes"/>
-        <xsl:param name="constraints" select="if (exists($types)) then (ldh:query-result(resolve-uri('ns', ldt:base()), $constraint-query || ' VALUES $Type { ' || string-join(for $type in $types return '&lt;' || $type || '&gt;', ' ') || ' }')) else ()" as="document-node()?" tunnel="yes"/>
-        <xsl:param name="shapes" select="if (exists($types)) then (ldh:query-result(resolve-uri('ns', ldt:base()), $shape-query || ' VALUES $Type { ' || string-join(for $type in $types return '&lt;' || $type || '&gt;', ' ') || ' }')) else ()" as="document-node()?" tunnel="yes"/>
-        <xsl:param name="type-metadata" select="if (exists($types)) then ldh:send-request(resolve-uri('ns', ldt:base()), 'POST', 'application/sparql-query', 'DESCRIBE $Type' || ' VALUES $Type { ' || string-join(for $type in $types return '&lt;' || $type || '&gt;', ' ') || ' }', map{ 'Accept': 'application/rdf+xml' }) else ()" as="document-node()?" tunnel="yes"/>
+        <xsl:param name="constructors" select="if (exists($types)) then (ldh:query-result(resolve-uri('ns', lapp:base()), $constructor-query || ' VALUES $Type { ' || string-join(for $type in $types return '&lt;' || $type || '&gt;', ' ') || ' }')) else ()" as="document-node()?" tunnel="yes"/>
+        <xsl:param name="constraints" select="if (exists($types)) then (ldh:query-result(resolve-uri('ns', lapp:base()), $constraint-query || ' VALUES $Type { ' || string-join(for $type in $types return '&lt;' || $type || '&gt;', ' ') || ' }')) else ()" as="document-node()?" tunnel="yes"/>
+        <xsl:param name="shapes" select="if (exists($types)) then (ldh:query-result(resolve-uri('ns', lapp:base()), $shape-query || ' VALUES $Type { ' || string-join(for $type in $types return '&lt;' || $type || '&gt;', ' ') || ' }')) else ()" as="document-node()?" tunnel="yes"/>
+        <xsl:param name="type-metadata" select="if (exists($types)) then ldh:send-request(resolve-uri('ns', lapp:base()), 'POST', 'application/sparql-query', 'DESCRIBE $Type' || ' VALUES $Type { ' || string-join(for $type in $types return '&lt;' || $type || '&gt;', ' ') || ' }', map{ 'Accept': 'application/rdf+xml' }) else ()" as="document-node()?" tunnel="yes"/>
         <xsl:param name="property-uris" select="distinct-values(rdf:Description/*/concat(namespace-uri(), local-name()))" as="xs:string*"/>
         <!-- TO-DO: optimize using CONSTRUCT? -->
-        <xsl:param name="property-metadata" select="if (exists($property-uris)) then ldh:send-request(resolve-uri('ns', ldt:base()), 'POST', 'application/sparql-query', 'DESCRIBE $Type' || ' VALUES $Type { ' || string-join(for $uri in $property-uris return '&lt;' || $uri || '&gt;', ' ') || ' }', map{ 'Accept': 'application/rdf+xml' }) else ()" as="document-node()?" tunnel="yes"/>
+        <xsl:param name="property-metadata" select="if (exists($property-uris)) then ldh:send-request(resolve-uri('ns', lapp:base()), 'POST', 'application/sparql-query', 'DESCRIBE $Type' || ' VALUES $Type { ' || string-join(for $uri in $property-uris return '&lt;' || $uri || '&gt;', ' ') || ' }', map{ 'Accept': 'application/rdf+xml' }) else ()" as="document-node()?" tunnel="yes"/>
         <xsl:param name="object-uris" select="rdf:Description/*/@rdf:resource[not(key('resources', .))]" as="xs:anyURI*"/>
-        <xsl:param name="object-metadata" select="if (exists($object-uris)) then ldh:send-request(resolve-uri('ns', ldt:base()), 'POST', 'application/sparql-query', $object-metadata-query || ' VALUES $this { ' || string-join(for $uri in $object-uris return '&lt;' || $uri || '&gt;', ' ') || ' }', map{ 'Accept': 'application/rdf+xml' }) else ()" as="document-node()?" tunnel="yes"/>
+        <xsl:param name="object-metadata" select="if (exists($object-uris)) then ldh:send-request(resolve-uri('ns', lapp:base()), 'POST', 'application/sparql-query', $object-metadata-query || ' VALUES $this { ' || string-join(for $uri in $object-uris return '&lt;' || $uri || '&gt;', ' ') || ' }', map{ 'Accept': 'application/rdf+xml' }) else ()" as="document-node()?" tunnel="yes"/>
         <!-- inner form content; default is the exception alerts + primary/non-primary Description iteration. Override via xsl:with-param name="body" to substitute a different body (e.g. ldh:DocumentForm mode for declarative suppression) while reusing the form shell. -->
         <xsl:param name="body" as="node()*">
             <xsl:apply-templates mode="ldh:Exception"/>

--- a/src/main/webapp/static/com/atomgraph/linkeddatahub/xsl/document.xsl
+++ b/src/main/webapp/static/com/atomgraph/linkeddatahub/xsl/document.xsl
@@ -285,7 +285,7 @@ exclude-result-prefixes="#all"
 
             <xsl:if test="not($ldh:ajaxRendering)">
                 <!-- render breadcrumbs server-side -->
-                <xsl:apply-templates select="key('resources', $uri)" mode="ac:BreadcrumbItem"/>
+                <xsl:apply-templates select="key('resources', $uri)" mode="ldh:BreadcrumbItem"/>
             </xsl:if>
         </div>
     </xsl:template>

--- a/src/main/webapp/static/com/atomgraph/linkeddatahub/xsl/imports/ac.xsl
+++ b/src/main/webapp/static/com/atomgraph/linkeddatahub/xsl/imports/ac.xsl
@@ -4,7 +4,6 @@
     <!ENTITY rdf    "http://www.w3.org/1999/02/22-rdf-syntax-ns#">
     <!ENTITY rdfs   "http://www.w3.org/2000/01/rdf-schema#">
     <!ENTITY xsd    "http://www.w3.org/2001/XMLSchema#">
-    <!ENTITY ldt    "https://www.w3.org/ns/ldt#">
 ]>
 <xsl:stylesheet version="3.0"
 xmlns="http://www.w3.org/1999/xhtml"
@@ -14,7 +13,6 @@ xmlns:xs="http://www.w3.org/2001/XMLSchema"
 xmlns:ac="&ac;"
 xmlns:rdf="&rdf;"
 xmlns:rdfs="&rdfs;"
-xmlns:ldt="&ldt;"
 exclude-result-prefixes="#all">
     
     <!-- override the value of ac:mode with a dropdown of ac:Mode instances -->

--- a/src/main/webapp/static/com/atomgraph/linkeddatahub/xsl/imports/acl.xsl
+++ b/src/main/webapp/static/com/atomgraph/linkeddatahub/xsl/imports/acl.xsl
@@ -7,7 +7,6 @@
     <!ENTITY rdf    "http://www.w3.org/1999/02/22-rdf-syntax-ns#">
     <!ENTITY rdfs   "http://www.w3.org/2000/01/rdf-schema#">
     <!ENTITY acl    "http://www.w3.org/ns/auth/acl#">
-    <!ENTITY ldt    "https://www.w3.org/ns/ldt#">
     <!ENTITY dh     "https://www.w3.org/ns/ldt/document-hierarchy#">
     <!ENTITY prov   "http://www.w3.org/ns/prov#">
     <!ENTITY foaf   "http://xmlns.com/foaf/0.1/">
@@ -25,7 +24,6 @@ xmlns:lacl="&lacl;"
 xmlns:rdf="&rdf;"
 xmlns:rdfs="&rdfs;"
 xmlns:acl="&acl;"
-xmlns:ldt="&ldt;"
 xmlns:dh="&dh;"
 xmlns:foaf="&foaf;"
 exclude-result-prefixes="#all">
@@ -64,7 +62,7 @@ exclude-result-prefixes="#all">
     <xsl:template match="*[rdf:type/@rdf:resource = '&lacl;AuthorizationRequest']" priority="1">
         <xsl:param name="method" select="'post'" as="xs:string"/>
         <!-- we're not using the form's default action so we're not tunneling the param here -->
-        <xsl:param name="action" select="ldh:href(resolve-uri(ac:uuid() || '/', resolve-uri('acl/authorizations/', ldt:base())), map{ '_method': 'PUT' })" as="xs:anyURI"/> <!-- create new authorization document -->
+        <xsl:param name="action" select="ldh:href(resolve-uri(ac:uuid() || '/', resolve-uri('acl/authorizations/', lapp:base())), map{ '_method': 'PUT' })" as="xs:anyURI"/> <!-- create new authorization document -->
         <xsl:param name="id" select="concat('form-', generate-id())" as="xs:string?"/>
         <xsl:param name="class" select="'ldh-prop-form'" as="xs:string?"/>
         <xsl:param name="accept-charset" select="'UTF-8'" as="xs:string?"/>

--- a/src/main/webapp/static/com/atomgraph/linkeddatahub/xsl/imports/dct.xsl
+++ b/src/main/webapp/static/com/atomgraph/linkeddatahub/xsl/imports/dct.xsl
@@ -7,7 +7,6 @@
     <!ENTITY rdf    "http://www.w3.org/1999/02/22-rdf-syntax-ns#">
     <!ENTITY rdfs   "http://www.w3.org/2000/01/rdf-schema#">
     <!ENTITY xsd    "http://www.w3.org/2001/XMLSchema#">
-    <!ENTITY ldt    "https://www.w3.org/ns/ldt#">
     <!ENTITY dh     "https://www.w3.org/ns/ldt/document-hierarchy#">
     <!ENTITY foaf   "http://xmlns.com/foaf/0.1/">
     <!ENTITY dct    "http://purl.org/dc/terms/">
@@ -21,7 +20,6 @@ xmlns:ldh="&ldh;"
 xmlns:ac="&ac;"
 xmlns:rdf="&rdf;"
 xmlns:rdfs="&rdfs;"
-xmlns:ldt="&ldt;"
 xmlns:foaf="&foaf;"
 xmlns:dct="&dct;"
 exclude-result-prefixes="#all">

--- a/src/main/webapp/static/com/atomgraph/linkeddatahub/xsl/imports/default.xsl
+++ b/src/main/webapp/static/com/atomgraph/linkeddatahub/xsl/imports/default.xsl
@@ -14,7 +14,6 @@
     <!ENTITY http   "http://www.w3.org/2011/http#">
     <!ENTITY acl    "http://www.w3.org/ns/auth/acl#">
     <!ENTITY sd     "http://www.w3.org/ns/sparql-service-description#">
-    <!ENTITY ldt    "https://www.w3.org/ns/ldt#">
     <!ENTITY dh     "https://www.w3.org/ns/ldt/document-hierarchy#">
     <!ENTITY sh     "http://www.w3.org/ns/shacl#">
     <!ENTITY sp     "http://spinrdf.org/sp#">
@@ -41,7 +40,6 @@ xmlns:srx="&srx;"
 xmlns:http="&http;"
 xmlns:acl="&acl;"
 xmlns:sd="&sd;"
-xmlns:ldt="&ldt;"
 xmlns:sh="&sh;"
 xmlns:sp="&sp;"
 xmlns:spin="&spin;"
@@ -55,6 +53,8 @@ exclude-result-prefixes="#all"
 
     <xsl:key name="predicates-by-object" match="*[@rdf:about]/* | *[@rdf:nodeID]/*" use="@rdf:resource | @rdf:nodeID"/>
     <xsl:key name="violations-by-root" match="*[@rdf:about] | *[@rdf:nodeID]" use="spin:violationRoot/@rdf:resource | spin:violationRoot/@rdf:nodeID"/>
+    <xsl:key name="violations-by-value" match="*" use="ldh:violationValue/text()"/>
+    <xsl:key name="violations-by-focus-node" match="*" use="sh:focusNode/@rdf:resource | sh:focusNode/@rdf:nodeID"/>
     <xsl:key name="resources-by-type" match="*[*][@rdf:about] | *[*][@rdf:nodeID]" use="rdf:type/@rdf:resource"/>
 
     <xsl:param name="ac:contextUri" as="xs:anyURI?"/>
@@ -156,12 +156,149 @@ exclude-result-prefixes="#all"
     </xsl:function>
     
       
-    <xsl:function name="ldt:base" as="xs:anyURI">
-        <xsl:sequence select="$ldt:base"/>
+    <!-- the endpoint a block queries: the one its ldh:service names, else this dataspace's own -->
+    <!-- the authenticated agent: the WebID the writer supplies server-side and the SaxonJS
+         stylesheetParams supply client-side, and its description. One declaration for both
+         entry points, which previously carried byte-identical copies -->
+    <xsl:param name="acl:agent" as="xs:anyURI?"/>
+    <xsl:param name="foaf:Agent" select="if ($acl:agent) then document(ac:document-uri($acl:agent)) else ()" as="document-node()?"/>
+
+    <!-- metadata and constructor queries shared by the server and client renderers; each used to be
+         declared once per entry point, with the copies drifting only in whitespace -->
+    <xsl:param name="object-metadata-query" as="xs:string">
+        <![CDATA[
+            PREFIX  rdf:  <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
+            PREFIX  xsd:  <http://www.w3.org/2001/XMLSchema#>
+            PREFIX  dct:  <http://purl.org/dc/terms/>
+            PREFIX  schema2: <https://schema.org/>
+            PREFIX  schema1: <http://schema.org/>
+            PREFIX  skos: <http://www.w3.org/2004/02/skos/core#>
+            PREFIX  rdfs: <http://www.w3.org/2000/01/rdf-schema#>
+            PREFIX  foaf: <http://xmlns.com/foaf/0.1/>
+            PREFIX  sioc: <http://rdfs.org/sioc/ns#>
+            PREFIX  dc:   <http://purl.org/dc/elements/1.1/>
+
+            CONSTRUCT
+              {
+                $this ?p ?literal .
+              }
+            WHERE
+              { GRAPH ?graph
+                  { $this  ?p  ?literal
+                    FILTER ( ( datatype(?literal) = xsd:string ) || ( datatype(?literal) = rdf:langString ) )
+                    FILTER ( ?p IN (rdfs:label, dc:title, dct:title, foaf:name, foaf:givenName, foaf:familyName, sioc:name, skos:prefLabel, schema1:name, schema2:name) )
+                  }
+              }
+        ]]>
+        <!-- VALUES $this goes here -->
+    </xsl:param>
+    <xsl:param name="object-metadata-ns-query" as="xs:string">
+        <![CDATA[
+            PREFIX  rdf:  <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
+            PREFIX  xsd:  <http://www.w3.org/2001/XMLSchema#>
+            PREFIX  dct:  <http://purl.org/dc/terms/>
+            PREFIX  schema2: <https://schema.org/>
+            PREFIX  schema1: <http://schema.org/>
+            PREFIX  skos: <http://www.w3.org/2004/02/skos/core#>
+            PREFIX  rdfs: <http://www.w3.org/2000/01/rdf-schema#>
+            PREFIX  foaf: <http://xmlns.com/foaf/0.1/>
+            PREFIX  sioc: <http://rdfs.org/sioc/ns#>
+            PREFIX  dc:   <http://purl.org/dc/elements/1.1/>
+
+            CONSTRUCT
+              {
+                $this ?p ?literal .
+              }
+            WHERE
+              { $this  ?p  ?literal
+                FILTER ( ( datatype(?literal) = xsd:string ) || ( datatype(?literal) = rdf:langString ) )
+                FILTER ( ?p IN (rdfs:label, dc:title, dct:title, foaf:name, foaf:givenName, foaf:familyName, sioc:name, skos:prefLabel, schema1:name, schema2:name) )
+              }
+        ]]>
+        <!-- VALUES $this goes here -->
+    </xsl:param>
+    <xsl:param name="property-metadata-query" as="xs:string">
+        <![CDATA[
+            DESCRIBE $Type
+        ]]>
+        <!-- VALUES $Type goes here -->
+    </xsl:param>
+    <xsl:param name="constraint-query" as="xs:string">
+        <![CDATA[
+            PREFIX  ldh:  <https://w3id.org/atomgraph/linkeddatahub#>
+            PREFIX  rdfs: <http://www.w3.org/2000/01/rdf-schema#>
+            PREFIX  sp:   <http://spinrdf.org/sp#>
+            PREFIX  spin: <http://spinrdf.org/spin#>
+
+            SELECT  $Type ?property
+            WHERE
+              { $Type (rdfs:subClassOf)*/spin:constraint  ?constraint .
+                ?constraint  a             ldh:MissingPropertyValue ;
+                          sp:arg1          ?property
+              }
+        ]]>
+        <!-- VALUES $Type goes here -->
+    </xsl:param>
+    <xsl:param name="constructor-query" as="xs:string">
+        <![CDATA[
+            PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
+            PREFIX sp:   <http://spinrdf.org/sp#>
+            PREFIX spin: <http://spinrdf.org/spin#>
+
+            SELECT  $Type ?constructor ?construct
+            WHERE
+              { $Type (rdfs:subClassOf)*/spin:constructor  ?constructor .
+                ?constructor sp:text ?construct .
+              }
+        ]]>
+    </xsl:param>
+    <xsl:param name="shape-query" as="xs:string">
+        <![CDATA[
+            PREFIX  sh:   <http://www.w3.org/ns/shacl#>
+
+            DESCRIBE $Shape ?property
+            WHERE
+              { $Shape  sh:targetClass  $Type
+                OPTIONAL
+                  { $Shape  sh:property  ?property }
+              }
+        ]]>
+    </xsl:param>
+
+    <!-- target URIs of the Link header entries whose parameters contain $marker (a rel URI, or 'rel=timemap').
+         Entries are split by regex rather than tokenize(','), because a Link value may carry commas inside
+         quoted parameters; the marker is tested against the parameter section only, so a target URI cannot
+         match it. Shared: the server passes the whole $ldh:httpHeaders('Link') sequence, the client one
+         response header string. -->
+    <!-- is this URI served by the dataspace the reader is browsing? The test the cross-origin proxy
+         decision, the ldh:href/ldh:parse-href pair and the pane lookups all made by hand -->
+    <xsl:function name="ldh:is-local" as="xs:boolean">
+        <xsl:param name="uri" as="xs:anyURI?"/>
+
+        <xsl:sequence select="starts-with($uri, lapp:origin(ldh:request-uri()) || '/')"/>
     </xsl:function>
 
-    <xsl:function name="sd:endpoint" as="xs:anyURI">
-        <xsl:sequence select="resolve-uri('sparql', ldt:base())"/>
+    <xsl:function name="ldh:link-targets" as="xs:anyURI*">
+        <xsl:param name="link-headers" as="xs:string*"/>
+        <xsl:param name="marker" as="xs:string"/>
+
+        <xsl:variable name="entries" as="xs:string*">
+            <xsl:for-each select="$link-headers">
+                <xsl:analyze-string select="." regex="&lt;[^&gt;]+&gt;[^&lt;]*">
+                    <xsl:matching-substring>
+                        <xsl:sequence select="."/>
+                    </xsl:matching-substring>
+                </xsl:analyze-string>
+            </xsl:for-each>
+        </xsl:variable>
+
+        <xsl:sequence select="$entries[contains(substring-after(., '&gt;'), $marker)] ! xs:anyURI(replace(., '^&lt;([^&gt;]+)&gt;.*$', '$1'))"/>
+    </xsl:function>
+
+    <xsl:function name="ldh:service-endpoint" as="xs:anyURI">
+        <xsl:param name="service" as="element()?"/>
+
+        <xsl:sequence select="($service/sd:endpoint/@rdf:resource/xs:anyURI(.), sd:endpoint())[1]"/>
     </xsl:function>
 
     <xsl:function name="lapp:origin" as="xs:anyURI">
@@ -228,7 +365,7 @@ exclude-result-prefixes="#all"
 
         <xsl:choose>
             <!-- cross-origin URI - wrap in ?uri= on the page origin so the request stays same-origin (carries credentials, then ProxyRequestFilter forwards) -->
-            <xsl:when test="$uri and not(starts-with($uri, lapp:origin(ldh:request-uri()) || '/'))">
+            <xsl:when test="$uri and not(ldh:is-local($uri))">
                 <xsl:sequence select="xs:anyURI(ac:build-uri(ac:absolute-path(ldh:request-uri()), map:merge((map{ 'uri': string($uri) }, $query-params))) || (if ($fragment) then ('#' || $fragment) else ()))"/>
             </xsl:when>
             <!-- local URI -->
@@ -246,7 +383,7 @@ exclude-result-prefixes="#all"
     <xsl:function name="ldh:parse-href" as="map(xs:string, item()?)">
         <xsl:param name="href" as="xs:anyURI"/>
 
-        <xsl:variable name="is-local" select="starts-with($href, lapp:origin(ldh:request-uri()) || '/')" as="xs:boolean"/>
+        <xsl:variable name="is-local" select="ldh:is-local($href)" as="xs:boolean"/>
         <xsl:variable name="query-params" select="ldh:parse-query-params(substring-after(ac:document-uri($href), '?'))" as="map(xs:string, xs:string*)"/>
         <xsl:variable name="fragment" select="ac:fragment-id($href)" as="xs:string?"/>
 
@@ -1030,7 +1167,7 @@ exclude-result-prefixes="#all"
             <xsl:with-param name="href" select="$href"/>
             <xsl:with-param name="id" select="$id"/>
             <xsl:with-param name="title" select="$title"/>
-            <xsl:with-param name="class" select="$class || (if (not(starts-with(., ldt:base()))) then ' external' else())"/>
+            <xsl:with-param name="class" select="$class || (if (not(starts-with(., lapp:base()))) then ' external' else())"/>
             <xsl:with-param name="role" select="$role"/>
             <xsl:with-param name="target" select="$target"/>
         </xsl:next-match>
@@ -1050,7 +1187,7 @@ exclude-result-prefixes="#all"
             <xsl:with-param name="id" select="$id"/>
             <xsl:with-param name="label" select="$label"/>
             <xsl:with-param name="title" select="$title"/>
-            <xsl:with-param name="class" select="$class || (if (not(starts-with(., ldt:base()))) then ' external' else())"/>
+            <xsl:with-param name="class" select="$class || (if (not(starts-with(., lapp:base()))) then ' external' else())"/>
             <xsl:with-param name="target" select="$target"/>
         </xsl:next-match>
     </xsl:template>
@@ -1070,7 +1207,7 @@ exclude-result-prefixes="#all"
             <xsl:with-param name="href" select="$href"/>
             <xsl:with-param name="id" select="$id"/>
             <xsl:with-param name="title" select="$title"/>
-            <xsl:with-param name="class" select="$class || (if (not(starts-with(., ldt:base()))) then ' external' else())"/>
+            <xsl:with-param name="class" select="$class || (if (not(starts-with(., lapp:base()))) then ' external' else())"/>
             <xsl:with-param name="target" select="$target"/>
         </xsl:next-match>
     </xsl:template>

--- a/src/main/webapp/static/com/atomgraph/linkeddatahub/xsl/imports/ldh.xsl
+++ b/src/main/webapp/static/com/atomgraph/linkeddatahub/xsl/imports/ldh.xsl
@@ -5,7 +5,6 @@
     <!ENTITY rdf    "http://www.w3.org/1999/02/22-rdf-syntax-ns#">
     <!ENTITY rdfs   "http://www.w3.org/2000/01/rdf-schema#">
     <!ENTITY xsd    "http://www.w3.org/2001/XMLSchema#">
-    <!ENTITY ldt    "https://www.w3.org/ns/ldt#">
     <!ENTITY dh     "https://www.w3.org/ns/ldt/document-hierarchy#">
 ]>
 <xsl:stylesheet version="3.0"
@@ -17,7 +16,6 @@ xmlns:ac="&ac;"
 xmlns:ldh="&ldh;"
 xmlns:rdf="&rdf;"
 xmlns:rdfs="&rdfs;"
-xmlns:ldt="&ldt;"
 exclude-result-prefixes="#all">
     
     <!-- FORM CONTROL MODE -->

--- a/src/main/webapp/static/com/atomgraph/linkeddatahub/xsl/imports/nfo.xsl
+++ b/src/main/webapp/static/com/atomgraph/linkeddatahub/xsl/imports/nfo.xsl
@@ -5,7 +5,6 @@
     <!ENTITY lapp   "https://w3id.org/atomgraph/linkeddatahub/apps#">
     <!ENTITY rdf    "http://www.w3.org/1999/02/22-rdf-syntax-ns#">
     <!ENTITY xsd    "http://www.w3.org/2001/XMLSchema#">
-    <!ENTITY ldt    "https://www.w3.org/ns/ldt#">
     <!ENTITY nfo    "http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#">
 ]>
 <xsl:stylesheet version="3.0"
@@ -17,7 +16,6 @@ xmlns:ac="&ac;"
 xmlns:ldh="&ldh;"
 xmlns:lapp="&lapp;"
 xmlns:rdf="&rdf;"
-xmlns:ldt="&ldt;"
 xmlns:nfo="&nfo;"
 exclude-result-prefixes="#all">
 

--- a/src/main/webapp/static/com/atomgraph/linkeddatahub/xsl/imports/rdf.xsl
+++ b/src/main/webapp/static/com/atomgraph/linkeddatahub/xsl/imports/rdf.xsl
@@ -9,7 +9,6 @@
     <!ENTITY xsd    "http://www.w3.org/2001/XMLSchema#">
     <!ENTITY owl    "http://www.w3.org/2002/07/owl#">
     <!ENTITY sparql "http://www.w3.org/2005/sparql-results#">
-    <!ENTITY ldt    "https://www.w3.org/ns/ldt#">
     <!ENTITY dh     "https://www.w3.org/ns/ldt/document-hierarchy#">
     <!ENTITY sd     "http://www.w3.org/ns/sparql-service-description#">
     <!ENTITY dct    "http://purl.org/dc/terms/">
@@ -31,7 +30,6 @@ xmlns:rdf="&rdf;"
 xmlns:rdfs="&rdfs;"
 xmlns:owl="&owl;"
 xmlns:sparql="&sparql;"
-xmlns:ldt="&ldt;"
 xmlns:sd="&sd;"
 xmlns:dct="&dct;"
 xmlns:foaf="&foaf;"
@@ -112,7 +110,7 @@ exclude-result-prefixes="#all">
         <xsl:param name="id" select="generate-id()" as="xs:string"/>
         <xsl:param name="class" select="'subject'" as="xs:string?"/>
         <xsl:param name="disabled" select="false()" as="xs:boolean"/>
-        <xsl:param name="auto" select="local-name() = 'nodeID' or starts-with(., ldt:base())" as="xs:boolean"/>
+        <xsl:param name="auto" select="local-name() = 'nodeID' or starts-with(., lapp:base())" as="xs:boolean"/>
         <xsl:param name="type-metadata" as="document-node()?" tunnel="yes"/>
         <xsl:param name="combobox-class" select="'type-combobox combobox'" as="xs:string"/>
         <xsl:param name="combobox-list-class" select="'type-combobox combobox ac-cb-panel'" as="xs:string"/>

--- a/src/main/webapp/static/com/atomgraph/linkeddatahub/xsl/imports/sh.xsl
+++ b/src/main/webapp/static/com/atomgraph/linkeddatahub/xsl/imports/sh.xsl
@@ -1,0 +1,49 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+Copyright 2025 Martynas Jusevičius <martynas@atomgraph.com>
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-->
+<!DOCTYPE xsl:stylesheet [
+    <!ENTITY ac     "https://w3id.org/atomgraph/client#">
+    <!ENTITY rdf    "http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+    <!ENTITY sh     "http://www.w3.org/ns/shacl#">
+]>
+<xsl:stylesheet version="3.0"
+xmlns="http://www.w3.org/1999/xhtml"
+xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
+xmlns:xs="http://www.w3.org/2001/XMLSchema"
+xmlns:ac="&ac;"
+xmlns:rdf="&rdf;"
+xmlns:sh="&sh;"
+exclude-result-prefixes="#all">
+
+    <!-- SHACL is a constraint vocabulary and the validator is this layer's, so the shape labels come
+         with it rather than living in Web-Client, which cannot validate anything.
+
+         The move costs the precedence this module used to have. In Web-Client it was imported first
+         among the vocabulary modules, deliberately, so that a shape's sh:name lost to every
+         data-layer label - dc:title, foaf:name, skos:prefLabel. Nothing in this tree can reproduce
+         that: client.xsl imports Web-Client's common.xsl before this one, so every module here
+         outranks every vocabulary module there, and import precedence is resolved before priority.
+         A resource carrying both sh:name and dc:title therefore now labels as its sh:name. -->
+
+    <xsl:template match="*[sh:name/text()]" mode="ac:label">
+        <xsl:sequence select="ac:preferred-lang(sh:name)"/>
+    </xsl:template>
+
+    <xsl:template match="*[sh:description/text()]" mode="ac:description">
+        <xsl:sequence select="ac:preferred-lang(sh:description)"/>
+    </xsl:template>
+
+</xsl:stylesheet>

--- a/src/main/webapp/static/com/atomgraph/linkeddatahub/xsl/imports/sioc.xsl
+++ b/src/main/webapp/static/com/atomgraph/linkeddatahub/xsl/imports/sioc.xsl
@@ -7,7 +7,6 @@
     <!ENTITY rdfs   "http://www.w3.org/2000/01/rdf-schema#">
     <!ENTITY xsd    "http://www.w3.org/2001/XMLSchema#">
     <!ENTITY owl    "http://www.w3.org/2002/07/owl#">
-    <!ENTITY ldt    "https://www.w3.org/ns/ldt#">
     <!ENTITY sioc   "http://rdfs.org/sioc/ns#">
     <!ENTITY foaf   "http://xmlns.com/foaf/0.1/">
 ]>
@@ -22,7 +21,6 @@ xmlns:lapp="&lapp;"
 xmlns:rdf="&rdf;"
 xmlns:rdfs="&rdfs;"
 xmlns:owl="&owl;"
-xmlns:ldt="&ldt;"
 xmlns:sioc="&sioc;"
 xmlns:foaf="&foaf;"
 exclude-result-prefixes="#all">

--- a/src/main/webapp/static/com/atomgraph/linkeddatahub/xsl/imports/sp.xsl
+++ b/src/main/webapp/static/com/atomgraph/linkeddatahub/xsl/imports/sp.xsl
@@ -5,7 +5,6 @@
     <!ENTITY ac     "https://w3id.org/atomgraph/client#">
     <!ENTITY rdf    "http://www.w3.org/1999/02/22-rdf-syntax-ns#">
     <!ENTITY xsd    "http://www.w3.org/2001/XMLSchema#">
-    <!ENTITY ldt    "https://www.w3.org/ns/ldt#">
     <!ENTITY sd     "http://www.w3.org/ns/sparql-service-description#">
     <!ENTITY sp     "http://spinrdf.org/sp#">
 ]>
@@ -18,7 +17,6 @@ xmlns:ldh="&ldh;"
 xmlns:lapp="&lapp;"
 xmlns:ac="&ac;"
 xmlns:rdf="&rdf;"
-xmlns:ldt="&ldt;"
 xmlns:sp="&sp;"
 exclude-result-prefixes="#all">
     

--- a/src/main/webapp/static/com/atomgraph/linkeddatahub/xsl/layout.xsl
+++ b/src/main/webapp/static/com/atomgraph/linkeddatahub/xsl/layout.xsl
@@ -24,7 +24,6 @@
     <!ENTITY cert   "http://www.w3.org/ns/auth/cert#">
     <!ENTITY sh     "http://www.w3.org/ns/shacl#">
     <!ENTITY sd     "http://www.w3.org/ns/sparql-service-description#">
-    <!ENTITY ldt    "https://www.w3.org/ns/ldt#">
     <!ENTITY c      "https://www.w3.org/ns/ldt/core/domain#">
     <!ENTITY ct     "https://www.w3.org/ns/ldt/core/templates#">
     <!ENTITY dh     "https://www.w3.org/ns/ldt/document-hierarchy#">
@@ -37,6 +36,7 @@
     <!ENTITY void   "http://rdfs.org/ns/void#">
     <!ENTITY nfo    "http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#">
     <!ENTITY schema "https://schema.org/">
+    <!ENTITY ldt    "https://www.w3.org/ns/ldt#">
 ]>
 <xsl:stylesheet version="3.0"
 xmlns="http://www.w3.org/1999/xhtml"
@@ -60,7 +60,6 @@ xmlns:acl="&acl;"
 xmlns:cert="&cert;"
 xmlns:sd="&sd;"
 xmlns:sh="&sh;"
-xmlns:ldt="&ldt;"
 xmlns:core="&c;"
 xmlns:dh="&dh;"
 xmlns:dct="&dct;"
@@ -97,18 +96,35 @@ exclude-result-prefixes="#all">
     <xsl:param name="lapp:origin" as="xs:anyURI?"/>
     <xsl:param name="ldh:requestUri" as="xs:anyURI"/>
     <xsl:param name="ac:uri" as="xs:anyURI?"/>
-    <xsl:param name="acl:agent" as="xs:anyURI?"/>
     <xsl:param name="lapp:Context" as="document-node()"/>
-    <xsl:param name="foaf:Agent" select="if ($acl:agent) then document(ac:document-uri($acl:agent)) else ()" as="document-node()?"/>
-    <xsl:param name="ac:httpHeaders" as="xs:string"/>
-    <xsl:param name="ac:method" as="xs:string"/>
     <xsl:param name="ldh:httpHeaders" select="map{}" as="map(xs:string, xs:string*)"/>
     <xsl:param name="ldh:ajaxRendering" select="true()" as="xs:boolean"/>
     <xsl:param name="ldhc:enableWebIDSignUp" as="xs:boolean"/>
     <xsl:param name="ldh:renderSystemResources" select="false()" as="xs:boolean"/>
     <xsl:param name="google:clientID" as="xs:string?"/>
     <xsl:param name="orcid:clientID" as="xs:string?"/>
-    <xsl:param name="doc-types" select="key('resources', ac:absolute-path(ldh:base-uri(.)))/rdf:type/@rdf:resource[ . = ('&def;Root', '&dh;Container', '&dh;Item')]" as="xs:anyURI*"/>
+    <!-- the ontologies the client resolves through the proxy rather than over the network; every one
+         is fetched by the same recipe, so the list is data and the entry is written once -->
+    <!-- the application this origin resolves to, as described in the system context -->
+    <xsl:function name="lapp:application-description" as="element()*">
+        <xsl:sequence select="key('apps-by-origin', lapp:origin(), $lapp:Context)"/>
+    </xsl:function>
+
+    <xsl:param name="ontology-namespaces" as="xs:anyURI*" select="(
+        xs:anyURI('&ac;'), xs:anyURI('&adm;'), xs:anyURI('&lacl;'),
+        xs:anyURI('&lapp;'), xs:anyURI('&ldh;'), xs:anyURI('&def;'),
+        xs:anyURI('&dh;'), xs:anyURI('&sp;'), xs:anyURI('&spin;'),
+        xs:anyURI('&rdf;'), xs:anyURI('&rdfs;'), xs:anyURI('&owl;'),
+        xs:anyURI('&acl;'), xs:anyURI('&sd;'), xs:anyURI('&sh;'),
+        xs:anyURI('&nfo;'), xs:anyURI('http://www.semanticdesktop.org/ontologies/2007/01/19/nie#'), xs:anyURI('&http;'),
+        xs:anyURI('&sc;'), xs:anyURI('&ldt;'), xs:anyURI('&c;'),
+        xs:anyURI('&sioc;'), xs:anyURI('&void;'), xs:anyURI('&foaf;'),
+        xs:anyURI('&spl;'), xs:anyURI('&cert;'), xs:anyURI('http://www.w3.org/ns/prov#'),
+        xs:anyURI('&geo;'), xs:anyURI('http://www.w3.org/2004/02/skos/core#'), xs:anyURI('http://www.w3.org/2006/time#'),
+        xs:anyURI('http://purl.org/dc/elements/1.1/'), xs:anyURI('&dct;'), xs:anyURI('http://purl.org/dc/dcmitype/'),
+        xs:anyURI('http://purl.org/goodrelations/v1#'), xs:anyURI('http://usefulinc.com/ns/doap#')
+    )"/>
+
     <xsl:param name="location-mapping" as="map(xs:anyURI, xs:anyURI)">
         <xsl:map>
             <xsl:if test="lapp:origin()">
@@ -117,43 +133,11 @@ exclude-result-prefixes="#all">
                 <xsl:map-entry key="resolve-uri('static/com/atomgraph/linkeddatahub/xsl/admin/countries.rdf', lapp:origin())" select="resolve-uri('static/com/atomgraph/linkeddatahub/xsl/admin/countries.rdf', lapp:origin())"/>                
             </xsl:if>
 
-            <xsl:map-entry key="xs:anyURI(ac:document-uri(xs:anyURI('&ac;')))" select="ac:build-uri($ldt:base, map{ 'uri': string(ac:document-uri(xs:anyURI('&ac;'))), 'accept': 'application/rdf+xml' })"/>
-            <xsl:map-entry key="xs:anyURI(ac:document-uri(xs:anyURI('&adm;')))" select="ac:build-uri($ldt:base, map{ 'uri': string(ac:document-uri(xs:anyURI('&adm;'))), 'accept': 'application/rdf+xml' })"/>
-            <xsl:map-entry key="xs:anyURI(ac:document-uri(xs:anyURI('&lacl;')))" select="ac:build-uri($ldt:base, map{ 'uri': string(ac:document-uri(xs:anyURI('&lacl;'))), 'accept': 'application/rdf+xml' })"/>
-            <xsl:map-entry key="xs:anyURI(ac:document-uri(xs:anyURI('&lapp;')))" select="ac:build-uri($ldt:base, map{ 'uri': string(ac:document-uri(xs:anyURI('&lapp;'))), 'accept': 'application/rdf+xml' })"/>
-            <xsl:map-entry key="xs:anyURI(ac:document-uri(xs:anyURI('&ldh;')))" select="ac:build-uri($ldt:base, map{ 'uri': string(ac:document-uri(xs:anyURI('&ldh;'))), 'accept': 'application/rdf+xml' })"/>
-            <xsl:map-entry key="xs:anyURI(ac:document-uri(xs:anyURI('&def;')))" select="ac:build-uri($ldt:base, map{ 'uri': string(ac:document-uri(xs:anyURI('&def;'))), 'accept': 'application/rdf+xml' })"/>
-            <xsl:map-entry key="xs:anyURI(ac:document-uri(xs:anyURI('&dh;')))" select="ac:build-uri($ldt:base, map{ 'uri': string(ac:document-uri(xs:anyURI('&dh;'))), 'accept': 'application/rdf+xml' })"/>
-            <xsl:map-entry key="xs:anyURI(ac:document-uri(xs:anyURI('&sp;')))" select="ac:build-uri($ldt:base, map{ 'uri': string(ac:document-uri(xs:anyURI('&sp;'))), 'accept': 'application/rdf+xml' })"/>
-            <xsl:map-entry key="xs:anyURI(ac:document-uri(xs:anyURI('&spin;')))" select="ac:build-uri($ldt:base, map{ 'uri': string(ac:document-uri(xs:anyURI('&spin;'))), 'accept': 'application/rdf+xml' })"/>
-            <xsl:map-entry key="xs:anyURI(ac:document-uri(xs:anyURI('&rdf;')))" select="ac:build-uri($ldt:base, map{ 'uri': string(ac:document-uri(xs:anyURI('&rdf;'))), 'accept': 'application/rdf+xml' })"/>
-            <xsl:map-entry key="xs:anyURI(ac:document-uri(xs:anyURI('&rdfs;')))" select="ac:build-uri($ldt:base, map{ 'uri': string(ac:document-uri(xs:anyURI('&rdfs;'))), 'accept': 'application/rdf+xml' })"/>
-            <xsl:map-entry key="xs:anyURI(ac:document-uri(xs:anyURI('&owl;')))" select="ac:build-uri($ldt:base, map{ 'uri': string(ac:document-uri(xs:anyURI('&owl;'))), 'accept': 'application/rdf+xml' })"/>
-            <xsl:map-entry key="xs:anyURI(ac:document-uri(xs:anyURI('&acl;')))" select="ac:build-uri($ldt:base, map{ 'uri': string(ac:document-uri(xs:anyURI('&acl;'))), 'accept': 'application/rdf+xml' })"/>
-            <xsl:map-entry key="xs:anyURI(ac:document-uri(xs:anyURI('&sd;')))" select="ac:build-uri($ldt:base, map{ 'uri': string(ac:document-uri(xs:anyURI('&sd;'))), 'accept': 'application/rdf+xml' })"/>
-            <xsl:map-entry key="xs:anyURI(ac:document-uri(xs:anyURI('&sh;')))" select="ac:build-uri($ldt:base, map{ 'uri': string(ac:document-uri(xs:anyURI('&sh;'))), 'accept': 'application/rdf+xml' })"/>
-            <xsl:map-entry key="xs:anyURI(ac:document-uri(xs:anyURI('&nfo;')))" select="ac:build-uri($ldt:base, map{ 'uri': string(ac:document-uri(xs:anyURI('&nfo;'))), 'accept': 'application/rdf+xml' })"/>
-            <xsl:map-entry key="xs:anyURI(ac:document-uri(xs:anyURI('http://www.semanticdesktop.org/ontologies/2007/01/19/nie#')))" select="ac:build-uri($ldt:base, map{ 'uri': string(ac:document-uri(xs:anyURI('http://www.semanticdesktop.org/ontologies/2007/01/19/nie#'))), 'accept': 'application/rdf+xml' })"/>
-            <xsl:map-entry key="xs:anyURI(ac:document-uri(xs:anyURI('&http;')))" select="ac:build-uri($ldt:base, map{ 'uri': string(ac:document-uri(xs:anyURI('&http;'))), 'accept': 'application/rdf+xml' })"/>
-            <xsl:map-entry key="xs:anyURI(ac:document-uri(xs:anyURI('&sc;')))" select="ac:build-uri($ldt:base, map{ 'uri': string(ac:document-uri(xs:anyURI('&sc;'))), 'accept': 'application/rdf+xml' })"/>
-            <xsl:map-entry key="xs:anyURI(ac:document-uri(xs:anyURI('&ldt;')))" select="ac:build-uri($ldt:base, map{ 'uri': string(ac:document-uri(xs:anyURI('&ldt;'))), 'accept': 'application/rdf+xml' })"/>
-            <xsl:map-entry key="xs:anyURI(ac:document-uri(xs:anyURI('&c;')))" select="ac:build-uri($ldt:base, map{ 'uri': string(ac:document-uri(xs:anyURI('&c;'))), 'accept': 'application/rdf+xml' })"/>
-            <xsl:map-entry key="xs:anyURI(ac:document-uri(xs:anyURI('&sioc;')))" select="ac:build-uri($ldt:base, map{ 'uri': string(ac:document-uri(xs:anyURI('&sioc;'))), 'accept': 'application/rdf+xml' })"/>
-            <xsl:map-entry key="xs:anyURI(ac:document-uri(xs:anyURI('&void;')))" select="ac:build-uri($ldt:base, map{ 'uri': string(ac:document-uri(xs:anyURI('&void;'))), 'accept': 'application/rdf+xml' })"/>
-            <xsl:map-entry key="xs:anyURI(ac:document-uri(xs:anyURI('&foaf;')))" select="ac:build-uri($ldt:base, map{ 'uri': string(ac:document-uri(xs:anyURI('&foaf;'))), 'accept': 'application/rdf+xml' })"/>
-            <xsl:map-entry key="xs:anyURI(ac:document-uri(xs:anyURI('&spl;')))" select="ac:build-uri($ldt:base, map{ 'uri': string(ac:document-uri(xs:anyURI('&spl;'))), 'accept': 'application/rdf+xml' })"/>
-            <xsl:map-entry key="xs:anyURI(ac:document-uri(xs:anyURI('&cert;')))" select="ac:build-uri($ldt:base, map{ 'uri': string(ac:document-uri(xs:anyURI('&cert;'))), 'accept': 'application/rdf+xml' })"/>
-            <xsl:map-entry key="xs:anyURI(ac:document-uri(xs:anyURI('http://www.w3.org/ns/prov#')))" select="ac:build-uri($ldt:base, map{ 'uri': string(ac:document-uri(xs:anyURI('http://www.w3.org/ns/prov#'))), 'accept': 'application/rdf+xml' })"/>
-            <xsl:map-entry key="xs:anyURI(ac:document-uri(xs:anyURI('&geo;')))" select="ac:build-uri($ldt:base, map{ 'uri': string(ac:document-uri(xs:anyURI('&geo;'))), 'accept': 'application/rdf+xml' })"/>
-            <xsl:map-entry key="xs:anyURI(ac:document-uri(xs:anyURI('http://www.w3.org/2004/02/skos/core#')))" select="ac:build-uri($ldt:base, map{ 'uri': string(ac:document-uri(xs:anyURI('http://www.w3.org/2004/02/skos/core#'))), 'accept': 'application/rdf+xml' })"/>
-            <xsl:map-entry key="xs:anyURI(ac:document-uri(xs:anyURI('http://www.w3.org/2006/time#')))" select="ac:build-uri($ldt:base, map{ 'uri': string(ac:document-uri(xs:anyURI('http://www.w3.org/2006/time#'))), 'accept': 'application/rdf+xml' })"/>
-            <xsl:map-entry key="xs:anyURI(ac:document-uri(xs:anyURI('http://purl.org/dc/elements/1.1/')))" select="ac:build-uri($ldt:base, map{ 'uri': string(ac:document-uri(xs:anyURI('http://purl.org/dc/elements/1.1/'))), 'accept': 'application/rdf+xml' })"/>
-            <xsl:map-entry key="xs:anyURI(ac:document-uri(xs:anyURI('&dct;')))" select="ac:build-uri($ldt:base, map{ 'uri': string(ac:document-uri(xs:anyURI('&dct;'))), 'accept': 'application/rdf+xml' })"/>
-            <xsl:map-entry key="xs:anyURI(ac:document-uri(xs:anyURI('http://purl.org/dc/dcmitype/')))" select="ac:build-uri($ldt:base, map{ 'uri': string(ac:document-uri(xs:anyURI('http://purl.org/dc/dcmitype/'))), 'accept': 'application/rdf+xml' })"/>
-            <xsl:map-entry key="xs:anyURI(ac:document-uri(xs:anyURI('http://purl.org/goodrelations/v1#')))" select="ac:build-uri($ldt:base, map{ 'uri': string(ac:document-uri(xs:anyURI('http://purl.org/goodrelations/v1#'))), 'accept': 'application/rdf+xml' })"/>
-            <xsl:map-entry key="xs:anyURI(ac:document-uri(xs:anyURI('http://usefulinc.com/ns/doap#')))" select="ac:build-uri($ldt:base, map{ 'uri': string(ac:document-uri(xs:anyURI('http://usefulinc.com/ns/doap#'))), 'accept': 'application/rdf+xml' })"/>
+            <xsl:for-each select="$ontology-namespaces">
+                <xsl:map-entry key="ac:document-uri(.)" select="ac:build-uri(lapp:base(), map{ 'uri': string(ac:document-uri(.)), 'accept': 'application/rdf+xml' })"/>
+            </xsl:for-each>
             <xsl:if test="$acl:agent">
-                <xsl:map-entry key="ac:document-uri($acl:agent)" select="ac:build-uri($ldt:base, map{ 'uri': string(ac:document-uri($acl:agent)), 'accept': 'application/rdf+xml' })"/>
+                <xsl:map-entry key="ac:document-uri($acl:agent)" select="ac:build-uri(lapp:base(), map{ 'uri': string(ac:document-uri($acl:agent)), 'accept': 'application/rdf+xml' })"/>
             </xsl:if>
         </xsl:map>
     </xsl:param>
@@ -174,114 +158,10 @@ exclude-result-prefixes="#all">
         ]]>
     </xsl:variable>
     <xsl:variable name="app-request-uri" select="ac:build-uri(sd:endpoint(), map{ 'query': $app-query })" as="xs:anyURI"/>
-    <xsl:variable name="constraint-query" as="xs:string">
-        <![CDATA[
-            PREFIX  ldh:  <https://w3id.org/atomgraph/linkeddatahub#>
-            PREFIX  rdfs: <http://www.w3.org/2000/01/rdf-schema#>
-            PREFIX  sp:   <http://spinrdf.org/sp#>
-            PREFIX  spin: <http://spinrdf.org/spin#>
-
-            SELECT  $Type ?property
-            WHERE
-              { $Type (rdfs:subClassOf)*/spin:constraint  ?constraint .
-                ?constraint  a             ldh:MissingPropertyValue ;
-                          sp:arg1          ?property
-              }
-        ]]>
-        <!-- VALUES $Type goes here -->
-    </xsl:variable>
-    <xsl:variable name="constructor-query" as="xs:string">
-        <![CDATA[
-            PREFIX  rdfs: <http://www.w3.org/2000/01/rdf-schema#>
-            PREFIX  sp:   <http://spinrdf.org/sp#>
-            PREFIX  spin: <http://spinrdf.org/spin#>
-
-            SELECT  $Type ?constructor ?construct
-            WHERE
-              { $Type (rdfs:subClassOf)*/spin:constructor  ?constructor .
-                ?constructor sp:text ?construct .
-              }
-        ]]>
-        <!-- VALUES $Type goes here -->
-    </xsl:variable>
-    <xsl:variable name="shape-query" as="xs:string">
-        <![CDATA[
-            PREFIX  sh:   <http://www.w3.org/ns/shacl#>
-
-            DESCRIBE $Shape ?property
-            WHERE
-              { $Shape  sh:targetClass  $Type
-                OPTIONAL
-                  { $Shape  sh:property  ?property }
-              }
-        ]]>
-        <!-- VALUES $Type goes here -->
-    </xsl:variable>
-    <xsl:param name="object-metadata-query" as="xs:string">
-        <![CDATA[
-            PREFIX  rdf:  <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
-            PREFIX  xsd:  <http://www.w3.org/2001/XMLSchema#>
-            PREFIX  dct:  <http://purl.org/dc/terms/>
-            PREFIX  schema2: <https://schema.org/>
-            PREFIX  schema1: <http://schema.org/>
-            PREFIX  skos: <http://www.w3.org/2004/02/skos/core#>
-            PREFIX  rdfs: <http://www.w3.org/2000/01/rdf-schema#>
-            PREFIX  foaf: <http://xmlns.com/foaf/0.1/>
-            PREFIX  sioc: <http://rdfs.org/sioc/ns#>
-            PREFIX  dc:   <http://purl.org/dc/elements/1.1/>
-
-            CONSTRUCT 
-              { 
-                $this ?p ?literal .
-              }
-            WHERE
-              { GRAPH ?graph
-                  { $this  ?p  ?literal
-                    FILTER ( ( datatype(?literal) = xsd:string ) || ( datatype(?literal) = rdf:langString ) )
-                    FILTER ( ?p IN (rdfs:label, dc:title, dct:title, foaf:name, foaf:givenName, foaf:familyName, sioc:name, skos:prefLabel, schema1:name, schema2:name) )
-                  }
-              }
-        ]]>
-        <!-- VALUES $this goes here -->
-    </xsl:param>
     <!-- graph-free variant of object-metadata-query for the /ns ontology endpoint: its dataset is the in-memory OntModel served as the default graph (no named graphs), so a GRAPH ?graph pattern would match nothing -->
-    <xsl:param name="object-metadata-ns-query" as="xs:string">
-        <![CDATA[
-            PREFIX  rdf:  <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
-            PREFIX  xsd:  <http://www.w3.org/2001/XMLSchema#>
-            PREFIX  dct:  <http://purl.org/dc/terms/>
-            PREFIX  schema2: <https://schema.org/>
-            PREFIX  schema1: <http://schema.org/>
-            PREFIX  skos: <http://www.w3.org/2004/02/skos/core#>
-            PREFIX  rdfs: <http://www.w3.org/2000/01/rdf-schema#>
-            PREFIX  foaf: <http://xmlns.com/foaf/0.1/>
-            PREFIX  sioc: <http://rdfs.org/sioc/ns#>
-            PREFIX  dc:   <http://purl.org/dc/elements/1.1/>
-
-            CONSTRUCT
-              {
-                $this ?p ?literal .
-              }
-            WHERE
-              { $this  ?p  ?literal
-                FILTER ( ( datatype(?literal) = xsd:string ) || ( datatype(?literal) = rdf:langString ) )
-                FILTER ( ?p IN (rdfs:label, dc:title, dct:title, foaf:name, foaf:givenName, foaf:familyName, sioc:name, skos:prefLabel, schema1:name, schema2:name) )
-              }
-        ]]>
-        <!-- VALUES $this goes here -->
-    </xsl:param>
     <!-- server-side twin of client.xsl's $property-metadata-query, so ac:property-label resolves predicate labels from
          the application ontology on the initial render as it does client-side -->
-    <xsl:param name="property-metadata-query" as="xs:string">
-        <![CDATA[
-            DESCRIBE $Type
-        ]]>
-        <!-- VALUES $Type goes here -->
-    </xsl:param>
 
-    <xsl:key name="violations-by-root" match="*[@rdf:about] | *[@rdf:nodeID]" use="spin:violationRoot/@rdf:resource | spin:violationRoot/@rdf:nodeID"/>
-    <xsl:key name="violations-by-value" match="*" use="ldh:violationValue/text()"/>
-    <xsl:key name="violations-by-focus-node" match="*" use="sh:focusNode/@rdf:resource | sh:focusNode/@rdf:nodeID"/>
     <xsl:key name="apps-by-origin" match="*" use="lapp:origin/@rdf:resource"/>
 
     <rdf:Description rdf:about="">
@@ -291,7 +171,7 @@ exclude-result-prefixes="#all">
 
     <xsl:template match="rdf:RDF" mode="xhtml:Title">
         <title>
-            <xsl:for-each select="key('apps-by-origin', lapp:origin(), $lapp:Context)">
+            <xsl:for-each select="lapp:application-description()">
                 <xsl:value-of>
                     <xsl:apply-templates select="." mode="ac:label"/>
                 </xsl:value-of>
@@ -350,7 +230,7 @@ exclude-result-prefixes="#all">
             </xsl:for-each>
         </xsl:for-each>
 
-        <xsl:for-each select="key('apps-by-origin', lapp:origin(), $lapp:Context)">
+        <xsl:for-each select="lapp:application-description()">
             <meta property="og:site_name" content="{ac:label(.)}"/>
         </xsl:for-each>
     </xsl:template>
@@ -535,9 +415,9 @@ exclude-result-prefixes="#all">
 
     <xsl:template match="*" mode="ac:Header"/>
 
-    <xsl:template match="rdf:RDF[key('apps-by-origin', lapp:origin(), $lapp:Context)] | srx:sparql[key('apps-by-origin', lapp:origin(), $lapp:Context)]" mode="ldh:Brand" priority="1">
-        <a class="ldh-wordmark" href="{$ldt:base}">
-            <xsl:for-each select="key('apps-by-origin', lapp:origin(), $lapp:Context)">
+    <xsl:template match="rdf:RDF[lapp:application-description()] | srx:sparql[lapp:application-description()]" mode="ldh:Brand" priority="1">
+        <a class="ldh-wordmark" href="{lapp:base()}">
+            <xsl:for-each select="lapp:application-description()">
                 <xsl:if test="rdf:type/@rdf:resource = '&lapp;AdminApplication'">
                     <xsl:attribute name="class" select="'ldh-wordmark admin'"/>
                 </xsl:if>
@@ -553,7 +433,7 @@ exclude-result-prefixes="#all">
     <xsl:template match="*" mode="ldh:Brand"/>
 
     <!-- check if agent has access to the user endpoint by executing a dummy query ASK {} -->
-    <xsl:template match="rdf:RDF[doc-available(resolve-uri('sparql?query=ASK%20%7B%7D', $ldt:base))] | srx:sparql[doc-available(resolve-uri('sparql?query=ASK%20%7B%7D', $ldt:base))]" mode="ldh:AddressBar" priority="1">
+    <xsl:template match="rdf:RDF[doc-available(resolve-uri('sparql?query=ASK%20%7B%7D', lapp:base()))] | srx:sparql[doc-available(resolve-uri('sparql?query=ASK%20%7B%7D', lapp:base()))]" mode="ldh:AddressBar" priority="1">
         <form action="{ac:absolute-path(ldh:request-uri())}" method="get" class="ldh-address" accept-charset="UTF-8" role="search" aria-label="{ac:label(key('resources', 'address-bar-title', document('translations.rdf')))}" title="{ac:label(key('resources', 'address-bar-title', document('translations.rdf')))}">
             <span class="msi outline" aria-hidden="true">public</span>
             <input type="url" id="uri" name="uri" value="{ac:absolute-path(ldh:request-uri())}" spellcheck="false" autocomplete="off" aria-label="{ac:label(key('resources', 'address-bar-title', document('translations.rdf')))}"/>
@@ -604,10 +484,10 @@ WHERE
                     ]]>
                 </xsl:variable>
                 <xsl:variable name="notification-query" select="replace($notification-query, '$type', '&lt;&lacl;AuthorizationRequest&gt;', 'q')" as="xs:string"/>
-                <xsl:variable name="notification-query" select="replace($notification-query, '$container', '&lt;' || resolve-uri('acl/authorization-requests/', $ldt:base) || '&gt;', 'q')" as="xs:string"/>
+                <xsl:variable name="notification-query" select="replace($notification-query, '$container', '&lt;' || resolve-uri('acl/authorization-requests/', lapp:base()) || '&gt;', 'q')" as="xs:string"/>
 
-                <xsl:if test="doc-available(ac:build-uri(resolve-uri('sparql', $ldt:base), map{ 'query': $notification-query }))">
-                    <xsl:variable name="notifications" select="document(ac:build-uri(resolve-uri('sparql', $ldt:base), map{ 'query': $notification-query }))" as="document-node()"/>
+                <xsl:if test="doc-available(ac:build-uri(resolve-uri('sparql', lapp:base()), map{ 'query': $notification-query }))">
+                    <xsl:variable name="notifications" select="document(ac:build-uri(resolve-uri('sparql', lapp:base()), map{ 'query': $notification-query }))" as="document-node()"/>
 
                     <xsl:if test="$notifications/rdf:RDF/*[@rdf:about]">
                             <div class="ac-menu-anchor">
@@ -640,7 +520,7 @@ WHERE
         <xsl:apply-templates select="." mode="ldh:SignUp"/>
     </xsl:template>
 
-    <xsl:template match="rdf:RDF[lapp:origin()][key('apps-by-origin', lapp:origin(), $lapp:Context)/rdf:type/@rdf:resource = '&lapp;EndUserApplication'] | srx:sparql[lapp:origin()][key('apps-by-origin', lapp:origin(), $lapp:Context)/rdf:type/@rdf:resource = '&lapp;EndUserApplication']" mode="ldh:DataspaceTabs" priority="1">
+    <xsl:template match="rdf:RDF[lapp:origin()][lapp:application-description()/rdf:type/@rdf:resource = '&lapp;EndUserApplication'] | srx:sparql[lapp:origin()][lapp:application-description()/rdf:type/@rdf:resource = '&lapp;EndUserApplication']" mode="ldh:DataspaceTabs" priority="1">
             <xsl:variable name="user-defined-apps" select="if (doc-available($app-request-uri)) then document($app-request-uri)//*[lapp:origin/@rdf:resource] else ()" as="element()*"/>
             <xsl:variable name="system-apps" select="$lapp:Context//*[rdf:type/@rdf:resource = '&lapp;EndUserApplication'][lapp:origin/@rdf:resource]" as="element()*"/>
 
@@ -711,7 +591,7 @@ WHERE
 
     <!-- SIGNUP -->
     
-    <xsl:template match="rdf:RDF[lapp:origin()][not($foaf:Agent//@rdf:about)][key('apps-by-origin', lapp:origin(), $lapp:Context)/rdf:type/@rdf:resource = '&lapp;EndUserApplication'] | srx:sparql[lapp:origin()][not($foaf:Agent//@rdf:about)][key('apps-by-origin', lapp:origin(), $lapp:Context)/rdf:type/@rdf:resource = '&lapp;EndUserApplication']" mode="ldh:SignUp" priority="1">
+    <xsl:template match="rdf:RDF[lapp:origin()][not($foaf:Agent//@rdf:about)][lapp:application-description()/rdf:type/@rdf:resource = '&lapp;EndUserApplication'] | srx:sparql[lapp:origin()][not($foaf:Agent//@rdf:about)][lapp:application-description()/rdf:type/@rdf:resource = '&lapp;EndUserApplication']" mode="ldh:SignUp" priority="1">
         <!-- resolve links against the origin URI of the admin app -->
         <xsl:param name="google-signup" select="exists($google:clientID)" as="xs:boolean"/>
         <xsl:param name="orcid-signup" select="exists($orcid:clientID)" as="xs:boolean"/>
@@ -752,7 +632,7 @@ WHERE
         <!-- WebID signup - separate button -->
         <xsl:if test="$webid-signup">
             <div>
-                <a class="ac-btn in-primary ap-solid sz-md" href="{if (not(starts-with($ldt:base, lapp:origin()))) then ac:build-uri((), map{ 'uri': string($webid-signup-uri) }) else $webid-signup-uri}">
+                <a class="ac-btn in-primary ap-solid sz-md" href="{if (not(starts-with(lapp:base(), lapp:origin()))) then ac:build-uri((), map{ 'uri': string($webid-signup-uri) }) else $webid-signup-uri}">
                     <xsl:value-of>
                         <xsl:apply-templates select="key('resources', 'sign-up', document('translations.rdf'))" mode="ac:label"/>
                     </xsl:value-of>
@@ -798,7 +678,7 @@ WHERE
                                     </xsl:try>
                                 </xsl:variable>
                                 <xsl:variable name="ns-metadata" as="document-node()?">
-                                    <xsl:try select="ldh:send-request(resolve-uri('ns', ldt:base()), 'POST', 'application/sparql-query', $object-metadata-ns-query || $values, map{ 'Accept': 'application/rdf+xml' })">
+                                    <xsl:try select="ldh:send-request(resolve-uri('ns', lapp:base()), 'POST', 'application/sparql-query', $object-metadata-ns-query || $values, map{ 'Accept': 'application/rdf+xml' })">
                                         <xsl:catch/>
                                     </xsl:try>
                                 </xsl:variable>
@@ -813,7 +693,7 @@ WHERE
                         <xsl:variable name="property-metadata" as="document-node()?">
                             <xsl:if test="exists($property-uris)">
                                 <xsl:variable name="values" select="' VALUES $Type { ' || string-join(for $uri in $property-uris return '&lt;' || $uri || '&gt;', ' ') || ' }'" as="xs:string"/>
-                                <xsl:try select="ldh:send-request(resolve-uri('ns', ldt:base()), 'POST', 'application/sparql-query', $property-metadata-query || $values, map{ 'Accept': 'application/rdf+xml' })">
+                                <xsl:try select="ldh:send-request(resolve-uri('ns', lapp:base()), 'POST', 'application/sparql-query', $property-metadata-query || $values, map{ 'Accept': 'application/rdf+xml' })">
                                     <xsl:catch/>
                                 </xsl:try>
                             </xsl:if>
@@ -821,7 +701,7 @@ WHERE
                         <xsl:variable name="local-pane" as="element()">
                             <xsl:apply-templates select="." mode="ldh:TabPanel">
                                 <xsl:with-param name="mode" select="ac:mode(root())"/>
-                                <xsl:with-param name="base" select="ldt:base()"/>
+                                <xsl:with-param name="base" select="lapp:base()"/>
                                 <xsl:with-param name="endpoint" select="sd:endpoint()"/>
                                 <xsl:with-param name="acl-modes" select="acl:mode()"/>
                                 <xsl:with-param name="about" select="ac:absolute-path(ldh:base-uri(.))"/>
@@ -848,16 +728,16 @@ WHERE
     </xsl:template>
     
     <!-- only lookup resource locally using DESCRIBE if it's external (not relative to the app's base URI) and the agent is authenticated -->
-    <xsl:template match="*[*][@rdf:about = ac:absolute-path(ldh:base-uri(.))][not(starts-with(@rdf:about, $ldt:base))][$foaf:Agent//@rdf:about]" mode="ac:PropertyEditor">
+    <xsl:template match="*[*][@rdf:about = ac:absolute-path(ldh:base-uri(.))][not(starts-with(@rdf:about, lapp:base()))][$foaf:Agent//@rdf:about]" mode="ac:PropertyEditor">
         <xsl:param name="endpoint" select="sd:endpoint()" as="xs:anyURI"/>
         <xsl:param name="property-uris" select="distinct-values(*/concat(namespace-uri(), local-name()))" as="xs:anyURI*"/>
-        <xsl:param name="property-metadata" select="ldh:send-request(resolve-uri('ns', $ldt:base), 'POST', 'application/sparql-query', 'DESCRIBE ' || string-join(for $uri in distinct-values(/rdf:RDF/*/*/concat(namespace-uri(), local-name())) return '&lt;' || $uri || '&gt;', ' '), map{ 'Accept': 'application/rdf+xml' })" as="document-node()"/>
+        <xsl:param name="property-metadata" select="ldh:send-request(resolve-uri('ns', lapp:base()), 'POST', 'application/sparql-query', 'DESCRIBE ' || string-join(for $uri in distinct-values(/rdf:RDF/*/*/concat(namespace-uri(), local-name())) return '&lt;' || $uri || '&gt;', ' '), map{ 'Accept': 'application/rdf+xml' })" as="document-node()"/>
         <xsl:param name="object-metadata" as="document-node()?" tunnel="yes"/>
         <xsl:variable name="local-doc" select="ldh:query-result($endpoint, 'DESCRIBE &lt;' || @rdf:about || '&gt;')" as="document-node()"/>
         <xsl:variable name="original-doc" as="document-node()">
             <xsl:try>
                 <!-- try loading resource by deferencing its URI -->
-                <xsl:variable name="full-doc" select="document(ac:build-uri($ldt:base, map{ 'uri': string(ac:document-uri(@rdf:about)), 'accept': 'application/rdf+xml' }))" as="document-node()"/>
+                <xsl:variable name="full-doc" select="document(ac:build-uri(lapp:base(), map{ 'uri': string(ac:document-uri(@rdf:about)), 'accept': 'application/rdf+xml' }))" as="document-node()"/>
                 <xsl:document>
                     <rdf:RDF>
                         <xsl:copy-of select="key('resources', @rdf:about, $full-doc)"/>
@@ -986,7 +866,7 @@ WHERE
             </button>
 
             <div class="ac-menu al-end" role="menu">
-                <xsl:if test="$foaf:Agent//@rdf:about and key('apps-by-origin', lapp:origin(), $lapp:Context)/rdf:type/@rdf:resource = '&lapp;EndUserApplication'">
+                <xsl:if test="$foaf:Agent//@rdf:about and lapp:application-description()/rdf:type/@rdf:resource = '&lapp;EndUserApplication'">
                     <button type="button" class="ac-menu-item btn-app-settings" role="menuitem">
                         <xsl:value-of>
                             <xsl:apply-templates select="key('resources', '&lapp;Application', document(ac:document-uri('&lapp;')))" mode="ac:label"/>
@@ -997,7 +877,7 @@ WHERE
                             <xsl:apply-templates select="key('resources', 'administration', document('translations.rdf'))" mode="ac:label"/>
                         </xsl:value-of>
                     </a>
-                    <a class="ac-menu-item" role="menuitem" href="{resolve-uri('ns', $ldt:base)}">
+                    <a class="ac-menu-item" role="menuitem" href="{resolve-uri('ns', lapp:base())}">
                         <xsl:value-of>
                             <xsl:apply-templates select="key('resources', 'namespace-ontology', document('translations.rdf'))" mode="ac:label"/>
                         </xsl:value-of>
@@ -1013,7 +893,7 @@ WHERE
         <div class="ldh-footer" role="contentinfo">
             <div class="cols">
                 <div class="col brand-col">
-                    <a class="ldh-wordmark" href="{$ldt:base}">
+                    <a class="ldh-wordmark" href="{lapp:base()}">
                         <span class="mark"></span>
                         <span>LinkedDataHub</span>
                     </a>
@@ -1043,7 +923,7 @@ WHERE
             </div>
             <div class="legal">
                 <span>© <xsl:value-of select="format-date(current-date(), '[Y]')"/> AtomGraph · LinkedDataHub</span>
-                <span><xsl:value-of select="$ldt:base"/></span>
+                <span><xsl:value-of select="lapp:base()"/></span>
             </div>
         </div>
     </xsl:template>

--- a/src/main/webapp/static/com/atomgraph/linkeddatahub/xsl/resource.xsl
+++ b/src/main/webapp/static/com/atomgraph/linkeddatahub/xsl/resource.xsl
@@ -325,7 +325,7 @@ exclude-result-prefixes="#all"
     
     <!-- BREADCRUMBS -->
 
-    <xsl:template match="*[@rdf:about]" mode="ac:BreadcrumbItem">
+    <xsl:template match="*[@rdf:about]" mode="ldh:BreadcrumbItem">
         <xsl:param name="leaf" select="true()" as="xs:boolean"/>
         <!-- crumb icon by document type, as in the design system's breadcrumb -->
         <xsl:param name="icon" select="ldh:class-icon(., 'link')" as="xs:string"/>

--- a/src/main/webapp/static/com/atomgraph/linkeddatahub/xsl/resource.xsl
+++ b/src/main/webapp/static/com/atomgraph/linkeddatahub/xsl/resource.xsl
@@ -1617,26 +1617,6 @@ exclude-result-prefixes="#all"
         </div>
     </xsl:template>
     
-    <!-- VIOLATION -->
-
-    <xsl:template match="*[rdf:type/@rdf:resource = '&ldh;URISyntaxViolation']" mode="ac:Violation">
-        <xsl:param name="class" select="'ac-alert va-negative'" as="xs:string?"/>
-
-        <xsl:apply-templates select="." mode="ac:InlineAlert">
-            <xsl:with-param name="class" select="$class"/>
-            <xsl:with-param name="text" select="string(rdfs:label)"/>
-        </xsl:apply-templates>
-    </xsl:template>
-
-    <xsl:template match="*[rdf:type/@rdf:resource = '&sh;ValidationResult']" mode="ac:Violation">
-        <xsl:param name="class" select="'ac-alert va-negative'" as="xs:string?"/>
-
-        <xsl:apply-templates select="." mode="ac:InlineAlert">
-            <xsl:with-param name="class" select="$class"/>
-            <xsl:with-param name="text" select="string(sh:resultMessage)"/>
-        </xsl:apply-templates>
-    </xsl:template>
-    
     <!-- EXCEPTION -->
     
     <xsl:template match="*[*][@rdf:about] | *[*][@rdf:nodeID]" mode="ldh:Exception"/>

--- a/src/main/webapp/static/com/atomgraph/linkeddatahub/xsl/resource.xsl
+++ b/src/main/webapp/static/com/atomgraph/linkeddatahub/xsl/resource.xsl
@@ -15,7 +15,6 @@
     <!ENTITY http   "http://www.w3.org/2011/http#">
     <!ENTITY sc     "http://www.w3.org/2011/http-statusCodes#">
     <!ENTITY acl    "http://www.w3.org/ns/auth/acl#">
-    <!ENTITY ldt    "https://www.w3.org/ns/ldt#">
     <!ENTITY dh     "https://www.w3.org/ns/ldt/document-hierarchy#">
     <!ENTITY sh     "http://www.w3.org/ns/shacl#">
     <!ENTITY sd     "http://www.w3.org/ns/sparql-service-description#">
@@ -45,7 +44,6 @@ xmlns:owl="&owl;"
 xmlns:srx="&srx;"
 xmlns:http="&http;"
 xmlns:acl="&acl;"
-xmlns:ldt="&ldt;"
 xmlns:dh="&dh;"
 xmlns:sd="&sd;"
 xmlns:sh="&sh;"
@@ -294,12 +292,6 @@ exclude-result-prefixes="#all"
         <xsl:attribute name="class" select="concat($class, ' ', map:get($mode-logo-classes, @rdf:about))"/>
     </xsl:template>
 
-    <xsl:template match="*[@rdf:about = '&ac;QueryEditorMode']" mode="ldh:logo">
-        <xsl:param name="class" as="xs:string?"/>
-        
-        <xsl:attribute name="class" select="concat($class, ' ', 'btn-query')"/>
-    </xsl:template>
-
     <xsl:template match="*[@rdf:about = '&acl;Access']" mode="ldh:logo">
         <xsl:param name="class" as="xs:string?"/>
         
@@ -429,7 +421,7 @@ exclude-result-prefixes="#all"
     <xsl:template match="*[@rdf:about]" mode="ldh:LinkRow">
         <xsl:param name="icon" select="'link'" as="xs:string"/>
 
-        <a href="{ldh:href(ac:document-uri(xs:anyURI(@rdf:about)), map{}, ac:fragment-id(@rdf:about))}" title="{@rdf:about}" class="drow{if (not(starts-with(@rdf:about, ldt:base()))) then ' external' else ''}">
+        <a href="{ldh:href(ac:document-uri(xs:anyURI(@rdf:about)), map{}, ac:fragment-id(@rdf:about))}" title="{@rdf:about}" class="drow{if (not(starts-with(@rdf:about, lapp:base()))) then ' external' else ''}">
             <span class="msi sm" aria-hidden="true">
                 <xsl:value-of select="$icon"/>
             </span>
@@ -1364,7 +1356,7 @@ exclude-result-prefixes="#all"
                     <xsl:sequence select="ldh:reserialize($constructor)"/>
                 </xsl:when>
                 <xsl:when test="exists($forClass)">
-                    <xsl:variable name="results-uri" select="ac:build-uri(resolve-uri('ns', ldt:base()), map{ 'query': ldh:constructor-query($forClass), 'accept': 'application/sparql-results+xml' })" as="xs:anyURI"/>
+                    <xsl:variable name="results-uri" select="ac:build-uri(resolve-uri('ns', lapp:base()), map{ 'query': ldh:constructor-query($forClass), 'accept': 'application/sparql-results+xml' })" as="xs:anyURI"/>
                     <xsl:variable name="results" select="document(ldh:href($results-uri, map{}))" as="document-node()"/>
                     <xsl:sequence select="ldh:construct-instance(distinct-values($results//srx:binding[@name = 'text']/srx:literal), $forClass)"/>
                 </xsl:when>

--- a/src/main/webapp/static/com/atomgraph/linkeddatahub/xsl/server.xsl
+++ b/src/main/webapp/static/com/atomgraph/linkeddatahub/xsl/server.xsl
@@ -4,6 +4,7 @@
     <!ENTITY ldh    "https://w3id.org/atomgraph/linkeddatahub#">
     <!ENTITY ac     "https://w3id.org/atomgraph/client#">
     <!ENTITY acl    "http://www.w3.org/ns/auth/acl#">
+    <!ENTITY sd     "http://www.w3.org/ns/sparql-service-description#">
 ]>
 <xsl:stylesheet version="3.0"
 xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
@@ -12,6 +13,7 @@ xmlns:lapp="&lapp;"
 xmlns:ldh="&ldh;"
 xmlns:ac="&ac;"
 xmlns:acl="&acl;"
+xmlns:sd="&sd;"
 exclude-result-prefixes="#all">
 
     <!-- the server-side bindings of the product-dualed functions: the servlet request context
@@ -32,16 +34,7 @@ exclude-result-prefixes="#all">
     </xsl:function>
 
     <xsl:function name="acl:mode" as="xs:anyURI*">
-        <xsl:variable name="entries" as="xs:string*">
-            <xsl:for-each select="$ldh:httpHeaders('Link')">
-                <xsl:analyze-string select="." regex="&lt;[^&gt;]+&gt;[^&lt;]*">
-                    <xsl:matching-substring>
-                        <xsl:sequence select="."/>
-                    </xsl:matching-substring>
-                </xsl:analyze-string>
-            </xsl:for-each>
-        </xsl:variable>
-        <xsl:sequence select="for $entry in $entries return if (matches($entry, '^&lt;[^&gt;]+&gt;\s*;.*[;\s]rel\s*=\s*&quot;?[^&quot;\s,;]*acl#mode&quot;?')) then xs:anyURI(replace($entry, '^&lt;([^&gt;]+)&gt;.*$', '$1')) else ()"/>
+        <xsl:sequence select="ldh:link-targets($ldh:httpHeaders('Link'), '&acl;mode')"/>
     </xsl:function>
 
     <xsl:function name="ac:uri" as="xs:anyURI?">
@@ -50,16 +43,7 @@ exclude-result-prefixes="#all">
 
     <!-- TimeMap URI from the Link response header (rel=timemap), present when the document is versioned -->
     <xsl:function name="ldh:timemap" as="xs:anyURI?">
-        <xsl:variable name="entries" as="xs:string*">
-            <xsl:for-each select="$ldh:httpHeaders('Link')">
-                <xsl:analyze-string select="." regex="&lt;[^&gt;]+&gt;[^&lt;]*">
-                    <xsl:matching-substring>
-                        <xsl:sequence select="."/>
-                    </xsl:matching-substring>
-                </xsl:analyze-string>
-            </xsl:for-each>
-        </xsl:variable>
-        <xsl:sequence select="(for $entry in $entries return if (matches($entry, '^&lt;[^&gt;]+&gt;\s*;.*[;\s]rel\s*=\s*&quot;?timemap&quot;?([;,\s]|$)')) then xs:anyURI(replace($entry, '^&lt;([^&gt;]+)&gt;.*$', '$1')) else ())[1]"/>
+        <xsl:sequence select="ldh:link-targets($ldh:httpHeaders('Link'), 'rel=timemap')[1]"/>
     </xsl:function>
 
     <!-- Memento-Datetime response header value, present on ?version= responses -->
@@ -79,6 +63,19 @@ exclude-result-prefixes="#all">
 
     <xsl:function name="lapp:origin" as="xs:anyURI?">
         <xsl:sequence select="$lapp:origin"/>
+    </xsl:function>
+
+    <!-- the dataspace base: the origin with a trailing slash. ApplicationImpl.getBaseURI() derives it the
+         same way - getOriginURI().resolve("/"), which discards any path - so there is no separate
+         writer-supplied param, and LDH no longer reads Web-Client's $ldt:base. On a request that
+         resolves to no application $lapp:origin is absent and this yields the relative '/', where the
+         former $ldt:base binding raised XTTE0780. The Saxon-JS twin reads the active pane instead. -->
+    <xsl:function name="lapp:base" as="xs:anyURI">
+        <xsl:sequence select="xs:anyURI(lapp:origin() || '/')"/>
+    </xsl:function>
+
+    <xsl:function name="sd:endpoint" as="xs:anyURI">
+        <xsl:sequence select="resolve-uri('sparql', lapp:base())"/>
     </xsl:function>
 
     <xsl:function name="ldh:parse-query" as="xs:string" override-extension-function="no">


### PR DESCRIPTION
A DRY audit of the top-level `xsl:param` declarations and the accessor functions around them, plus the dead wiring it turned up. Net **−466/+304** across 30 files.

Depends on the matching Web-Client branch `dry-xsl-accessors` (`f5a44b69`) — the WAR overlay pulls `client:6.0.0-SNAPSHOT`, so that one has to be deployed before an image build here will carry its half.

## Dead wiring

Four params had a writer and no reader, and one had neither:

| param | written by | read by |
|---|---|---|
| `$ldh:base` | `Application.java` `setParameter`, every compile | nothing — never declared in any stylesheet |
| `$ldt:ontology` | both writers | nothing |
| `$ac:httpHeaders`, `$ac:method` | Web-Client writer | nothing — superseded by the typed `$ldh:httpHeaders` |
| `$Referer` | LDH writer, empty QName, with its own TO-DO | nothing |

Plus `$ac:googleMapsKey`, kept behind a comment claiming `container.xsl` needed it that a grep across both repos disproves; `$doc-types`, whose default reads the focus via `ldh:base-uri(.)` — illegal for a global param, hidden only by lazy evaluation; and `$main-doc` and `$acl:Agent`, the latter a never-populated homograph of the live `$acl:agent`.

Saxon ignores a supplied-but-undeclared parameter (verified directly), so the two repos do not have to ship in lockstep for this.

## The accessor layer

Every product-dualed function lives in the `server.xsl` ↔ `client/functions.xsl` pair, which are never compiled together — except `ldt:base#0` and `sd:endpoint#0`, which sat in the shared `imports/default.xsl` and were resolved by import precedence. They move into `server.xsl`, so the dual is module exclusivity again. That had to land **before** `$ldt:base` could be deleted from `client.xsl`, or the client compile is `XPST0008`.

`ldt:` then leaves the LDH stylesheets: `ldt:base()` → `lapp:base()` across 85 call sites and 15 raw references, prefix dropped from 25 modules. Not a renamed concept — `ApplicationImpl.getBaseURI()` is `getOriginURI().resolve("/")`, which discards any path, so the base has always been the origin plus a slash. `lapp:base()` now derives from `lapp:origin()` rather than reading Web-Client's `$ldt:base` across the repo boundary, which `server.xsl` had been doing silently since the param was deleted here.

The Java `LDT` vocabulary, the `rel=…ldt#ontology` Link header and `ldt:` in `config/*.trig` are untouched — retiring those is a public-contract change, tracked separately.

## Subsumes d12c0fc8f

Link parsing existed in three implementations: `acl:mode` and `ldh:timemap` each hand-rolled the same `analyze-string` split, and `ldh:link-targets` parsed the header again with `tokenize(',')`. One shared function serves all three, keeping the robust split and testing the marker against the parameter section only — which its own doc comment already claimed.

`d12c0fc8f` widened `ldh:timemap`'s rel terminator to admit RFC 8288's comma; this drops the terminator entirely, so a non-last entry cannot fail for that reason. Measured against the header the running instance sends, where timemap is **entry 5 of 7**: old and new agree on all five markers in use, and on three adversarial cases the new one is strictly better — a comma inside a quoted parameter *before* the rel (where `tokenize` dropped the link entirely), and a marker string occurring inside a target URI (where `contains()` over the whole entry returned a false positive).

## Naming what was written by hand

- `ldh:is-local()` — 6 copies of `starts-with($uri, lapp:origin(ldh:request-uri()) || '/')`
- `ldh:service-endpoint()` — 6 copies of `($service/sd:endpoint/@rdf:resource/xs:anyURI(.), sd:endpoint())[1]`
- `lapp:application-description()` — 10 copies of `key('apps-by-origin', lapp:origin(), $lapp:Context)`, four inside match patterns
- `$ontology-namespaces` + one `xsl:for-each` — 35 near-identical `xsl:map-entry` lines
- six SPARQL queries that existed twice each (`object-metadata-ns-query` byte-identical, the rest differing only in whitespace), plus `$acl:agent`/`$foaf:Agent`, single-sourced in `imports/default.xsl`
- violation keys: three identical declarations → one

`QueryEditorMode`'s `ldh:logo` template is removed — `layout.xsl`'s blanket empty `ac:Header` override shadows the only template that builds that link, so the mode is unreachable here.

## Verification

`make sef` compiles **only `client.xsl`**; the SSR stylesheet is the `ac:stylesheet` context parameter, compiled by Saxon-HE at runtime, so an `XPST0017` there is a first-request 500 the build never sees. Both gates run:

```bash
java -cp "$SAXON:$RES:$DATA" net.sf.saxon.Transform \
  -xsl:target/ROOT/static/com/atomgraph/linkeddatahub/xsl/layout.xsl -it:main -nogo
```

Both clean. The client gate caught the rename once — `XPST0081` in `client/block/object.xsl`, which declared `ldt` but not `lapp`. On the rebuilt stack the root document renders with no error markers, document titles resolve through the collapsed label templates, and a DBpedia URI still renders through the proxy.

### One behavioural delta

Where no application resolves, `lapp:base()` yields the relative `'/'` where `ldt:base()` raised `XTTE0780`. Both are broken states, and `resolve-uri` against the absent param was already a type error, so the symptom changes shape rather than appearing.

### Pre-existing test failures

The suite shows failures in `admin/acl/*` (targets `admin.test.localhost`, a dataspace never present in `dataspaces.trig` — 404 from `ApplicationFilter`, before any XSLT), the SSRF guards (`.env` sets `ALLOW_INTERNAL_URLS=true`), the 413 limits (`MAX_CONTENT_LENGTH` overridden), and package import (registry returns 404). None touch the XSLT layer; most never request HTML at all. No baseline was captured, so this is explanation, not proof.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PPLdcTh9VikFVpAN3iTXf4