### PR TITLE
Package stylesheets reach the client: compose and compile a SEF per import set

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,6 @@
 /fuseki
 .claude/scheduled_tasks.lock
 /cli/target
+/ui-tests/node_modules
+/ui-tests/out
+/ui-tests/test-results

--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 /target
 /.env
 /uploads
+/sef
 /nb-configuration.xml
 /node
 /node_modules

--- a/Dockerfile
+++ b/Dockerfile
@@ -19,6 +19,48 @@ COPY src /usr/src/platform/src
 COPY pom.xml /usr/src/platform/pom.xml
 
 RUN mvn -Pstandalone clean install
+# ==============================
+
+# SEF compiler: composes each dataspace's client stylesheet with its imported package
+# stylesheets and compiles the result to a SEF.
+#
+# Out-of-process because the compile peaks around 1.5 GB resident - measured 1,495,990,272
+# bytes for client.xsl - which is fatal beside a Tomcat heap sized at 75% of a 2 GB limit.
+#
+# The static tree comes from the same Maven stage the WAR does, so the modules compiled here
+# are the deployed bytes by construction: no mount, no shared volume, and no way for the
+# compiler to drift from the application it compiles for.
+
+FROM node:22-alpine AS sef-compiler
+
+# must match the SaxonJS runtime shipped in the webapp (js/saxon-js/SaxonJS3.js). A skew
+# between compiler and runtime surfaces as "Cannot read properties of undefined (reading
+# 'principalResult')" with the compile succeeding and only the export failing
+ARG XSLT3_VERSION=3.0.0-beta2
+
+RUN npm install -g "xslt3-he@${XSLT3_VERSION}"
+
+COPY --from=maven /usr/src/platform/target/ROOT/static /static
+
+COPY platform/sef-compiler/server.js /opt/sef-compiler/server.js
+
+ENV XSL_DIR=/static/com/atomgraph/linkeddatahub/xsl
+
+ENV PORT=8080
+
+# the service writes the generated wrapper and the package modules beside client.xsl, then
+# removes them again, so the stylesheet directory has to be writable by the runtime user
+RUN chown -R node:node /static
+
+USER node
+
+EXPOSE 8080
+
+HEALTHCHECK --start-period=10s --retries=3 \
+    CMD wget -q -O- http://localhost:8080/health || exit 1
+
+CMD [ "node", "/opt/sef-compiler/server.js" ]
+
 
 # ==============================
 
@@ -34,6 +76,14 @@ ARG UPLOAD_ROOT=/var/www/linkeddatahub/uploads
 
 ARG UPLOAD_CONTAINER_PATH=uploads
 
+# composed client stylesheets are served from here through a Tomcat alias, not from the WAR,
+# so they survive redeploys and stay outside the packaged application
+ARG SEF_ROOT=/var/www/linkeddatahub/sef
+
+# the compiler runs as its own service: the compile peaks near 1.5 GB and must not share this
+# container's memory limit with Tomcat
+ARG SEF_COMPILER=http://sef-compiler:8080/compile
+
 ENV SOURCE_COMMIT=$SOURCE_COMMIT
 
 WORKDIR $CATALINA_HOME
@@ -43,6 +93,10 @@ ENV STYLESHEET=static/com/atomgraph/linkeddatahub/xsl/layout.xsl
 ENV CACHE_STYLESHEET=true
 
 ENV UPLOAD_ROOT=$UPLOAD_ROOT
+
+ENV SEF_ROOT=$SEF_ROOT
+
+ENV SEF_COMPILER=$SEF_COMPILER
 
 ENV PROXY_HOST=
 
@@ -213,6 +267,8 @@ RUN useradd --no-log-init -U ldh && \
     chown -R ldh:ldh /var/linkeddatahub && \
     mkdir -p "${UPLOAD_ROOT}/${UPLOAD_CONTAINER_PATH}" && \
     chown -R ldh:ldh "$UPLOAD_ROOT" && \
+    mkdir -p "$SEF_ROOT" && \
+    chown -R ldh:ldh "$SEF_ROOT" && \
     mkdir -p /etc/letsencrypt/staging && \
     chown -R ldh:ldh /etc/letsencrypt/staging
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -41,6 +41,7 @@ services:
     depends_on:
       - fuseki-admin
       - fuseki-end-user
+      - sef-compiler
     environment:
     #  - JPDA_ADDRESS=*:8000 # debugger host - performance hit when enabled
       - CATALINA_OPTS=-XX:+UseContainerSupport -XX:MaxRAMPercentage=75 --add-exports java.base/sun.security.tools.keytool=ALL-UNNAMED # heap will use up to 75% of container's RAM
@@ -101,9 +102,21 @@ services:
       - ./datasets/owner:/var/linkeddatahub/datasets/owner
       - ./datasets/secretary:/var/linkeddatahub/datasets/secretary
       - ./uploads:/var/www/linkeddatahub/uploads
+      - ./sef:/var/www/linkeddatahub/sef
       - ./config/dev.log4j.properties:/usr/local/tomcat/webapps/ROOT/WEB-INF/classes/log4j.properties:ro
       - ./config/dataspaces.trig:/var/linkeddatahub/datasets/dataspaces.trig
       - ./config/system.trig:/var/linkeddatahub/datasets/system.trig
+  sef-compiler:
+    # composes each dataspace's client stylesheet with its package stylesheets and compiles
+    # the result to a SEF. Built from the same Dockerfile as the platform, so its copy of the
+    # static tree is the deployed one by construction
+    build:
+      context: .
+      target: sef-compiler
+    mem_limit: 3072m # the compile peaks around 1.5 GB; it must not share the platform's limit
+    restart: on-failure
+    expose:
+      - 8080 # internal only - the platform is the sole client
   fuseki-admin:
     image: atomgraph/fuseki:6.1.0
     user: root # otherwise fuseki user does not have permissions to the mounted folder which is owner by root

--- a/platform/context.xsl
+++ b/platform/context.xsl
@@ -30,8 +30,6 @@ xmlns:orcid="&orcid;"
     <xsl:param name="ldhc:clientKeyStorePassword"/>
     <xsl:param name="ldhc:clientTrustStorePassword"/>
     <xsl:param name="ldhc:uploadRoot"/>
-    <xsl:param name="ldhc:sefRoot"/>
-    <xsl:param name="ldhc:sefCompiler"/>
     <xsl:param name="ldhc:signUpCertValidity"/>
     <xsl:param name="ldhc:contextDataset"/>
     <xsl:param name="ldhc:authQuery"/>
@@ -67,16 +65,6 @@ xmlns:orcid="&orcid;"
         <xsl:copy>
             <xsl:apply-templates select="@*"/>
 
-            <!-- composed per-dataspace client stylesheets live outside the WAR but are served
-                 under /static/, so the default servlet handles them: no Jersey, no authorization
-                 filter, and nginx's immutable caching and CORS headers apply as they do to the
-                 stylesheets built into the image -->
-            <xsl:if test="$ldhc:sefRoot">
-                <xsl:attribute name="aliases">
-                    <xsl:text>/static/xsl/sef=</xsl:text>
-                    <xsl:value-of select="substring-after($ldhc:sefRoot, 'file://')"/>
-                </xsl:attribute>
-            </xsl:if>
 
             <xsl:if test="$ac:stylesheet">
                 <Parameter name="&ac;stylesheet" value="{$ac:stylesheet}" override="false"/>
@@ -116,12 +104,6 @@ xmlns:orcid="&orcid;"
             </xsl:if>
             <xsl:if test="$ldhc:uploadRoot">
                 <Parameter name="&ldhc;uploadRoot" value="{$ldhc:uploadRoot}" override="false"/>
-            </xsl:if>
-            <xsl:if test="$ldhc:sefRoot">
-                <Parameter name="&ldhc;sefRoot" value="{$ldhc:sefRoot}" override="false"/>
-            </xsl:if>
-            <xsl:if test="$ldhc:sefCompiler">
-                <Parameter name="&ldhc;sefCompiler" value="{$ldhc:sefCompiler}" override="false"/>
             </xsl:if>
             <xsl:if test="$ldhc:signUpCertValidity">
                 <Parameter name="&ldhc;signUpCertValidity" value="{$ldhc:signUpCertValidity}" override="false"/>

--- a/platform/context.xsl
+++ b/platform/context.xsl
@@ -30,6 +30,8 @@ xmlns:orcid="&orcid;"
     <xsl:param name="ldhc:clientKeyStorePassword"/>
     <xsl:param name="ldhc:clientTrustStorePassword"/>
     <xsl:param name="ldhc:uploadRoot"/>
+    <xsl:param name="ldhc:sefRoot"/>
+    <xsl:param name="ldhc:sefCompiler"/>
     <xsl:param name="ldhc:signUpCertValidity"/>
     <xsl:param name="ldhc:contextDataset"/>
     <xsl:param name="ldhc:authQuery"/>
@@ -64,6 +66,17 @@ xmlns:orcid="&orcid;"
     <xsl:template match="Context">
         <xsl:copy>
             <xsl:apply-templates select="@*"/>
+
+            <!-- composed per-dataspace client stylesheets live outside the WAR but are served
+                 under /static/, so the default servlet handles them: no Jersey, no authorization
+                 filter, and nginx's immutable caching and CORS headers apply as they do to the
+                 stylesheets built into the image -->
+            <xsl:if test="$ldhc:sefRoot">
+                <xsl:attribute name="aliases">
+                    <xsl:text>/static/xsl/sef=</xsl:text>
+                    <xsl:value-of select="substring-after($ldhc:sefRoot, 'file://')"/>
+                </xsl:attribute>
+            </xsl:if>
 
             <xsl:if test="$ac:stylesheet">
                 <Parameter name="&ac;stylesheet" value="{$ac:stylesheet}" override="false"/>
@@ -103,6 +116,12 @@ xmlns:orcid="&orcid;"
             </xsl:if>
             <xsl:if test="$ldhc:uploadRoot">
                 <Parameter name="&ldhc;uploadRoot" value="{$ldhc:uploadRoot}" override="false"/>
+            </xsl:if>
+            <xsl:if test="$ldhc:sefRoot">
+                <Parameter name="&ldhc;sefRoot" value="{$ldhc:sefRoot}" override="false"/>
+            </xsl:if>
+            <xsl:if test="$ldhc:sefCompiler">
+                <Parameter name="&ldhc;sefCompiler" value="{$ldhc:sefCompiler}" override="false"/>
             </xsl:if>
             <xsl:if test="$ldhc:signUpCertValidity">
                 <Parameter name="&ldhc;signUpCertValidity" value="{$ldhc:signUpCertValidity}" override="false"/>

--- a/platform/entrypoint.sh
+++ b/platform/entrypoint.sh
@@ -1244,7 +1244,20 @@ eval "$transform"
 # /static/ by the default servlet through a Context alias. Added here rather than in context.xsl
 # because that transform has no argv budget left for another --stringparam
 if [ -n "$SEF_ROOT" ]; then
-    xmlstarlet ed --inplace --insert "/Context" --type attr --name "aliases" --value "/static/xsl/sef=$SEF_ROOT" conf/Catalina/localhost/ROOT.xml
+    # A PostResources set, not the Context "aliases" attribute: that attribute was removed after
+    # Tomcat 7 and 10 rejects it outright with "failed to set property [aliases]", leaving the path
+    # 404 with nothing else to show for it. PostResources is the supported way to mount a directory
+    # outside the WAR into the web application, and being POST it is consulted only when the WAR has
+    # no such resource, so it cannot shadow anything the platform ships.
+    # Deleted before being added because a restart reuses the container filesystem and runs this again.
+    xmlstarlet ed --inplace \
+      -d "/Context/Resources" \
+      -s "/Context" -t elem -n "Resources" \
+      -s "/Context/Resources" -t elem -n "PostResources" \
+      -i "/Context/Resources/PostResources" -t attr -n "className" -v "org.apache.catalina.webresources.DirResourceSet" \
+      -i "/Context/Resources/PostResources" -t attr -n "base" -v "$SEF_ROOT" \
+      -i "/Context/Resources/PostResources" -t attr -n "webAppMount" -v "/static/xsl/sef" \
+      conf/Catalina/localhost/ROOT.xml
 fi
 
 # change webapp (servlet) configuration

--- a/platform/entrypoint.sh
+++ b/platform/entrypoint.sh
@@ -176,6 +176,16 @@ if [ -z "$UPLOAD_ROOT" ]; then
     exit 1
 fi
 
+if [ -z "$SEF_ROOT" ]; then
+    echo '$SEF_ROOT not set'
+    exit 1
+fi
+
+if [ -z "$SEF_COMPILER" ]; then
+    echo '$SEF_COMPILER not set'
+    exit 1
+fi
+
 if [ -z "$SIGN_UP_CERT_VALIDITY" ]; then
     echo '$SIGN_UP_CERT_VALIDITY not set'
     exit 1
@@ -1041,6 +1051,8 @@ CLIENT_TRUSTSTORE_PARAM="--stringparam ldhc:clientTrustStore 'file://$CLIENT_TRU
 CLIENT_KEYSTORE_PASSWORD_PARAM="--stringparam ldhc:clientKeyStorePassword '$CLIENT_KEYSTORE_PASSWORD' "
 CLIENT_TRUSTSTORE_PASSWORD_PARAM="--stringparam ldhc:clientTrustStorePassword '$CLIENT_TRUSTSTORE_PASSWORD' "
 UPLOAD_ROOT_PARAM="--stringparam ldhc:uploadRoot 'file://$UPLOAD_ROOT' "
+SEF_ROOT_PARAM="--stringparam ldhc:sefRoot 'file://$SEF_ROOT' "
+SEF_COMPILER_PARAM="--stringparam ldhc:sefCompiler '$SEF_COMPILER' "
 SIGN_UP_CERT_VALIDITY_PARAM="--stringparam ldhc:signUpCertValidity '$SIGN_UP_CERT_VALIDITY' "
 CONTEXT_DATASET_PARAM="--stringparam ldhc:contextDataset '$webapp_context_dataset' "
 MAIL_SMTP_HOST_PARAM="--stringparam mail.smtp.host '$MAIL_SMTP_HOST' "
@@ -1199,6 +1211,8 @@ transform="xsltproc \
   $CLIENT_KEYSTORE_PASSWORD_PARAM \
   $CLIENT_TRUSTSTORE_PASSWORD_PARAM \
   $UPLOAD_ROOT_PARAM \
+  $SEF_ROOT_PARAM \
+  $SEF_COMPILER_PARAM \
   $SIGN_UP_CERT_VALIDITY_PARAM \
   $CONTEXT_DATASET_PARAM \
   $AUTH_QUERY_PARAM \

--- a/platform/entrypoint.sh
+++ b/platform/entrypoint.sh
@@ -176,16 +176,6 @@ if [ -z "$UPLOAD_ROOT" ]; then
     exit 1
 fi
 
-if [ -z "$SEF_ROOT" ]; then
-    echo '$SEF_ROOT not set'
-    exit 1
-fi
-
-if [ -z "$SEF_COMPILER" ]; then
-    echo '$SEF_COMPILER not set'
-    exit 1
-fi
-
 if [ -z "$SIGN_UP_CERT_VALIDITY" ]; then
     echo '$SIGN_UP_CERT_VALIDITY not set'
     exit 1
@@ -1051,8 +1041,6 @@ CLIENT_TRUSTSTORE_PARAM="--stringparam ldhc:clientTrustStore 'file://$CLIENT_TRU
 CLIENT_KEYSTORE_PASSWORD_PARAM="--stringparam ldhc:clientKeyStorePassword '$CLIENT_KEYSTORE_PASSWORD' "
 CLIENT_TRUSTSTORE_PASSWORD_PARAM="--stringparam ldhc:clientTrustStorePassword '$CLIENT_TRUSTSTORE_PASSWORD' "
 UPLOAD_ROOT_PARAM="--stringparam ldhc:uploadRoot 'file://$UPLOAD_ROOT' "
-SEF_ROOT_PARAM="--stringparam ldhc:sefRoot 'file://$SEF_ROOT' "
-SEF_COMPILER_PARAM="--stringparam ldhc:sefCompiler '$SEF_COMPILER' "
 SIGN_UP_CERT_VALIDITY_PARAM="--stringparam ldhc:signUpCertValidity '$SIGN_UP_CERT_VALIDITY' "
 CONTEXT_DATASET_PARAM="--stringparam ldhc:contextDataset '$webapp_context_dataset' "
 MAIL_SMTP_HOST_PARAM="--stringparam mail.smtp.host '$MAIL_SMTP_HOST' "
@@ -1126,6 +1114,18 @@ fi
 
 if [ -n "$JWKS_CACHE_EXPIRATION" ]; then
     export CATALINA_OPTS="$CATALINA_OPTS -Dcom.atomgraph.linkeddatahub.jwksCacheExpiration=$JWKS_CACHE_EXPIRATION"
+fi
+
+# where composed client stylesheets are written and which service compiles them. System properties
+# rather than --stringparam: xsltproc's MAX_PARAMETERS is a hard 64 argv slots, two per parameter,
+# and the ROOT.xml transform already sits at that ceiling once the optional mail and OAuth settings
+# are configured - adding to it takes the container down at startup rather than failing visibly
+if [ -n "$SEF_ROOT" ]; then
+    export CATALINA_OPTS="$CATALINA_OPTS -Dcom.atomgraph.linkeddatahub.sefRoot=file://$SEF_ROOT"
+fi
+
+if [ -n "$SEF_COMPILER" ]; then
+    export CATALINA_OPTS="$CATALINA_OPTS -Dcom.atomgraph.linkeddatahub.sefCompiler=$SEF_COMPILER"
 fi
 
 if [ -n "$MAX_CONTENT_LENGTH" ]; then
@@ -1211,8 +1211,6 @@ transform="xsltproc \
   $CLIENT_KEYSTORE_PASSWORD_PARAM \
   $CLIENT_TRUSTSTORE_PASSWORD_PARAM \
   $UPLOAD_ROOT_PARAM \
-  $SEF_ROOT_PARAM \
-  $SEF_COMPILER_PARAM \
   $SIGN_UP_CERT_VALIDITY_PARAM \
   $CONTEXT_DATASET_PARAM \
   $AUTH_QUERY_PARAM \
@@ -1241,6 +1239,13 @@ transform="xsltproc \
   conf/Catalina/localhost/ROOT.xml"
 
 eval "$transform"
+
+# composed client stylesheets live outside the WAR so they survive redeploys, and are served under
+# /static/ by the default servlet through a Context alias. Added here rather than in context.xsl
+# because that transform has no argv budget left for another --stringparam
+if [ -n "$SEF_ROOT" ]; then
+    xmlstarlet ed --inplace --insert "/Context" --type attr --name "aliases" --value "/static/xsl/sef=$SEF_ROOT" conf/Catalina/localhost/ROOT.xml
+fi
 
 # change webapp (servlet) configuration
 

--- a/platform/sef-compiler/server.js
+++ b/platform/sef-compiler/server.js
@@ -1,0 +1,220 @@
+/**
+ * SEF compiler service.
+ *
+ * Saxon-JS refuses to compile XSLT in the browser (SaxonJS.compile() is gated on inBrowser()
+ * and throws SXJS0006), and independently compiled per-package SEFs cannot compose, because
+ * xsl:import precedence is resolved at compile time. So a dataspace that imports packages
+ * needs its client stylesheet composed and compiled server-side, per import set.
+ *
+ * This runs out-of-process rather than inside the platform container because the compile peaks
+ * around 1.5 GB of resident memory - measured 1,495,990,272 bytes for client.xsl - which would
+ * be fatal next to a Tomcat heap sized at 75% of a 2 GB limit.
+ *
+ * The service is stateless: the caller sends the package modules inline, and the static tree
+ * this image was built from supplies client.xsl and everything it imports. That tree arrives by
+ * COPY --from the same Maven stage the WAR comes from, so the modules compiled here are the
+ * deployed bytes by construction - no mount, no volume, and no way to drift.
+ */
+
+import { createServer } from 'node:http';
+import { execFile } from 'node:child_process';
+import { gzip } from 'node:zlib';
+import { writeFile, unlink, readFile, access } from 'node:fs/promises';
+import { join } from 'node:path';
+
+const PORT = Number(process.env.PORT ?? 8080);
+// the directory client.xsl lives in: the wrapper is written beside it so that -relocate:on
+// records every module's base URI the same way the build's own SEF does
+const XSL_DIR = process.env.XSL_DIR ?? '/static/com/atomgraph/linkeddatahub/xsl';
+const TIMEOUT_MS = Number(process.env.COMPILE_TIMEOUT_MS ?? 120_000);
+const MAX_OLD_SPACE_MB = Number(process.env.COMPILE_MAX_OLD_SPACE_MB ?? 2560);
+const MAX_BODY_BYTES = Number(process.env.MAX_BODY_BYTES ?? 8 * 1024 * 1024);
+
+const WRAPPER = 'ldh-composed.xsl';
+const OUTPUT = 'ldh-composed.sef.json';
+
+// One compile at a time. Two concurrent 1.5 GB compiles is the OOM this service exists to avoid,
+// so a second request is refused rather than queued - the caller already serialises per key.
+let busy = false;
+
+const gzipAsync = (buf) => new Promise((resolve, reject) =>
+    gzip(buf, (err, out) => err ? reject(err) : resolve(out)));
+
+/** Composes the wrapper: client.xsl first, then each package, so packages take higher precedence. */
+function wrapper(names)
+{
+    const imports = ['client.xsl', ...names].
+        map((href) => `    <xsl:import href="${href}"/>`).
+        join('\n');
+
+    return `<?xml version="1.0" encoding="UTF-8"?>
+<xsl:stylesheet version="3.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
+${imports}
+</xsl:stylesheet>
+`;
+}
+
+function readBody(req)
+{
+    return new Promise((resolve, reject) =>
+    {
+        const chunks = [];
+        let size = 0;
+
+        req.on('data', (chunk) =>
+        {
+            size += chunk.length;
+            if (size > MAX_BODY_BYTES)
+            {
+                reject(Object.assign(new Error('Request body too large'), { statusCode: 413 }));
+                req.destroy();
+                return;
+            }
+            chunks.push(chunk);
+        });
+        req.on('end', () => resolve(Buffer.concat(chunks)));
+        req.on('error', reject);
+    });
+}
+
+/** Package module names are used as filenames, so they must not escape the xsl directory. */
+function validName(name)
+{
+    return typeof name === 'string' && /^[A-Za-z0-9._-]+\.xsl$/.test(name) && !name.startsWith('.');
+}
+
+function compile()
+{
+    return new Promise((resolve) =>
+    {
+        execFile('xslt3-he',
+            [
+                `-xsl:${join(XSL_DIR, WRAPPER)}`,
+                `-export:${join(XSL_DIR, OUTPUT)}`,
+                '-nogo',
+                '-ns:##html5',
+                '-relocate:on'
+            ],
+            {
+                timeout: TIMEOUT_MS,
+                maxBuffer: 4 * 1024 * 1024,
+                env: { ...process.env, NODE_OPTIONS: `--max-old-space-size=${MAX_OLD_SPACE_MB}` }
+            },
+            (error, stdout, stderr) => resolve({ error, stdout, stderr }));
+    });
+}
+
+async function handleCompile(req, res)
+{
+    if (busy)
+    {
+        res.writeHead(503, { 'content-type': 'application/json', 'retry-after': '30' });
+        res.end(JSON.stringify({ error: 'A compilation is already in progress' }));
+        return;
+    }
+
+    let body;
+    try
+    {
+        body = JSON.parse((await readBody(req)).toString('utf-8'));
+    }
+    catch (ex)
+    {
+        res.writeHead(ex.statusCode ?? 400, { 'content-type': 'application/json' });
+        res.end(JSON.stringify({ error: `Malformed request: ${ex.message}` }));
+        return;
+    }
+
+    const imports = Array.isArray(body?.imports) ? body.imports : null;
+    if (!imports || !imports.every((imp) => validName(imp?.name) && typeof imp?.content === 'string'))
+    {
+        res.writeHead(400, { 'content-type': 'application/json' });
+        res.end(JSON.stringify({ error: 'Expected { imports: [ { name: "<name>.xsl", content: "..." } ] }' }));
+        return;
+    }
+
+    busy = true;
+    const written = [];
+    try
+    {
+        for (const imp of imports)
+        {
+            const path = join(XSL_DIR, imp.name);
+            await writeFile(path, imp.content, 'utf-8');
+            written.push(path);
+        }
+
+        const wrapperPath = join(XSL_DIR, WRAPPER);
+        await writeFile(wrapperPath, wrapper(imports.map((imp) => imp.name)), 'utf-8');
+        written.push(wrapperPath);
+
+        const started = Date.now();
+        const { error, stderr } = await compile();
+        const outputPath = join(XSL_DIR, OUTPUT);
+
+        // xslt3-he reports compilation errors on stdout/stderr and may still exit 0, so the
+        // export's existence is the real success test
+        let exported = true;
+        try { await access(outputPath); } catch { exported = false; }
+
+        if (error || !exported)
+        {
+            const detail = (stderr || '').trim() || error?.message || 'Compilation produced no output';
+            console.error(`compile failed after ${Date.now() - started}ms: ${detail}`);
+            res.writeHead(422, { 'content-type': 'application/json' });
+            res.end(JSON.stringify({ error: detail }));
+            return;
+        }
+
+        written.push(outputPath);
+        const sef = await readFile(outputPath);
+        console.log(`compiled ${imports.length} package module(s) in ${Date.now() - started}ms, ${sef.length} bytes`);
+
+        // 19 MB down to under 1 MB; the caller is on the same network but this is still worth it
+        const accepts = (req.headers['accept-encoding'] ?? '').includes('gzip');
+        const payload = accepts ? await gzipAsync(sef) : sef;
+
+        res.writeHead(200, {
+            'content-type': 'application/json',
+            'content-length': String(payload.length),
+            ...(accepts ? { 'content-encoding': 'gzip' } : {})
+        });
+        res.end(payload);
+    }
+    catch (ex)
+    {
+        console.error(`compile error: ${ex.stack ?? ex}`);
+        res.writeHead(500, { 'content-type': 'application/json' });
+        res.end(JSON.stringify({ error: String(ex.message ?? ex) }));
+    }
+    finally
+    {
+        // the static tree is this container's private copy, but a leftover wrapper would be
+        // picked up by the next compile, so the directory is always returned to its built state
+        await Promise.all(written.map((path) => unlink(path).catch(() => {})));
+        busy = false;
+    }
+}
+
+const server = createServer((req, res) =>
+{
+    if (req.method === 'GET' && req.url === '/health')
+    {
+        res.writeHead(busy ? 503 : 200, { 'content-type': 'application/json' });
+        res.end(JSON.stringify({ status: busy ? 'busy' : 'ready' }));
+        return;
+    }
+
+    if (req.method === 'POST' && req.url === '/compile')
+    {
+        handleCompile(req, res);
+        return;
+    }
+
+    res.writeHead(404, { 'content-type': 'application/json' });
+    res.end(JSON.stringify({ error: 'Not found' }));
+});
+
+server.headersTimeout = TIMEOUT_MS + 30_000;
+server.requestTimeout = TIMEOUT_MS + 30_000;
+server.listen(PORT, () => console.log(`SEF compiler listening on ${PORT}, stylesheets at ${XSL_DIR}`));

--- a/src/main/java/com/atomgraph/linkeddatahub/Application.java
+++ b/src/main/java/com/atomgraph/linkeddatahub/Application.java
@@ -259,6 +259,9 @@ public class Application extends ResourceConfig
 
     private static final Logger log = LoggerFactory.getLogger(Application.class);
 
+    /** Webapp path of the client stylesheet built at package time. Its digest fingerprints the platform build, so a composed stylesheet is invalidated by an upgrade */
+    public static final String CLIENT_SEF_PATH = "/static/com/atomgraph/linkeddatahub/xsl/client.xsl.sef.json";
+
     private final ExecutorService importThreadPool;
     private final ServletConfig servletConfig;
     private final EventBus eventBus = new EventBus();
@@ -274,7 +277,7 @@ public class Application extends ResourceConfig
     private final XsltExecutable xsltExec;
     private final boolean cacheStylesheet;
     private final boolean resolvingUncached;
-    private final URI baseURI, uploadRoot;
+    private final URI baseURI, uploadRoot, sefRoot;
     private final boolean invalidateCache;
     private final Integer cookieMaxAge;
     private final boolean enableLinkedDataProxy;
@@ -305,6 +308,7 @@ public class Application extends ResourceConfig
     private final URI backendProxyEndUser;
     private Map<String, com.atomgraph.linkeddatahub.model.ServiceContext> serviceContextMap;
     private final com.atomgraph.linkeddatahub.server.util.GraphVersioningService graphVersioningService;
+    private final com.atomgraph.linkeddatahub.server.util.ClientStylesheetService clientStylesheetService;
 
     /**
      * Constructs system application and configures it using sevlet config.
@@ -342,6 +346,8 @@ public class Application extends ResourceConfig
             servletConfig.getServletContext().getInitParameter(LDHC.proxyHost.getURI()) != null ? servletConfig.getServletContext().getInitParameter(LDHC.proxyHost.getURI()) : null,
             servletConfig.getServletContext().getInitParameter(LDHC.proxyPort.getURI()) != null ? Integer.valueOf(servletConfig.getServletContext().getInitParameter(LDHC.proxyPort.getURI())) : null,
             servletConfig.getServletContext().getInitParameter(LDHC.uploadRoot.getURI()) != null ? servletConfig.getServletContext().getInitParameter(LDHC.uploadRoot.getURI()) : null,
+            servletConfig.getServletContext().getInitParameter(LDHC.sefRoot.getURI()) != null ? servletConfig.getServletContext().getInitParameter(LDHC.sefRoot.getURI()) : null,
+            servletConfig.getServletContext().getInitParameter(LDHC.sefCompiler.getURI()) != null ? servletConfig.getServletContext().getInitParameter(LDHC.sefCompiler.getURI()) : null,
             servletConfig.getServletContext().getInitParameter(LDHC.invalidateCache.getURI()) != null ? Boolean.parseBoolean(servletConfig.getServletContext().getInitParameter(LDHC.invalidateCache.getURI())) : false,
             servletConfig.getServletContext().getInitParameter(LDHC.cookieMaxAge.getURI()) != null ? Integer.valueOf(servletConfig.getServletContext().getInitParameter(LDHC.cookieMaxAge.getURI())) : null,
             servletConfig.getServletContext().getInitParameter(LDHC.enableLinkedDataProxy.getURI()) != null ? Boolean.parseBoolean(servletConfig.getServletContext().getInitParameter(LDHC.enableLinkedDataProxy.getURI())) : true,
@@ -404,6 +410,8 @@ public class Application extends ResourceConfig
      * @param proxyHostname client's URI rewrite hostname
      * @param proxyPort client's URI rewrite port
      * @param uploadRootString location of the root folder for file uploads
+     * @param sefRootString location of the root folder for composed client stylesheets
+     * @param sefCompilerString endpoint of the client stylesheet compiler service
      * @param invalidateCache true if Varnish proxy cache should be invalidated
      * @param cookieMaxAge max age of auth cookies
      * @param enableLinkedDataProxy true if Linked Data proxy is enabled
@@ -438,7 +446,7 @@ public class Application extends ResourceConfig
             final String documentTypeQueryString, final String documentOwnerQueryString, final String aclQueryString, final String ownerAclQueryString,
             final String webIDQueryString, final String agentQueryString, final String userAccountQueryString, final String ontologyQueryString,
             final String baseURIString, final String proxyScheme, final String proxyHostname, final Integer proxyPort,
-            final String uploadRootString, final boolean invalidateCache,
+            final String uploadRootString, final String sefRootString, final String sefCompilerString, final boolean invalidateCache,
             final Integer cookieMaxAge, final boolean enableLinkedDataProxy, final boolean allowInternalUrls, final Integer maxContentLength,
             final Integer maxConnPerRoute, final Integer maxTotalConn, final Integer maxRequestRetries, final Integer connectionRequestTimeout,
             final Integer socketTimeout, final Integer connectTimeout, final Long connectionTimeToLive, final Integer validateAfterInactivity, final Integer maxImportThreads,
@@ -595,6 +603,18 @@ public class Application extends ResourceConfig
         catch (URISyntaxException ex)
         {
             if (log.isErrorEnabled()) log.error("Upload root URI syntax error: {}", ex);
+            throw new IllegalStateException(ex);
+        }
+
+        try
+        {
+            // optional: an instance whose applications import no packages never composes a client
+            // stylesheet, so a missing SEF root disables that feature rather than failing startup
+            this.sefRoot = sefRootString != null ? new URI(sefRootString) : null;
+        }
+        catch (URISyntaxException ex)
+        {
+            if (log.isErrorEnabled()) log.error("SEF root URI syntax error: {}", ex);
             throw new IllegalStateException(ex);
         }
         
@@ -788,6 +808,31 @@ public class Application extends ResourceConfig
 
             graphVersioningService = new com.atomgraph.linkeddatahub.server.util.GraphVersioningService(ctxUnion, verifiedClient);
             servletConfig.getServletContext().setAttribute(com.atomgraph.linkeddatahub.server.util.GraphVersioningService.class.getName(), graphVersioningService); // used in GraphVersioningListener to shut down its executor
+
+            // composing client stylesheets is optional: without a SEF root, a compiler endpoint, or the
+            // stylesheet built into the webapp to fingerprint the platform with, package rules simply stay
+            // server-side, which is how the platform behaved before this existed
+            com.atomgraph.linkeddatahub.server.util.ClientStylesheetService stylesheetService = null;
+            if (sefRoot != null && sefCompilerString != null)
+            {
+                try (InputStream stockSEF = servletConfig.getServletContext().getResourceAsStream(CLIENT_SEF_PATH))
+                {
+                    if (stockSEF == null)
+                    {
+                        if (log.isWarnEnabled()) log.warn("Client stylesheet '{}' not found in the webapp, package stylesheets will not reach the client", CLIENT_SEF_PATH);
+                    }
+                    else
+                        stylesheetService = new com.atomgraph.linkeddatahub.server.util.ClientStylesheetService(
+                            java.nio.file.Paths.get(sefRoot), URI.create(sefCompilerString), client, stockSEF);
+                }
+                catch (IOException ex)
+                {
+                    if (log.isErrorEnabled()) log.error("Could not start the client stylesheet service, package stylesheets will not reach the client", ex);
+                }
+            }
+            clientStylesheetService = stylesheetService;
+            if (clientStylesheetService != null)
+                servletConfig.getServletContext().setAttribute(com.atomgraph.linkeddatahub.server.util.ClientStylesheetService.class.getName(), clientStylesheetService); // used in ClientStylesheetListener to shut down its executor
 
             endUserRepositories = new ConcurrentHashMap<>();
             // global graph repository: bundled vocabularies/ontologies mapped from the prefix-mapping config
@@ -2238,6 +2283,16 @@ public class Application extends ResourceConfig
     {
         return uploadRoot;
     }
+
+    /**
+     * Returns URL of the server directory holding composed client stylesheets, or null if not configured.
+     *
+     * @return path as URI, or null
+     */
+    public URI getSEFRoot()
+    {
+        return sefRoot;
+    }
     
     /**
      * Returns RDF dataset with LinkedDataHub application descriptions.
@@ -2452,6 +2507,16 @@ public class Application extends ResourceConfig
     public com.atomgraph.linkeddatahub.server.util.GraphVersioningService getGraphVersioningService()
     {
         return graphVersioningService;
+    }
+
+    /**
+     * Returns the service that composes and compiles client stylesheets, or null if not configured.
+     *
+     * @return client stylesheet service, or null
+     */
+    public com.atomgraph.linkeddatahub.server.util.ClientStylesheetService getClientStylesheetService()
+    {
+        return clientStylesheetService;
     }
 
     /**

--- a/src/main/java/com/atomgraph/linkeddatahub/Application.java
+++ b/src/main/java/com/atomgraph/linkeddatahub/Application.java
@@ -346,8 +346,11 @@ public class Application extends ResourceConfig
             servletConfig.getServletContext().getInitParameter(LDHC.proxyHost.getURI()) != null ? servletConfig.getServletContext().getInitParameter(LDHC.proxyHost.getURI()) : null,
             servletConfig.getServletContext().getInitParameter(LDHC.proxyPort.getURI()) != null ? Integer.valueOf(servletConfig.getServletContext().getInitParameter(LDHC.proxyPort.getURI())) : null,
             servletConfig.getServletContext().getInitParameter(LDHC.uploadRoot.getURI()) != null ? servletConfig.getServletContext().getInitParameter(LDHC.uploadRoot.getURI()) : null,
-            servletConfig.getServletContext().getInitParameter(LDHC.sefRoot.getURI()) != null ? servletConfig.getServletContext().getInitParameter(LDHC.sefRoot.getURI()) : null,
-            servletConfig.getServletContext().getInitParameter(LDHC.sefCompiler.getURI()) != null ? servletConfig.getServletContext().getInitParameter(LDHC.sefCompiler.getURI()) : null,
+            // system properties rather than context parameters: the ROOT.xml transform that produces
+            // those is at xsltproc's MAX_PARAMETERS ceiling, so infrastructure settings go through
+            // CATALINA_OPTS like the HTTP client timeouts and cache expirations already do
+            System.getProperty("com.atomgraph.linkeddatahub.sefRoot"),
+            System.getProperty("com.atomgraph.linkeddatahub.sefCompiler"),
             servletConfig.getServletContext().getInitParameter(LDHC.invalidateCache.getURI()) != null ? Boolean.parseBoolean(servletConfig.getServletContext().getInitParameter(LDHC.invalidateCache.getURI())) : false,
             servletConfig.getServletContext().getInitParameter(LDHC.cookieMaxAge.getURI()) != null ? Integer.valueOf(servletConfig.getServletContext().getInitParameter(LDHC.cookieMaxAge.getURI())) : null,
             servletConfig.getServletContext().getInitParameter(LDHC.enableLinkedDataProxy.getURI()) != null ? Boolean.parseBoolean(servletConfig.getServletContext().getInitParameter(LDHC.enableLinkedDataProxy.getURI())) : true,

--- a/src/main/java/com/atomgraph/linkeddatahub/Application.java
+++ b/src/main/java/com/atomgraph/linkeddatahub/Application.java
@@ -812,6 +812,18 @@ public class Application extends ResourceConfig
             graphVersioningService = new com.atomgraph.linkeddatahub.server.util.GraphVersioningService(ctxUnion, verifiedClient);
             servletConfig.getServletContext().setAttribute(com.atomgraph.linkeddatahub.server.util.GraphVersioningService.class.getName(), graphVersioningService); // used in GraphVersioningListener to shut down its executor
 
+
+            endUserRepositories = new ConcurrentHashMap<>();
+            // global graph repository: bundled vocabularies/ontologies mapped from the prefix-mapping config
+            repository = new PrefixGraphRepository(GraphStoreClient.create(client, mediaTypes));
+            if (prefixMappingConfig != null)
+            {
+                Model prefixMappingModel = ModelFactory.createDefaultModel();
+                RDFParser.create().source(prefixMappingConfig).streamManager(repository.getStreamManager()).build().parse(prefixMappingModel);
+                repository.processConfig(prefixMappingModel);
+            }
+            resolver = new SameSiteSourceResolver(repository, GraphStoreClient.create(client, mediaTypes), resolvingUncached, baseURI);
+
             // composing client stylesheets is optional: without a SEF root, a compiler endpoint, or the
             // stylesheet built into the webapp to fingerprint the platform with, package rules simply stay
             // server-side, which is how the platform behaved before this existed
@@ -826,7 +838,7 @@ public class Application extends ResourceConfig
                     }
                     else
                         stylesheetService = new com.atomgraph.linkeddatahub.server.util.ClientStylesheetService(
-                            java.nio.file.Paths.get(sefRoot), URI.create(sefCompilerString), client, stockSEF);
+                            java.nio.file.Paths.get(sefRoot), URI.create(sefCompilerString), client, repository, stockSEF);
                 }
                 catch (IOException ex)
                 {
@@ -836,17 +848,6 @@ public class Application extends ResourceConfig
             clientStylesheetService = stylesheetService;
             if (clientStylesheetService != null)
                 servletConfig.getServletContext().setAttribute(com.atomgraph.linkeddatahub.server.util.ClientStylesheetService.class.getName(), clientStylesheetService); // used in ClientStylesheetListener to shut down its executor
-
-            endUserRepositories = new ConcurrentHashMap<>();
-            // global graph repository: bundled vocabularies/ontologies mapped from the prefix-mapping config
-            repository = new PrefixGraphRepository(GraphStoreClient.create(client, mediaTypes));
-            if (prefixMappingConfig != null)
-            {
-                Model prefixMappingModel = ModelFactory.createDefaultModel();
-                RDFParser.create().source(prefixMappingConfig).streamManager(repository.getStreamManager()).build().parse(prefixMappingModel);
-                repository.processConfig(prefixMappingModel);
-            }
-            resolver = new SameSiteSourceResolver(repository, GraphStoreClient.create(client, mediaTypes), resolvingUncached, baseURI);
 
             if (mailUser != null && mailPassword !=  null) // enable SMTP authentication
             {

--- a/src/main/java/com/atomgraph/linkeddatahub/listener/ClientStylesheetListener.java
+++ b/src/main/java/com/atomgraph/linkeddatahub/listener/ClientStylesheetListener.java
@@ -1,0 +1,44 @@
+/**
+ *  Copyright 2026 Martynas Jusevičius <martynas@atomgraph.com>
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ */
+package com.atomgraph.linkeddatahub.listener;
+
+import com.atomgraph.linkeddatahub.server.util.ClientStylesheetService;
+import jakarta.servlet.ServletContextEvent;
+import jakarta.servlet.ServletContextListener;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Client stylesheet listener.
+ * Shuts down the compilation executor of the client stylesheet service.
+ *
+ * @author Martynas Jusevičius {@literal <martynas@atomgraph.com>}
+ */
+public class ClientStylesheetListener implements ServletContextListener
+{
+
+    private static final Logger log = LoggerFactory.getLogger(ClientStylesheetListener.class);
+
+    @Override
+    public void contextDestroyed(ServletContextEvent sce)
+    {
+        if (log.isDebugEnabled()) log.debug("Shutting down {} thread pool", getClass().getName());
+        ClientStylesheetService service = (ClientStylesheetService)sce.getServletContext().getAttribute(ClientStylesheetService.class.getName());
+        if (service != null) service.shutdown();
+    }
+
+}

--- a/src/main/java/com/atomgraph/linkeddatahub/server/filter/response/ResponseHeadersFilter.java
+++ b/src/main/java/com/atomgraph/linkeddatahub/server/filter/response/ResponseHeadersFilter.java
@@ -30,6 +30,7 @@ import com.atomgraph.linkeddatahub.server.security.AuthorizationContext;
 import com.atomgraph.linkeddatahub.server.util.Link;
 import com.atomgraph.linkeddatahub.vocabulary.ACL;
 import com.atomgraph.linkeddatahub.vocabulary.LAPP;
+import com.atomgraph.linkeddatahub.vocabulary.LDH;
 import com.atomgraph.linkeddatahub.writer.TimeMapWriter;
 import java.io.IOException;
 import java.net.URI;
@@ -136,6 +137,13 @@ public class ResponseHeadersFilter implements ContainerResponseFilter
             // add Link rel=ac:stylesheet, if the stylesheet URI is specified
             if (application.getStylesheet() != null)
                 response.getHeaders().add(HttpHeaders.LINK, new Link(URI.create(application.getStylesheet().getURI()), AC.stylesheet.getURI(), null));
+
+            // the compiled client stylesheet composed with this application's packages, set by
+            // XsltExecutableFilter only once it exists. Advertised rather than injected as a stylesheet
+            // parameter, so the client reads it the same way it reads acl:mode and the Memento relations
+            Object clientStylesheet = request.getProperty(LDH.clientStylesheet.getURI());
+            if (clientStylesheet != null)
+                response.getHeaders().add(HttpHeaders.LINK, new Link(application.getBaseURI().resolve(clientStylesheet.toString()), LDH.clientStylesheet.getURI(), null));
         }
 
         if (response.getHeaders().get(HttpHeaders.LINK) != null)

--- a/src/main/java/com/atomgraph/linkeddatahub/server/filter/response/XsltExecutableFilter.java
+++ b/src/main/java/com/atomgraph/linkeddatahub/server/filter/response/XsltExecutableFilter.java
@@ -18,7 +18,9 @@ package com.atomgraph.linkeddatahub.server.filter.response;
 
 import com.atomgraph.client.vocabulary.AC;
 import com.atomgraph.linkeddatahub.MediaType;
+import com.atomgraph.linkeddatahub.server.util.ClientStylesheetService;
 import com.atomgraph.linkeddatahub.server.util.SecureXML;
+import com.atomgraph.linkeddatahub.vocabulary.LDH;
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.io.InputStream;
@@ -70,7 +72,7 @@ import org.xml.sax.SAXException;
  * 
  * @author {@literal Martynas Jusevičius <martynas@atomgraph.com>}
  */
-@Priority(Priorities.USER + 200)
+@Priority(Priorities.USER + 350)
 public class XsltExecutableFilter implements ContainerResponseFilter
 {
 
@@ -98,9 +100,31 @@ public class XsltExecutableFilter implements ContainerResponseFilter
             if (stylesheet != null)
             {
                 List<URI> packages = getPackages(getApplication().get());
+                ClientStylesheetService stylesheetService = getSystem().getClientStylesheetService();
 
                 if (packages.isEmpty()) req.setProperty(AC.stylesheet.getURI(), getXsltExecutable(stylesheet));
-                else req.setProperty(AC.stylesheet.getURI(), getXsltExecutable(getApplication().get(), stylesheet, packages));
+                else if (stylesheetService == null)
+                    // no compiler configured: compose server-side only, which is how packages behaved
+                    // before client-side composition existed
+                    req.setProperty(AC.stylesheet.getURI(), getXsltExecutable(getApplication().get(), stylesheet, packages));
+                else
+                {
+                    String key = stylesheetService.getKey(packages);
+
+                    if (stylesheetService.isPublished(key))
+                    {
+                        req.setProperty(LDH.clientStylesheet.getURI(), stylesheetService.getPublicPath(key));
+                        req.setProperty(AC.stylesheet.getURI(), getXsltExecutable(getApplication().get(), stylesheet, packages));
+                    }
+                    else
+                    {
+                        // both renderers stay on the uncomposed stylesheet until the compiled one exists.
+                        // Composing server-side while the client cannot is what makes a package's rules
+                        // appear on load and vanish on the first client-side navigation
+                        stylesheetService.buildAsync(key, getStylesheets(packages));
+                        req.setProperty(AC.stylesheet.getURI(), getXsltExecutable(stylesheet));
+                    }
+                }
             }
             else req.setProperty(AC.stylesheet.getURI(), getSystem().getXsltExecutable());
 

--- a/src/main/java/com/atomgraph/linkeddatahub/server/filter/response/XsltExecutableFilter.java
+++ b/src/main/java/com/atomgraph/linkeddatahub/server/filter/response/XsltExecutableFilter.java
@@ -103,26 +103,21 @@ public class XsltExecutableFilter implements ContainerResponseFilter
                 ClientStylesheetService stylesheetService = getSystem().getClientStylesheetService();
 
                 if (packages.isEmpty()) req.setProperty(AC.stylesheet.getURI(), getXsltExecutable(stylesheet));
-                else if (stylesheetService == null)
-                    // no compiler configured: compose server-side only, which is how packages behaved
-                    // before client-side composition existed
-                    req.setProperty(AC.stylesheet.getURI(), getXsltExecutable(getApplication().get(), stylesheet, packages));
                 else
                 {
-                    String key = stylesheetService.getKey(packages);
+                    // server-side composition is never withheld: a declarative import takes effect on the
+                    // next request, and it is the only rendering an instance whose compiler is unreachable
+                    // will ever get
+                    req.setProperty(AC.stylesheet.getURI(), getXsltExecutable(getApplication().get(), stylesheet, packages));
 
-                    if (stylesheetService.isPublished(key))
+                    if (stylesheetService != null)
                     {
-                        req.setProperty(LDH.clientStylesheet.getURI(), stylesheetService.getPublicPath(key));
-                        req.setProperty(AC.stylesheet.getURI(), getXsltExecutable(getApplication().get(), stylesheet, packages));
-                    }
-                    else
-                    {
-                        // both renderers stay on the uncomposed stylesheet until the compiled one exists.
-                        // Composing server-side while the client cannot is what makes a package's rules
-                        // appear on load and vanish on the first client-side navigation
-                        stylesheetService.buildAsync(key, getStylesheets(packages));
-                        req.setProperty(AC.stylesheet.getURI(), getXsltExecutable(stylesheet));
+                        String key = stylesheetService.getKey(packages);
+
+                        // until the composed stylesheet exists the client renders without the package, as it
+                        // always has; compiling one closes that window rather than opening it
+                        if (stylesheetService.isPublished(key)) req.setProperty(LDH.clientStylesheet.getURI(), stylesheetService.getPublicPath(key));
+                        else stylesheetService.buildAsync(key, getStylesheets(packages));
                     }
                 }
             }

--- a/src/main/java/com/atomgraph/linkeddatahub/server/util/ClientStylesheetService.java
+++ b/src/main/java/com/atomgraph/linkeddatahub/server/util/ClientStylesheetService.java
@@ -86,6 +86,7 @@ public class ClientStylesheetService
     private final Path sefRoot;
     private final URI compilerURI;
     private final Client client;
+    private final com.atomgraph.client.util.jena.PrefixGraphRepository repository;
     private final String baseDigest;
     private final Set<String> published = ConcurrentHashMap.newKeySet();
     private final Map<String, CompletableFuture<Void>> builds = new ConcurrentHashMap<>();
@@ -98,14 +99,16 @@ public class ClientStylesheetService
      * @param sefRoot directory holding compiled stylesheets
      * @param compilerURI URI of the compiler service's compile endpoint
      * @param client HTTP client
+     * @param repository graph repository, consulted for bundled package locations
      * @param stockSEF stream of the stylesheet built into the webapp, digested as the platform fingerprint
      * @throws IOException if the stock stylesheet cannot be read or the SEF root cannot be scanned
      */
-    public ClientStylesheetService(Path sefRoot, URI compilerURI, Client client, InputStream stockSEF) throws IOException
+    public ClientStylesheetService(Path sefRoot, URI compilerURI, Client client, com.atomgraph.client.util.jena.PrefixGraphRepository repository, InputStream stockSEF) throws IOException
     {
         this.sefRoot = sefRoot;
         this.compilerURI = compilerURI;
         this.client = client;
+        this.repository = repository;
         this.baseDigest = digest(stockSEF);
 
         Files.createDirectories(sefRoot);
@@ -248,6 +251,19 @@ public class ClientStylesheetService
      */
     public String expandEntities(URI stylesheet)
     {
+        // a bundled package's stylesheet never leaves the JVM: its URI is mapped to a classpath file,
+        // which is also why that URI does not have to resolve over the network at all
+        if (getRepository() != null && getRepository().isMapped(stylesheet.toString()))
+            try (InputStream is = getClass().getClassLoader().getResourceAsStream(getRepository().resolve(stylesheet.toString())))
+            {
+                if (is == null) throw new IllegalStateException("Bundled package stylesheet <" + stylesheet + "> not found on the classpath");
+                return expandEntities(is, stylesheet);
+            }
+            catch (IOException ex)
+            {
+                throw new IllegalStateException("Could not read bundled package stylesheet <" + stylesheet + ">", ex);
+            }
+
         try (Response cr = getClient().target(stylesheet).request(com.atomgraph.linkeddatahub.MediaType.TEXT_XSL_TYPE).get())
         {
             if (!cr.getStatusInfo().getFamily().equals(Response.Status.Family.SUCCESSFUL))
@@ -255,21 +271,51 @@ public class ClientStylesheetService
 
             try (InputStream is = cr.readEntity(InputStream.class))
             {
-                // newXMLReader() tolerates a benign internal DOCTYPE; newDocumentBuilderFactory() forbids it outright
-                SAXSource source = new SAXSource(SecureXML.newXMLReader(), new InputSource(is));
-                source.setSystemId(stylesheet.toString());
-
-                ByteArrayOutputStream baos = new ByteArrayOutputStream();
-                Transformer transformer = TransformerFactory.newInstance().newTransformer();
-                transformer.transform(source, new StreamResult(baos));
-
-                return baos.toString(StandardCharsets.UTF_8);
+                return expandEntities(is, stylesheet);
             }
+        }
+        catch (IOException ex)
+        {
+            throw new IllegalStateException("Could not read package stylesheet <" + stylesheet + ">", ex);
+        }
+    }
+
+    /**
+     * Parses an already-opened stylesheet with the DOCTYPE-tolerant reader and serialises it with its
+     * entities expanded. The overload taking a URI decides where the bytes come from and delegates here.
+     *
+     * @param is stylesheet stream
+     * @param systemId system id to resolve relative references against
+     * @return expanded stylesheet
+     */
+    public String expandEntities(InputStream is, URI systemId)
+    {
+        try
+        {
+            // newXMLReader() tolerates a benign internal DOCTYPE; newDocumentBuilderFactory() forbids it outright
+            SAXSource source = new SAXSource(SecureXML.newXMLReader(), new InputSource(is));
+            source.setSystemId(systemId.toString());
+
+            ByteArrayOutputStream baos = new ByteArrayOutputStream();
+            Transformer transformer = TransformerFactory.newInstance().newTransformer();
+            transformer.transform(source, new StreamResult(baos));
+
+            return baos.toString(StandardCharsets.UTF_8);
         }
         catch (Exception ex)
         {
-            throw new IllegalStateException("Could not expand entities of package stylesheet <" + stylesheet + ">", ex);
+            throw new IllegalStateException("Could not expand entities of package stylesheet <" + systemId + ">", ex);
         }
+    }
+
+    /**
+     * Returns the graph repository, or null when none was supplied.
+     *
+     * @return repository
+     */
+    public com.atomgraph.client.util.jena.PrefixGraphRepository getRepository()
+    {
+        return repository;
     }
 
     private String digest(InputStream is) throws IOException

--- a/src/main/java/com/atomgraph/linkeddatahub/server/util/ClientStylesheetService.java
+++ b/src/main/java/com/atomgraph/linkeddatahub/server/util/ClientStylesheetService.java
@@ -1,0 +1,326 @@
+/**
+ *  Copyright 2026 Martynas Jusevičius <martynas@atomgraph.com>
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ */
+package com.atomgraph.linkeddatahub.server.util;
+
+import jakarta.json.Json;
+import jakarta.json.JsonArrayBuilder;
+import jakarta.json.JsonObject;
+import jakarta.ws.rs.client.Client;
+import jakarta.ws.rs.client.Entity;
+import jakarta.ws.rs.core.MediaType;
+import jakarta.ws.rs.core.Response;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.net.URI;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.StandardCopyOption;
+import java.security.DigestInputStream;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.stream.Collectors;
+import javax.xml.transform.Transformer;
+import javax.xml.transform.TransformerFactory;
+import javax.xml.transform.sax.SAXSource;
+import javax.xml.transform.stream.StreamResult;
+import org.apache.commons.codec.binary.Hex;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.xml.sax.InputSource;
+
+/**
+ * Composes and compiles the client stylesheet of applications that import packages.
+ *
+ * The client SEF shipped in the webapp is compiled at build time from <code>client.xsl</code> alone,
+ * so package rules reach server-rendered output only and vanish as soon as the client re-renders a
+ * pane. Saxon-JS cannot compile in the browser, and independently compiled per-package SEFs cannot
+ * be composed, because <code>xsl:import</code> precedence is resolved at compile time. This service
+ * therefore composes and compiles one SEF per distinct import set, out-of-process.
+ *
+ * Keyed on the <em>inputs</em> rather than the output: a SEF is not byte-deterministic (its header
+ * carries a build timestamp), so content-addressing the result would mint a new URI on every compile
+ * and a different one on every node. The key combines the digest of the stock SEF - which fingerprints
+ * every client module and changes on every platform build - with the sorted package URIs, so a
+ * platform upgrade invalidates it and nodes agree on one URI for one import set.
+ *
+ * Compilation is best-effort: a failure leaves the key unpublished, which keeps both renderers on the
+ * stock stylesheet rather than letting the server compose while the client cannot.
+ *
+ * @author Martynas Jusevičius {@literal <martynas@atomgraph.com>}
+ */
+public class ClientStylesheetService
+{
+
+    private static final Logger log = LoggerFactory.getLogger(ClientStylesheetService.class);
+
+    /** Path under which composed stylesheets are served, mapped to the SEF root by a Tomcat alias */
+    public static final String PUBLIC_PATH = "static/xsl/sef/";
+
+    /** Suffix of a compiled stylesheet file */
+    public static final String SEF_SUFFIX = ".sef.json";
+
+    private final Path sefRoot;
+    private final URI compilerURI;
+    private final Client client;
+    private final String baseDigest;
+    private final Set<String> published = ConcurrentHashMap.newKeySet();
+    private final Map<String, CompletableFuture<Void>> builds = new ConcurrentHashMap<>();
+    // one at a time: the compile peaks around 1.5 GB, and the compiler refuses concurrent jobs anyway
+    private final ExecutorService executor = Executors.newFixedThreadPool(1);
+
+    /**
+     * Constructs the service and adopts any stylesheets a previous run left in the SEF root.
+     *
+     * @param sefRoot directory holding compiled stylesheets
+     * @param compilerURI URI of the compiler service's compile endpoint
+     * @param client HTTP client
+     * @param stockSEF stream of the stylesheet built into the webapp, digested as the platform fingerprint
+     * @throws IOException if the stock stylesheet cannot be read or the SEF root cannot be scanned
+     */
+    public ClientStylesheetService(Path sefRoot, URI compilerURI, Client client, InputStream stockSEF) throws IOException
+    {
+        this.sefRoot = sefRoot;
+        this.compilerURI = compilerURI;
+        this.client = client;
+        this.baseDigest = digest(stockSEF);
+
+        Files.createDirectories(sefRoot);
+        try (var paths = Files.list(sefRoot))
+        {
+            paths.map(path -> path.getFileName().toString()).
+                filter(name -> name.endsWith(SEF_SUFFIX)).
+                map(name -> name.substring(0, name.length() - SEF_SUFFIX.length())).
+                forEach(published::add);
+        }
+
+        if (log.isInfoEnabled()) log.info("Client stylesheet service ready, compiler <{}>, {} stylesheet(s) already compiled", compilerURI, published.size());
+    }
+
+    /**
+     * Returns the key identifying the stylesheet composed from this platform build and these packages.
+     *
+     * @param packages imported package URIs
+     * @return key
+     */
+    public String getKey(List<URI> packages)
+    {
+        try
+        {
+            MessageDigest md = MessageDigest.getInstance("SHA-1"); // a fresh instance: Application's is shared and not thread-safe
+            md.update(baseDigest.getBytes(StandardCharsets.UTF_8));
+            for (URI pkg : packages.stream().sorted().collect(Collectors.toList()))
+            {
+                md.update((byte)'\n');
+                md.update(pkg.toString().getBytes(StandardCharsets.UTF_8));
+            }
+
+            return Hex.encodeHexString(md.digest());
+        }
+        catch (NoSuchAlgorithmException ex)
+        {
+            throw new IllegalStateException(ex);
+        }
+    }
+
+    /**
+     * Returns true if a stylesheet for this key has been compiled and is readable.
+     *
+     * @param key stylesheet key
+     * @return true if published
+     */
+    public boolean isPublished(String key)
+    {
+        return published.contains(key);
+    }
+
+    /**
+     * Returns the path of a compiled stylesheet, relative to the application's base URI.
+     *
+     * @param key stylesheet key
+     * @return relative path
+     */
+    public String getPublicPath(String key)
+    {
+        return PUBLIC_PATH + key + SEF_SUFFIX;
+    }
+
+    /**
+     * Compiles the stylesheet for this key unless it is already compiled or being compiled.
+     * Returns immediately; the result is observed through {@link #isPublished(String)}.
+     *
+     * @param key stylesheet key
+     * @param stylesheets package stylesheet URLs, in import order
+     */
+    public void buildAsync(String key, List<URI> stylesheets)
+    {
+        if (isPublished(key)) return;
+
+        CompletableFuture<Void> build = builds.computeIfAbsent(key, k ->
+            CompletableFuture.runAsync(() -> build(k, stylesheets), executor).
+                exceptionally(ex ->
+                {
+                    if (log.isErrorEnabled()) log.error("Could not compile client stylesheet '{}': {}", k, ex.getMessage());
+                    return null;
+                }));
+
+        // registered after computeIfAbsent returns: whenComplete runs on the calling thread when the future
+        // is already done, and ConcurrentHashMap forbids re-entrant updates from inside the mapping function -
+        // registered inside, a fast completion would remove the entry before it is installed and leak it
+        build.whenComplete((result, ex) -> builds.remove(key, build));
+    }
+
+    private void build(String key, List<URI> stylesheets)
+    {
+        JsonArrayBuilder imports = Json.createArrayBuilder();
+        for (int i = 0; i < stylesheets.size(); i++)
+            imports.add(Json.createObjectBuilder().
+                add("name", "pkg-" + i + ".xsl").
+                add("content", expandEntities(stylesheets.get(i))));
+
+        JsonObject request = Json.createObjectBuilder().add("imports", imports).build();
+
+        byte[] sef;
+        try (Response cr = getClient().target(getCompilerURI()).request(MediaType.APPLICATION_JSON_TYPE).
+                post(Entity.entity(request, MediaType.APPLICATION_JSON_TYPE)))
+        {
+            if (!cr.getStatusInfo().getFamily().equals(Response.Status.Family.SUCCESSFUL))
+                // the compiler returns the diagnostics verbatim; a package author needs those, not "compilation failed"
+                throw new IllegalStateException("Compiler returned " + cr.getStatus() + ": " + cr.readEntity(String.class));
+
+            try (InputStream is = cr.readEntity(InputStream.class))
+            {
+                sef = is.readAllBytes();
+            }
+            catch (IOException ex)
+            {
+                throw new IllegalStateException("Could not read compiled stylesheet", ex);
+            }
+        }
+
+        try
+        {
+            // temp file plus atomic move, so a reader never sees a partially written stylesheet
+            Path temp = Files.createTempFile(getSEFRoot(), key, ".tmp");
+            Files.write(temp, sef);
+            Files.move(temp, getSEFRoot().resolve(key + SEF_SUFFIX), StandardCopyOption.ATOMIC_MOVE, StandardCopyOption.REPLACE_EXISTING);
+        }
+        catch (IOException ex)
+        {
+            throw new IllegalStateException("Could not store compiled stylesheet '" + key + "'", ex);
+        }
+
+        published.add(key);
+        if (log.isInfoEnabled()) log.info("Compiled client stylesheet '{}' from {} package stylesheet(s), {} bytes", key, stylesheets.size(), sef.length);
+    }
+
+    /**
+     * Reads a package stylesheet and serialises it with its internal entities expanded.
+     * The compiler's parser has no DTD internal subset, so a stylesheet declaring entities - as the
+     * bundled ones do - must be expanded first, the same step the build applies to the webapp's own
+     * stylesheets before compiling them.
+     *
+     * @param stylesheet stylesheet URL
+     * @return expanded stylesheet
+     */
+    public String expandEntities(URI stylesheet)
+    {
+        try (Response cr = getClient().target(stylesheet).request(com.atomgraph.linkeddatahub.MediaType.TEXT_XSL_TYPE).get())
+        {
+            if (!cr.getStatusInfo().getFamily().equals(Response.Status.Family.SUCCESSFUL))
+                throw new IllegalStateException("Package stylesheet <" + stylesheet + "> could not be loaded: " + cr.getStatus());
+
+            try (InputStream is = cr.readEntity(InputStream.class))
+            {
+                // newXMLReader() tolerates a benign internal DOCTYPE; newDocumentBuilderFactory() forbids it outright
+                SAXSource source = new SAXSource(SecureXML.newXMLReader(), new InputSource(is));
+                source.setSystemId(stylesheet.toString());
+
+                ByteArrayOutputStream baos = new ByteArrayOutputStream();
+                Transformer transformer = TransformerFactory.newInstance().newTransformer();
+                transformer.transform(source, new StreamResult(baos));
+
+                return baos.toString(StandardCharsets.UTF_8);
+            }
+        }
+        catch (Exception ex)
+        {
+            throw new IllegalStateException("Could not expand entities of package stylesheet <" + stylesheet + ">", ex);
+        }
+    }
+
+    private String digest(InputStream is) throws IOException
+    {
+        try (DigestInputStream dis = new DigestInputStream(is, MessageDigest.getInstance("SHA-1")))
+        {
+            dis.transferTo(OutputStream.nullOutputStream());
+            return Hex.encodeHexString(dis.getMessageDigest().digest());
+        }
+        catch (NoSuchAlgorithmException ex)
+        {
+            throw new IllegalStateException(ex);
+        }
+    }
+
+    /**
+     * Returns the directory holding compiled stylesheets.
+     *
+     * @return directory
+     */
+    public Path getSEFRoot()
+    {
+        return sefRoot;
+    }
+
+    /**
+     * Returns the URI of the compiler service.
+     *
+     * @return compiler URI
+     */
+    public URI getCompilerURI()
+    {
+        return compilerURI;
+    }
+
+    /**
+     * Returns the HTTP client.
+     *
+     * @return client
+     */
+    public Client getClient()
+    {
+        return client;
+    }
+
+    /**
+     * Shuts down the compilation thread pool.
+     */
+    public void shutdown()
+    {
+        executor.shutdown();
+    }
+
+}

--- a/src/main/java/com/atomgraph/linkeddatahub/server/util/LocalStylesheetResolver.java
+++ b/src/main/java/com/atomgraph/linkeddatahub/server/util/LocalStylesheetResolver.java
@@ -87,6 +87,27 @@ public class LocalStylesheetResolver extends StylesheetResolver
             }
         }
 
+        // a bundled package's stylesheet: its URI is mapped to a classpath file, so the package
+        // resolves without leaving the JVM. The graph repository owns that mapping, but it hands back
+        // RDF graphs - a stylesheet is not RDF, so the location is resolved and the bytes read directly
+        if (getSystem().getRepository().isMapped(uri.toString()))
+        {
+            String location = getSystem().getRepository().resolve(uri.toString());
+            try (InputStream is = getClass().getClassLoader().getResourceAsStream(location))
+            {
+                if (is != null)
+                {
+                    // the URI stays the system id, so relative imports inside resolve against it
+                    byte[] bytes = IOUtils.toByteArray(is);
+                    return new StreamSource(new ByteArrayInputStream(bytes), uri.toString());
+                }
+            }
+            catch (IOException ex)
+            {
+                throw new TransformerException(ex);
+            }
+        }
+
         return super.resolve(href, base);
     }
 

--- a/src/main/java/com/atomgraph/linkeddatahub/server/util/LocalStylesheetResolver.java
+++ b/src/main/java/com/atomgraph/linkeddatahub/server/util/LocalStylesheetResolver.java
@@ -89,10 +89,14 @@ public class LocalStylesheetResolver extends StylesheetResolver
 
         // a bundled package's stylesheet: its URI is mapped to a classpath file, so the package
         // resolves without leaving the JVM. The graph repository owns that mapping, but it hands back
-        // RDF graphs - a stylesheet is not RDF, so the location is resolved and the bytes read directly
-        if (getSystem().getRepository().isMapped(uri.toString()))
+        // RDF graphs - a stylesheet is not RDF, so the location is resolved and the bytes read directly.
+        // The repository is optional and read through a local: an application can exist without one, so
+        // an unguarded call NPEs every resolution that is not a bundled package - which is what it did
+        // to this resolver's own tests for a file: URI and for an unknown origin
+        com.atomgraph.client.util.jena.PrefixGraphRepository repository = getSystem().getRepository();
+        if (repository != null && repository.isMapped(uri.toString()))
         {
-            String location = getSystem().getRepository().resolve(uri.toString());
+            String location = repository.resolve(uri.toString());
             try (InputStream is = getClass().getClassLoader().getResourceAsStream(location))
             {
                 if (is != null)

--- a/src/main/java/com/atomgraph/linkeddatahub/vocabulary/LDH.java
+++ b/src/main/java/com/atomgraph/linkeddatahub/vocabulary/LDH.java
@@ -113,4 +113,8 @@ public class LDH
      * Import property - used to import packages into an application */
     public static final Property importPackage = m_model.createObjectProperty( NS + "import" );
 
+    /**
+     * Client stylesheet property - the compiled stylesheet this application's client runs, composed with its imported packages */
+    public static final Property clientStylesheet = m_model.createObjectProperty( NS + "clientStylesheet" );
+
 }

--- a/src/main/java/com/atomgraph/linkeddatahub/vocabulary/LDHC.java
+++ b/src/main/java/com/atomgraph/linkeddatahub/vocabulary/LDHC.java
@@ -94,6 +94,12 @@ public class LDHC
     /** Upload root property */
     public static final Property uploadRoot = m_model.createObjectProperty( NS + "uploadRoot" );
 
+    /** SEF root property. Directory holding the composed client stylesheets, served under /static/ through a Tomcat alias */
+    public static final Property sefRoot = m_model.createObjectProperty( NS + "sefRoot" );
+
+    /** SEF compiler property. Endpoint of the service that compiles composed client stylesheets */
+    public static final Property sefCompiler = m_model.createObjectProperty( NS + "sefCompiler" );
+
     /** Invalidate cache property */
     public static final Property invalidateCache = m_model.createDataProperty( NS + "invalidateCache" );
 

--- a/src/main/java/com/atomgraph/linkeddatahub/vocabulary/LDHC.java
+++ b/src/main/java/com/atomgraph/linkeddatahub/vocabulary/LDHC.java
@@ -94,12 +94,6 @@ public class LDHC
     /** Upload root property */
     public static final Property uploadRoot = m_model.createObjectProperty( NS + "uploadRoot" );
 
-    /** SEF root property. Directory holding the composed client stylesheets, served under /static/ through a Tomcat alias */
-    public static final Property sefRoot = m_model.createObjectProperty( NS + "sefRoot" );
-
-    /** SEF compiler property. Endpoint of the service that compiles composed client stylesheets */
-    public static final Property sefCompiler = m_model.createObjectProperty( NS + "sefCompiler" );
-
     /** Invalidate cache property */
     public static final Property invalidateCache = m_model.createDataProperty( NS + "invalidateCache" );
 

--- a/src/main/resources/com/atomgraph/linkeddatahub/ldh.ttl
+++ b/src/main/resources/com/atomgraph/linkeddatahub/ldh.ttl
@@ -105,13 +105,6 @@
     rdfs:comment "Attaches a view to a property for inverse relationships (?value property $about)" ;
     rdfs:isDefinedBy : .
 
-:container a owl:ObjectProperty ;
-    rdfs:domain :View ;
-    rdfs:range dh:Container ;
-    rdfs:label "Item container" ;
-    rdfs:comment "Container under which instances created inline from the view are stored as child documents" ;
-    rdfs:isDefinedBy : .
-
 :showWhenEmpty a owl:DatatypeProperty ;
     rdfs:domain :View ;
     rdfs:range xsd:boolean ;
@@ -345,7 +338,6 @@
       CONSTRUCT {
           $this spin:query [ a sp:Select ] ;
               ac:mode [ a rdfs:Resource ] ;
-              ldh:container [ a rdfs:Resource ] ;
               ldh:showWhenEmpty [ a xsd:boolean ] .
       }
       WHERE {}""" ;

--- a/src/main/resources/com/linkeddatahub/packages/skos/layout.xsl
+++ b/src/main/resources/com/linkeddatahub/packages/skos/layout.xsl
@@ -1,0 +1,105 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE xsl:stylesheet [
+    <!ENTITY ldh    "https://w3id.org/atomgraph/linkeddatahub#">
+    <!ENTITY ac     "https://w3id.org/atomgraph/client#">
+    <!ENTITY rdf    "http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+    <!ENTITY rdfs   "http://www.w3.org/2000/01/rdf-schema#">
+    <!ENTITY xsd    "http://www.w3.org/2001/XMLSchema#">
+    <!ENTITY foaf   "http://xmlns.com/foaf/0.1/">
+    <!ENTITY skos   "http://www.w3.org/2004/02/skos/core#">
+    <!ENTITY srx    "http://www.w3.org/2005/sparql-results#">
+]>
+<xsl:stylesheet version="3.0"
+xmlns="http://www.w3.org/1999/xhtml"
+xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
+xmlns:ixsl="http://saxonica.com/ns/interactiveXSLT"
+xmlns:xhtml="http://www.w3.org/1999/xhtml"
+xmlns:xs="http://www.w3.org/2001/XMLSchema"
+xmlns:ac="&ac;"
+xmlns:ldh="&ldh;"
+xmlns:rdf="&rdf;"
+xmlns:rdfs="&rdfs;"
+xmlns:xsd="&xsd;"
+xmlns:foaf="&foaf;"
+xmlns:skos="&skos;"
+xmlns:srx="&srx;"
+exclude-result-prefixes="#all">
+
+    <!-- This one stylesheet is composed into BOTH the server and the client tree, so anything that
+         reaches client/tree.xsl - the disclosure handlers, the children query, the fetch - is declared
+         use-when Saxon-JS. Without the guard the server compile fails on XTSE0650/XPST0017 and the
+         platform falls back to a stylesheet carrying no package rules at all, so the package stops
+         working entirely rather than degrading. The emitter is deliberately NOT guarded: ldh:TreeNode
+         lives in the shared trunk precisely so the tree is in the server's first paint, which is the
+         only paint a directly loaded URL gets.
+
+         the hierarchy predicates render as the concept tree, not as statement rows -->
+    <xsl:template match="skos:narrower | skos:broader | skos:related | skos:member" mode="ac:PropertyEditor"/>
+
+    <!-- A concept can always be expanded. Whether it has children is one query away and this template
+         renders without one, so offering the disclosure and letting it resolve to an empty list beats
+         either blocking the render or hiding a control the node may well need: the alternative is a
+         tree whose leaves are wrong whenever narrower is asserted only on the child. -->
+    <xsl:template match="*[@rdf:about][rdf:type/@rdf:resource = '&skos;Concept']" mode="ldh:TreeNode" priority="1">
+        <xsl:next-match>
+            <xsl:with-param name="expandable" select="true()"/>
+        </xsl:next-match>
+    </xsl:template>
+
+
+    <!-- A taxonomy is read alongside its content, so the tree fills the platform's ldh:ContentColumn
+         slot and the content body lays itself out in two columns. The card, its stickiness and the
+         column width come from the design system's ontology-editor layout (.ldh-onto-list), already
+         vendored in app.css; the grid is the platform's, keyed on this slot being filled.
+
+         Anchored on the primary topic of THIS document, not on any SKOS resource in the graph: a
+         container listing concept documents describes every child's topic too, and matching those
+         would hang a tree off every such listing, rooted at whichever concept happened to come first.
+
+         Not guarded by use-when: ldh:TreeNode lives in the shared trunk precisely so the tree is in
+         the server's first paint, which is the only paint a directly loaded URL gets. -->
+    <xsl:template match="rdf:RDF[key('resources', key('resources', ac:absolute-path(ldh:base-uri(.)))/foaf:primaryTopic/@rdf:resource)/rdf:type/@rdf:resource = ('&skos;ConceptScheme', '&skos;Concept')]" mode="ldh:ContentColumn">
+        <xsl:variable name="topic" select="key('resources', key('resources', ac:absolute-path(ldh:base-uri(.)))/foaf:primaryTopic/@rdf:resource)" as="element()*"/>
+        <!-- the root of a scheme's tree expands over hasTopConcept/topConceptOf, a concept's over broader/narrower;
+             the class is what the ldh:TreeChildrenLoad rules below read at click time -->
+        <xsl:variable name="scheme-root" select="$topic/rdf:type/@rdf:resource = '&skos;ConceptScheme'" as="xs:boolean"/>
+
+        <div class="ldh-onto-list">
+            <ul class="ldh-tree concept-tree{if ($scheme-root) then ' scheme-root' else ''}">
+                <xsl:apply-templates select="$topic[1]" mode="ldh:TreeNode">
+                    <xsl:with-param name="expandable" select="true()"/>
+                </xsl:apply-templates>
+            </ul>
+        </div>
+    </xsl:template>
+
+    <!-- SKOS puts the hierarchy link on whichever end the modeller chose, and both are in use in the
+         wild, so every relation below is given from both directions and client/tree.xsl unions them.
+
+         Which relation applies is a question of depth, not of class: the node at the root of this tree
+         is the scheme, whose children are its top concepts; every node below it is a concept, whose
+         children are narrower concepts. count(ancestor::li) tells them apart without a marker class
+         that the generic emitter would have to know how to attach. -->
+    <xsl:template match="button[ancestor::ul[contains-token(@class, 'scheme-root')]][count(ancestor::li) = 1]" mode="ldh:TreeChildrenLoad" priority="1" use-when="system-property('xsl:product-name') = 'SaxonJS'">
+        <xsl:param name="container" as="element()"/>
+        <xsl:param name="uri" as="xs:anyURI"/>
+
+        <xsl:call-template name="ldh:TreeChildrenFetch">
+            <xsl:with-param name="container" select="$container"/>
+            <xsl:with-param name="uri" select="$uri"/>
+            <xsl:with-param name="query" select="ldh:tree-children-query($uri, xs:anyURI('&skos;topConceptOf'), xs:anyURI('&skos;hasTopConcept'))"/>
+        </xsl:call-template>
+    </xsl:template>
+
+    <xsl:template match="button[ancestor::ul[contains-token(@class, 'concept-tree')]]" mode="ldh:TreeChildrenLoad" use-when="system-property('xsl:product-name') = 'SaxonJS'">
+        <xsl:param name="container" as="element()"/>
+        <xsl:param name="uri" as="xs:anyURI"/>
+
+        <xsl:call-template name="ldh:TreeChildrenFetch">
+            <xsl:with-param name="container" select="$container"/>
+            <xsl:with-param name="uri" select="$uri"/>
+            <xsl:with-param name="query" select="ldh:tree-children-query($uri, xs:anyURI('&skos;broader'), xs:anyURI('&skos;narrower'))"/>
+        </xsl:call-template>
+    </xsl:template>
+
+</xsl:stylesheet>

--- a/src/main/resources/com/linkeddatahub/packages/skos/layout.xsl
+++ b/src/main/resources/com/linkeddatahub/packages/skos/layout.xsl
@@ -8,6 +8,7 @@
     <!ENTITY foaf   "http://xmlns.com/foaf/0.1/">
     <!ENTITY skos   "http://www.w3.org/2004/02/skos/core#">
     <!ENTITY srx    "http://www.w3.org/2005/sparql-results#">
+    <!ENTITY sd     "http://www.w3.org/ns/sparql-service-description#">
 ]>
 <xsl:stylesheet version="3.0"
 xmlns="http://www.w3.org/1999/xhtml"
@@ -23,6 +24,9 @@ xmlns:xsd="&xsd;"
 xmlns:foaf="&foaf;"
 xmlns:skos="&skos;"
 xmlns:srx="&srx;"
+xmlns:sd="&sd;"
+xmlns:map="http://www.w3.org/2005/xpath-functions/map"
+extension-element-prefixes="ixsl"
 exclude-result-prefixes="#all">
 
     <!-- This one stylesheet is composed into BOTH the server and the client tree, so anything that
@@ -94,7 +98,12 @@ exclude-result-prefixes="#all">
              blocks, else ReadMode. -->
         <xsl:if test="$root and $mode = '&ac;ReadMode'">
             <div class="ldh-onto-list">
+                <!-- the concept being viewed, stamped so the reveal has its target without re-deriving
+                     it from the page; absent when the topic IS the scheme, which is already the root -->
                 <ul class="ldh-tree concept-tree">
+                    <xsl:if test="not($topic/rdf:type/@rdf:resource = '&skos;ConceptScheme')">
+                        <xsl:attribute name="data-concept" select="$topic[1]/@rdf:about"/>
+                    </xsl:if>
                     <xsl:apply-templates select="$root" mode="ldh:TreeNode">
                         <xsl:with-param name="expandable" select="true()"/>
                     </xsl:apply-templates>
@@ -102,6 +111,252 @@ exclude-result-prefixes="#all">
             </div>
         </xsl:if>
     </xsl:template>
+
+    <!-- ===================== REVEALING THE OPEN CONCEPT =====================
+
+         The tree roots at the scheme, so on a concept page it must open the path down to that concept
+         or the reader is left at the top of a taxonomy with no idea where they are.
+
+         Triggered from ldh:RenderRow, which the platform already applies to every direct child of
+         .content-body after the pane is in the DOM - on a direct load AND on a client-side navigation
+         alike. That is the whole reason no new platform hook was needed, and why there is one
+         implementation rather than a synchronous server walk beside an asynchronous client one: this
+         mode is the only place both paths meet after the markup exists.
+
+         The mode's contract is a FACTORY, not work: it is evaluated inside a non-updating variable
+         binding and the factories are invoked later inside ixsl:promise, which is also what gives
+         ixsl:http-request the active promise it requires. -->
+    <xsl:template match="div[contains-token(@class, 'ldh-content-aside')][descendant::ul[contains-token(@class, 'concept-tree')][@data-concept]]" mode="ldh:RenderRow" as="(function(item()?) as map(*))*" priority="2" use-when="system-property('xsl:product-name') = 'SaxonJS'">
+        <!-- descendant, not child: the platform owns the .ldh-content-aside wrapper and the package puts
+             its own card treatment (.ldh-onto-list) inside it, so the tree sits a level deeper than the
+             slot - and a package that wanted no card would have it one level up. Either way the tree is
+             found by what it is rather than by where it happens to sit. -->
+        <xsl:variable name="tree" select="descendant::ul[contains-token(@class, 'concept-tree')][@data-concept][1]" as="element()"/>
+        <xsl:variable name="root-li" select="$tree/li[1]" as="element()?"/>
+
+        <xsl:sequence select="ldh:conceptree-reveal#2(
+            map{
+                'tree': $tree,
+                'root-li': $root-li,
+                'target': xs:anyURI($tree/@data-concept)
+            }, ?)"/>
+    </xsl:template>
+
+    <!-- Step one: climb to the scheme, one hop per request.
+
+         Shaped after the document tree's descent rather than after a closure query: ldh:doctree-descend
+         issues one constant-size children query per level and decides where to go next from what is
+         already in the DOM. The concept tree cannot make that decision locally - the document hierarchy
+         is path-nested, so a target's ancestors are exactly its lexical prefixes, while
+         /taxonomies/espresso/#this sits under no prefix of /taxonomies/coffee/#this - so the path is
+         asked for instead of derived. It is asked for the same way: one hop, one request, constant
+         query, no depth bound, stopping when a hop returns nothing new.
+
+         A bounded transitive closure was the alternative and is worse on both counts the shape is meant
+         to get right. Expressed as a UNION of one chain per depth it grows quadratically in text - 4.6kB
+         at six hops, past Tomcat's header limit once percent-encoded, measured as a 400 - and either
+         formulation has to name a maximum depth, which a taxonomy has no reason to respect.
+
+         Why per-hop GRAPH at all rather than skos:broader*: a property path cannot leave its GRAPH, and
+         with one concept per document every hop crosses one. Measured on the fixture, the path form
+         reached the first ancestor and stopped, because that ancestor's own parent link lives in another
+         document; the default graph is empty, so an unscoped path has nowhere to run.
+
+         The frontier is a set, so one request covers a whole level however wide it branches: a concept
+         with two broader concepts puts both in the next VALUES block. That is also the cycle guard -
+         only parents not already seen enter the frontier, so A broader B with B broader A (malformed but
+         legal SKOS) runs out of new nodes and terminates, where a depth bound alone would have walked
+         the two of them as deep as the bound allowed. -->
+    <xsl:function name="ldh:conceptree-parents-query" as="xs:string" use-when="system-property('xsl:product-name') = 'SaxonJS'">
+        <xsl:param name="children" as="xs:anyURI*"/>
+
+        <xsl:sequence select="
+            'SELECT DISTINCT ?parent WHERE { VALUES ?child { ' || string-join(for $child in $children return '&lt;' || $child || '&gt;', ' ') || ' } ' ||
+            'GRAPH ?g { { ?child &lt;&skos;broader&gt; ?parent } UNION { ?parent &lt;&skos;narrower&gt; ?child } } }'"/>
+    </xsl:function>
+
+    <xsl:function name="ldh:conceptree-reveal" as="map(*)" ixsl:updating="yes" use-when="system-property('xsl:product-name') = 'SaxonJS'">
+        <xsl:param name="context" as="map(*)"/>
+        <xsl:param name="ignored" as="item()?"/>
+
+        <!-- ixsl:resolve, because the mode's contract is a promise and everything below this point
+             returns a plain map: each continuation is fired as an ixsl:promise INSTRUCTION rather than
+             returned, which is what lets one level fan out into several branches. -->
+        <xsl:sequence select="ixsl:resolve(ldh:conceptree-climb(map:merge(($context, map{ 'frontier': $context('target'), 'ancestors': () }), map{ 'duplicates': 'use-last' })))"/>
+    </xsl:function>
+
+    <!-- one hop up: asks for the parents of everything on the frontier at once -->
+    <xsl:function name="ldh:conceptree-climb" as="map(*)" ixsl:updating="yes" use-when="system-property('xsl:product-name') = 'SaxonJS'">
+        <xsl:param name="context" as="map(*)"/>
+        <xsl:variable name="query" select="ldh:conceptree-parents-query($context('frontier'))" as="xs:string"/>
+        <xsl:variable name="request-uri" select="ldh:href(ac:build-uri(sd:endpoint(), map{ 'query': $query }), map{})" as="xs:anyURI"/>
+        <xsl:variable name="request" select="map{ 'method': 'GET', 'href': $request-uri, 'headers': map{ 'Accept': 'application/sparql-results+xml' } }" as="map(*)"/>
+
+        <ixsl:promise select="
+            ixsl:resolve(map:merge(($context, map{ 'request': $request }), map{ 'duplicates': 'use-last' })) =>
+                ixsl:then(ldh:http-request-threaded(?, 'request', 'parents-response')) =>
+                ixsl:then(ldh:handle-response(?, 'parents-response')) =>
+                ixsl:then(ldh:conceptree-climbed#1)
+            " on-failure="ldh:promise-failure#1"/>
+        <xsl:sequence select="$context"/>
+    </xsl:function>
+
+    <!-- the hop's answer: keep climbing while it brings new nodes, then hand the set to the descent.
+
+         The walk stops itself at the top concept, because the link from there to the scheme is
+         topConceptOf/hasTopConcept rather than broader/narrower. That is the right place to stop: the
+         scheme is the tree's root node and the descent starts there, so it never belongs to the set. -->
+    <xsl:function name="ldh:conceptree-climbed" as="map(*)" ixsl:updating="yes" use-when="system-property('xsl:product-name') = 'SaxonJS'">
+        <xsl:param name="context" as="map(*)"/>
+        <xsl:variable name="ancestors" select="$context('ancestors')" as="xs:anyURI*"/>
+        <xsl:variable name="parents" select="$context('parents-response')?body//srx:binding[@name = 'parent']/srx:uri/xs:anyURI(.)" as="xs:anyURI*"/>
+        <xsl:variable name="frontier" select="distinct-values($parents[not(. = ($ancestors, $context('target')))])" as="xs:anyURI*"/>
+        <xsl:variable name="carry" select="map:merge((map:remove($context, 'parents-response'), map{ 'ancestors': ($ancestors, $frontier), 'frontier': $frontier }), map{ 'duplicates': 'use-last' })" as="map(*)"/>
+
+        <xsl:choose>
+            <xsl:when test="exists($frontier)">
+                <xsl:sequence select="ldh:conceptree-climb($carry)"/>
+            </xsl:when>
+            <xsl:otherwise>
+                <xsl:sequence select="ldh:conceptree-descend(map:remove($carry, 'frontier'))"/>
+            </xsl:otherwise>
+        </xsl:choose>
+    </xsl:function>
+
+    <!-- Step two: walk down from the scheme, one level per request.
+
+         Mirrors ldh:doctree-descend in shape - expand, fetch, re-enter from the response callback - and
+         differs only where it must: the document tree decides what to expand with a URI string-prefix
+         test, which works because the document hierarchy is path-nested. Concept URIs are not, so the
+         test here is membership of the ancestor set.
+
+         Every matching child is descended into, not just the first. A concept with two broader concepts
+         has two paths to it and Skosmos renders it under each; the activation pass marks all of them
+         without special handling, because it iterates every row whose href matches. -->
+    <xsl:function name="ldh:conceptree-descend" as="map(*)" ixsl:updating="yes" use-when="system-property('xsl:product-name') = 'SaxonJS'">
+        <xsl:param name="context" as="map(*)"/>
+        <xsl:variable name="ancestors" select="$context('ancestors')" as="xs:anyURI*"/>
+        <xsl:variable name="li" select="if (map:contains($context, 'li')) then $context('li') else $context('root-li')" as="element()"/>
+        <xsl:variable name="wanted" select="($ancestors, $context('target'))" as="xs:anyURI*"/>
+        <xsl:variable name="next" select="$li/ul/li[div/a/@href = $wanted]" as="element()*"/>
+
+        <xsl:choose>
+            <!-- children already in the DOM: step into every matching branch without refetching -->
+            <xsl:when test="exists($next)">
+                <!-- One promise per branch, not one call per branch: a function returns a single map, so
+                     N branches cannot be N return values. Firing each as an instruction also gives every
+                     branch of a polyhierarchy its own chain and its own failure handler. -->
+                <xsl:for-each select="$next">
+                    <ixsl:promise select="ixsl:resolve(map:merge(($context, map{ 'li': . }), map{ 'duplicates': 'use-last' })) => ixsl:then(ldh:conceptree-step#1)" on-failure="ldh:promise-failure#1"/>
+                </xsl:for-each>
+                <xsl:sequence select="$context"/>
+            </xsl:when>
+            <!-- Not expanded yet: open this level, then re-enter from the children response. No test on
+                 the ancestor set being non-empty - it is legitimately empty when the open concept is a
+                 top concept, whose link to the scheme is topConceptOf rather than broader, and that is
+                 the one level the root must still expand to reveal it. Descending into a node is only
+                 ever reached for the root or for a node already matched as wanted, so opening it is
+                 always right; a childless one fetches nothing, re-enters with an empty list and stops. -->
+            <xsl:when test="empty($li/ul)">
+                <xsl:sequence select="ldh:conceptree-expand($context, $li)"/>
+            </xsl:when>
+            <xsl:otherwise>
+                <xsl:sequence select="$context"/>
+            </xsl:otherwise>
+        </xsl:choose>
+    </xsl:function>
+
+    <!-- one node of the path: the target itself ends the walk, anything else opens and continues -->
+    <xsl:function name="ldh:conceptree-step" as="map(*)" ixsl:updating="yes" use-when="system-property('xsl:product-name') = 'SaxonJS'">
+        <xsl:param name="context" as="map(*)"/>
+        <xsl:variable name="li" select="$context('li')" as="element()"/>
+
+        <xsl:choose>
+            <xsl:when test="$li/div/a/@href = $context('target')">
+                <xsl:sequence select="ldh:conceptree-activate($context)"/>
+            </xsl:when>
+            <xsl:when test="empty($li/ul)">
+                <xsl:sequence select="ldh:conceptree-expand($context, $li)"/>
+            </xsl:when>
+            <xsl:otherwise>
+                <xsl:sequence select="ldh:conceptree-descend($context)"/>
+            </xsl:otherwise>
+        </xsl:choose>
+    </xsl:function>
+
+    <!-- Opens one node and fetches its children, then re-enters the descent.
+
+         The disclosure is flipped in place and the loading row emitted, so a pre-expanded level looks
+         exactly like a clicked one - ldh.css hides a subtree purely off aria-expanded, which is why no
+         click needs simulating. The relation follows depth, as the click handlers below do: the root is
+         the scheme, whose children are its top concepts. -->
+    <xsl:function name="ldh:conceptree-expand" as="map(*)" ixsl:updating="yes" use-when="system-property('xsl:product-name') = 'SaxonJS'">
+        <xsl:param name="context" as="map(*)"/>
+        <xsl:param name="li" as="element()"/>
+        <xsl:variable name="uri" select="xs:anyURI($li/div/a/@href)" as="xs:anyURI"/>
+        <xsl:variable name="depth" select="count($li/ancestor::li) + 1" as="xs:integer"/>
+        <xsl:variable name="query" select="
+            if (empty($li/ancestor::li)) then ldh:tree-children-query($uri, xs:anyURI('&skos;topConceptOf'), xs:anyURI('&skos;hasTopConcept'))
+            else ldh:tree-children-query($uri, xs:anyURI('&skos;broader'), xs:anyURI('&skos;narrower'))" as="xs:string"/>
+        <xsl:variable name="request-uri" select="ldh:href(ac:build-uri(sd:endpoint(), map{ 'query': $query }), map{})" as="xs:anyURI"/>
+        <xsl:variable name="request" select="map{ 'method': 'GET', 'href': $request-uri, 'headers': map{ 'Accept': 'application/rdf+xml' } }" as="map(*)"/>
+
+        <xsl:for-each select="$li/div/button">
+            <ixsl:set-attribute name="class" select="ldh:set-token(@class, 'btn-expand-tree', false())"/>
+            <ixsl:set-attribute name="class" select="ldh:set-token(@class, 'btn-expanded-tree', true())"/>
+            <ixsl:set-attribute name="aria-expanded" select="'true'"/>
+            <xsl:for-each select="span[contains-token(@class, 'msi')]">
+                <ixsl:set-property name="textContent" select="'expand_more'" object="."/>
+            </xsl:for-each>
+        </xsl:for-each>
+
+        <xsl:for-each select="$li">
+            <xsl:result-document href="?." method="ixsl:append-content">
+                <ul>
+                    <li class="tree-loading" style="--depth: {$depth}">
+                        <span class="msi sm" aria-hidden="true">progress_activity</span>
+                        <span>
+                            <xsl:apply-templates select="key('resources', 'loading', ldh:translations())" mode="ac:label"/>
+                        </span>
+                    </li>
+                </ul>
+            </xsl:result-document>
+        </xsl:for-each>
+
+        <ixsl:promise select="
+            ixsl:resolve(map:merge(($context, map{ 'request': $request, 'container': $li/ul, 'uri': $uri, 'li': $li }), map{ 'duplicates': 'use-last' })) =>
+                ixsl:then(ldh:http-request-threaded#1) =>
+                ixsl:then(ldh:handle-response#1) =>
+                ixsl:then(ldh:tree-children-response#1) =>
+                ixsl:then(ldh:conceptree-descend#1)
+            " on-failure="ldh:promise-failure#1"/>
+        <xsl:sequence select="$context"/>
+    </xsl:function>
+
+    <!-- Marks the open concept, at every occurrence. Copied from the drawer's ldh:DocTreeActivateHref
+         and scoped to this tree: is-active rides the li so the selected ground spans the disclosure,
+         aria-current rides the anchor, and both are the design system's own tree anatomy. Iterating all
+         matching rows is what makes a polyhierarchical concept light up under each of its parents. -->
+    <xsl:function name="ldh:conceptree-activate" as="map(*)" ixsl:updating="yes" use-when="system-property('xsl:product-name') = 'SaxonJS'">
+        <xsl:param name="context" as="map(*)"/>
+        <xsl:variable name="tree" select="$context('tree')" as="element()"/>
+        <xsl:variable name="target" select="$context('target')" as="xs:anyURI"/>
+
+        <xsl:for-each select="$tree//li[contains-token(@class, 'is-active')]">
+            <ixsl:set-attribute name="class" select="ldh:set-token(@class, 'is-active', false())"/>
+            <xsl:for-each select="div/a">
+                <ixsl:remove-attribute name="aria-current"/>
+            </xsl:for-each>
+        </xsl:for-each>
+        <xsl:for-each select="$tree//li[div/a/@href = $target]">
+            <ixsl:set-attribute name="class" select="ldh:set-token(@class, 'is-active', true())"/>
+            <xsl:for-each select="div/a">
+                <ixsl:set-attribute name="aria-current" select="'page'"/>
+            </xsl:for-each>
+        </xsl:for-each>
+
+        <xsl:sequence select="$context"/>
+    </xsl:function>
 
     <!-- SKOS puts the hierarchy link on whichever end the modeller chose, and both are in use in the
          wild, so every relation below is given from both directions and client/tree.xsl unions them.

--- a/src/main/resources/com/linkeddatahub/packages/skos/layout.xsl
+++ b/src/main/resources/com/linkeddatahub/packages/skos/layout.xsl
@@ -52,6 +52,20 @@ exclude-result-prefixes="#all">
          column width come from the design system's ontology-editor layout (.ldh-onto-list), already
          vendored in app.css; the grid is the platform's, keyed on this slot being filled.
 
+         The tree is rooted at the SCHEME, never at the document's own topic. A tree rooted at the
+         concept you are already looking at shows one node and tells you nothing: what a taxonomy tree
+         is for is placing that concept among the others, so it has to start where the taxonomy starts.
+
+         On a scheme document the topic IS the root. On a concept document the scheme is named by
+         skos:inScheme, which is already in the rendered RDF, and its label comes from the platform's
+         $object-metadata - the same label-only CONSTRUCT that renders "Drinks" as the link text in the
+         property list beside this tree. So the root node costs no request at all. That tunnel
+         parameter does reach this mode: it is set once per render (layout.xsl server-side,
+         client.xsl per pane) and flows down through ldh:ContentBody.
+
+         Falls back to the topic when no scheme resolves - an unplaced concept still gets a tree of
+         itself rather than an empty card.
+
          Anchored on the primary topic of THIS document, not on any SKOS resource in the graph: a
          container listing concept documents describes every child's topic too, and matching those
          would hang a tree off every such listing, rooted at whichever concept happened to come first.
@@ -59,28 +73,36 @@ exclude-result-prefixes="#all">
          Not guarded by use-when: ldh:TreeNode lives in the shared trunk precisely so the tree is in
          the server's first paint, which is the only paint a directly loaded URL gets. -->
     <xsl:template match="rdf:RDF[key('resources', key('resources', ac:absolute-path(ldh:base-uri(.)))/foaf:primaryTopic/@rdf:resource)/rdf:type/@rdf:resource = ('&skos;ConceptScheme', '&skos;Concept')]" mode="ldh:ContentColumn">
+        <xsl:param name="object-metadata" as="document-node()?" tunnel="yes"/>
         <xsl:variable name="topic" select="key('resources', key('resources', ac:absolute-path(ldh:base-uri(.)))/foaf:primaryTopic/@rdf:resource)" as="element()*"/>
-        <!-- the root of a scheme's tree expands over hasTopConcept/topConceptOf, a concept's over broader/narrower;
-             the class is what the ldh:TreeChildrenLoad rules below read at click time -->
-        <xsl:variable name="scheme-root" select="$topic/rdf:type/@rdf:resource = '&skos;ConceptScheme'" as="xs:boolean"/>
+        <xsl:variable name="scheme-uri" select="$topic/skos:inScheme/@rdf:resource" as="attribute()*"/>
+        <!-- described in this document (a scheme page), else in the label metadata (a concept page) -->
+        <xsl:variable name="root" select="(
+            $topic[rdf:type/@rdf:resource = '&skos;ConceptScheme'],
+            key('resources', $scheme-uri),
+            $object-metadata!key('resources', $scheme-uri, .),
+            $topic)[1]" as="element()?"/>
 
-        <div class="ldh-onto-list">
-            <ul class="ldh-tree concept-tree{if ($scheme-root) then ' scheme-root' else ''}">
-                <xsl:apply-templates select="$topic[1]" mode="ldh:TreeNode">
-                    <xsl:with-param name="expandable" select="true()"/>
-                </xsl:apply-templates>
-            </ul>
-        </div>
+        <xsl:if test="$root">
+            <div class="ldh-onto-list">
+                <ul class="ldh-tree concept-tree">
+                    <xsl:apply-templates select="$root" mode="ldh:TreeNode">
+                        <xsl:with-param name="expandable" select="true()"/>
+                    </xsl:apply-templates>
+                </ul>
+            </div>
+        </xsl:if>
     </xsl:template>
 
     <!-- SKOS puts the hierarchy link on whichever end the modeller chose, and both are in use in the
          wild, so every relation below is given from both directions and client/tree.xsl unions them.
 
-         Which relation applies is a question of depth, not of class: the node at the root of this tree
-         is the scheme, whose children are its top concepts; every node below it is a concept, whose
-         children are narrower concepts. count(ancestor::li) tells them apart without a marker class
-         that the generic emitter would have to know how to attach. -->
-    <xsl:template match="button[ancestor::ul[contains-token(@class, 'scheme-root')]][count(ancestor::li) = 1]" mode="ldh:TreeChildrenLoad" priority="1" use-when="system-property('xsl:product-name') = 'SaxonJS'">
+         Which relation applies is a question of depth alone: the root is always the scheme, whose
+         children are its top concepts, and every node below it is a concept, whose children are
+         narrower concepts. count(ancestor::li) tells them apart - no marker class, which is why the
+         scheme-root token this used to carry is gone: with the root always a scheme it distinguished
+         nothing. -->
+    <xsl:template match="button[ancestor::ul[contains-token(@class, 'concept-tree')]][count(ancestor::li) = 1]" mode="ldh:TreeChildrenLoad" priority="1" use-when="system-property('xsl:product-name') = 'SaxonJS'">
         <xsl:param name="container" as="element()"/>
         <xsl:param name="uri" as="xs:anyURI"/>
 

--- a/src/main/resources/com/linkeddatahub/packages/skos/layout.xsl
+++ b/src/main/resources/com/linkeddatahub/packages/skos/layout.xsl
@@ -73,6 +73,7 @@ exclude-result-prefixes="#all">
          Not guarded by use-when: ldh:TreeNode lives in the shared trunk precisely so the tree is in
          the server's first paint, which is the only paint a directly loaded URL gets. -->
     <xsl:template match="rdf:RDF[key('resources', key('resources', ac:absolute-path(ldh:base-uri(.)))/foaf:primaryTopic/@rdf:resource)/rdf:type/@rdf:resource = ('&skos;ConceptScheme', '&skos;Concept')]" mode="ldh:ContentColumn">
+        <xsl:param name="mode" as="xs:anyURI?"/>
         <xsl:param name="object-metadata" as="document-node()?" tunnel="yes"/>
         <xsl:variable name="topic" select="key('resources', key('resources', ac:absolute-path(ldh:base-uri(.)))/foaf:primaryTopic/@rdf:resource)" as="element()*"/>
         <xsl:variable name="scheme-uri" select="$topic/skos:inScheme/@rdf:resource" as="attribute()*"/>
@@ -83,7 +84,15 @@ exclude-result-prefixes="#all">
             $object-metadata!key('resources', $scheme-uri, .),
             $topic)[1]" as="element()?"/>
 
-        <xsl:if test="$root">
+        <!-- ReadMode only. The tree is for reading a concept in its place among the others, and the
+             other document modes have a body it does not belong beside: ContentMode is an authoring
+             surface for the document's own content blocks, and the Map, Chart and Graph canvases take
+             the whole body - ldh.css even zeroes its padding and drops its max-width for them, which a
+             two-column grid would fight. Rendering the tree there put it next to an empty authoring
+             body, which is what prompted this. ac:mode() always resolves to a concrete mode, so the
+             test can be positive: ?mode= when given, else ContentMode for a document that has content
+             blocks, else ReadMode. -->
+        <xsl:if test="$root and $mode = '&ac;ReadMode'">
             <div class="ldh-onto-list">
                 <ul class="ldh-tree concept-tree">
                     <xsl:apply-templates select="$root" mode="ldh:TreeNode">

--- a/src/main/resources/com/linkeddatahub/packages/skos/ns.ttl
+++ b/src/main/resources/com/linkeddatahub/packages/skos/ns.ttl
@@ -16,16 +16,23 @@
 skos:Concept spin:constructor :ConceptConstructor ;
     spin:constraint :MissingPrefLabel , :MissingInScheme .
 
+# The labels and the definition are declared rdf:langString, not xsd:string: a SKOS label is natural
+# language, and SKOS's own integrity rules assume it carries a tag (a concept may have only one
+# prefLabel PER LANGUAGE, which is not even expressible without one). A constructor declaring
+# xsd:string produced a form field with a datatype and no language control, so a label added through
+# the form came out untagged beside the tagged ones already in the data - visible as a value with an
+# xsd:string annotation next to one showing en.
 :ConceptConstructor a ldh:Constructor ;
     rdfs:label "Concept constructor" ;
     sp:text """
         PREFIX skos:    <http://www.w3.org/2004/02/skos/core#>
+        PREFIX rdf:     <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
         PREFIX xsd:     <http://www.w3.org/2001/XMLSchema#>
 
         CONSTRUCT {
-            $this skos:prefLabel [ a xsd:string ] ;
-                skos:altLabel [ a xsd:string ] ;
-                skos:definition [ a xsd:string ] ;
+            $this skos:prefLabel [ a rdf:langString ] ;
+                skos:altLabel [ a rdf:langString ] ;
+                skos:definition [ a rdf:langString ] ;
                 skos:broader [ a skos:Concept ] ;
                 skos:narrower [ a skos:Concept ] ;
                 skos:related [ a skos:Concept ] ;

--- a/src/main/resources/com/linkeddatahub/packages/skos/ns.ttl
+++ b/src/main/resources/com/linkeddatahub/packages/skos/ns.ttl
@@ -14,7 +14,7 @@
 # Concept
 
 skos:Concept spin:constructor :ConceptConstructor ;
-    spin:constraint :MissingPrefLabel .
+    spin:constraint :MissingPrefLabel , :MissingInScheme .
 
 :ConceptConstructor a ldh:Constructor ;
     rdfs:label "Concept constructor" ;
@@ -157,7 +157,55 @@ skos:ConceptScheme spin:constructor :ConceptSchemeConstructor .
         WHERE {}""" ;
     rdfs:isDefinedBy : .
 
-skos:inScheme ldh:inverseView :ConceptsInScheme .
+skos:hasTopConcept ldh:view :TopConcepts .
+
+:TopConcepts a ldh:View ;
+    dct:title "Top concepts" ;
+    spin:query :SelectTopConcepts ;
+    rdfs:isDefinedBy : .
+
+# the entry level of a taxonomy, and the root of the concept tree. Both directions count as a top
+# concept - a scheme may assert skos:hasTopConcept, a concept may assert skos:topConceptOf - because
+# SKOS declares them inverses and leaves the choice to the modeller
+:SelectTopConcepts a sp:Select ;
+    rdfs:label "Select top concepts" ;
+    dct:title "Select top concepts" ;
+    sp:text """
+PREFIX  skos: <http://www.w3.org/2004/02/skos/core#>
+
+SELECT DISTINCT  ?concept
+WHERE
+  { GRAPH ?graph
+      {   { $about  skos:hasTopConcept  ?concept }
+        UNION
+          { ?concept  skos:topConceptOf  $about }
+      }
+  }
+""" ;
+    rdfs:isDefinedBy : .
+
+skos:inScheme ldh:view :ConceptScheme .
+
+:ConceptScheme a ldh:View ;
+    dct:title "Scheme" ;
+    spin:query :SelectConceptScheme ;
+    rdfs:isDefinedBy : .
+
+:SelectConceptScheme a sp:Select ;
+    rdfs:label "Select the scheme a concept belongs to" ;
+    dct:title "Select the scheme a concept belongs to" ;
+    sp:text """
+PREFIX  skos: <http://www.w3.org/2004/02/skos/core#>
+
+SELECT DISTINCT  ?scheme
+WHERE
+  { GRAPH ?graph
+      { $about  skos:inScheme  ?scheme }
+  }
+""" ;
+    rdfs:isDefinedBy : .
+
+skos:inScheme ldh:inverseView :ConceptsInScheme , :OrphanConcepts .
 
 :ConceptsInScheme a ldh:View ;
     dct:title "Concepts in scheme" ;
@@ -181,9 +229,43 @@ ORDER BY ?prefLabel
 """ ;
     rdfs:isDefinedBy : .
 
+# Concepts a scheme lists but nothing places in its hierarchy: neither a top concept nor narrower
+# than anything. A taxonomy with orphans is not wrong, but they are invisible to a tree that
+# descends from the top, so the scheme surfaces them rather than letting them go unreachable
+:OrphanConcepts a ldh:View ;
+    dct:title "Unplaced concepts" ;
+    spin:query :SelectOrphanConcepts ;
+    ldh:showWhenEmpty false ;
+    rdfs:isDefinedBy : .
+
+:SelectOrphanConcepts a sp:Select ;
+    rdfs:label "Select concepts with no place in the hierarchy" ;
+    dct:title "Select concepts with no place in the hierarchy" ;
+    sp:text """
+PREFIX  skos: <http://www.w3.org/2004/02/skos/core#>
+
+SELECT DISTINCT  ?concept
+WHERE
+  { GRAPH ?graph
+      { ?concept  skos:inScheme  $about }
+    FILTER NOT EXISTS { GRAPH ?topGraph { $about skos:hasTopConcept ?concept } }
+    FILTER NOT EXISTS { GRAPH ?topGraph { ?concept skos:topConceptOf $about } }
+    FILTER NOT EXISTS { GRAPH ?broaderGraph { ?concept skos:broader ?parent } }
+    FILTER NOT EXISTS { GRAPH ?narrowerGraph { ?parent skos:narrower ?concept } }
+  }
+""" ;
+    rdfs:isDefinedBy : .
+
 # Constraints
 
 :MissingPrefLabel a ldh:MissingPropertyValue ;
     rdfs:label "Missing skos:prefLabel" ;
     sp:arg1 skos:prefLabel ;
+    rdfs:isDefinedBy : .
+
+# a concept outside every scheme cannot be reached from a scheme's tree, so the package treats
+# skos:inScheme as mandatory even though SKOS itself does not
+:MissingInScheme a ldh:MissingPropertyValue ;
+    rdfs:label "Missing skos:inScheme" ;
+    sp:arg1 skos:inScheme ;
     rdfs:isDefinedBy : .

--- a/src/main/resources/com/linkeddatahub/packages/skos/ns.ttl
+++ b/src/main/resources/com/linkeddatahub/packages/skos/ns.ttl
@@ -51,7 +51,9 @@ PREFIX  skos: <http://www.w3.org/2004/02/skos/core#>
 SELECT DISTINCT  ?narrower
 WHERE
   { GRAPH ?graph
-      { $about  skos:narrower  ?narrower .
+      {   { $about  skos:narrower  ?narrower }
+        UNION
+          { ?narrower  skos:broader  $about }
         GRAPH ?narrowerGraph
         {
           ?narrower skos:prefLabel ?prefLabel .
@@ -80,7 +82,9 @@ PREFIX  skos: <http://www.w3.org/2004/02/skos/core#>
 SELECT DISTINCT  ?broader
 WHERE
   { GRAPH ?graph
-      { $about  skos:broader  ?broader .
+      {   { $about  skos:broader  ?broader }
+        UNION
+          { ?broader  skos:narrower  $about }
         GRAPH ?broaderGraph
         {
           ?broader skos:prefLabel ?prefLabel .
@@ -165,8 +169,15 @@ skos:hasTopConcept ldh:view :TopConcepts .
     rdfs:isDefinedBy : .
 
 # the entry level of a taxonomy, and the root of the concept tree. Both directions count as a top
-# concept - a scheme may assert skos:hasTopConcept, a concept may assert skos:topConceptOf - because
-# SKOS declares them inverses and leaves the choice to the modeller
+# Every hierarchy query below reads BOTH directions, for the same reason: SKOS declares
+# skos:broader/skos:narrower and skos:hasTopConcept/skos:topConceptOf as inverse pairs and leaves the
+# choice to the modeller, so a parent may point down or a child may point up and both are correct.
+# Reading one direction made a view disagree with the concept tree, which unions them: measured on the
+# fixture, Hot drinks' Narrower block showed 1 child where the tree showed 3, because Coffee and Tea
+# assert skos:broader upwards, and Juice's Broader block showed nothing while the tree nested it under
+# Hot drinks. The union stays INSIDE the link's GRAPH rather than becoming a sibling block, because
+# SPARQLBuilder's round-trip merges sibling GRAPH blocks into one and would scope the child's label to
+# the link's document.
 :SelectTopConcepts a sp:Select ;
     rdfs:label "Select top concepts" ;
     dct:title "Select top concepts" ;

--- a/src/main/resources/com/linkeddatahub/packages/skos/package.ttl
+++ b/src/main/resources/com/linkeddatahub/packages/skos/package.ttl
@@ -13,8 +13,9 @@
     dct:description "Provides SKOS (Simple Knowledge Organization System) vocabulary support with custom templates for concept hierarchies, schemes, and collections." ;
     dct:creator <https://atomgraph.com/#company> ;
     ldt:ontology <https://raw.githubusercontent.com/AtomGraph/LinkedDataHub-Apps/refs/heads/master/packages/skos/ns.ttl#> ;
-    # the stylesheet is fetched live at import time and must match this branch's mode contract; releases point back at master
-    ac:stylesheet <https://raw.githubusercontent.com/AtomGraph/LinkedDataHub-Apps/refs/heads/develop/packages/skos/layout.xsl> .
+    # relative to this description's own URI, and mapped to a bundled file, so the package resolves
+    # entirely offline: no fetch from a branch whose content can change after review
+    ac:stylesheet <layout.xsl> .
 
 <https://atomgraph.com/#company> a foaf:Organization ;
     foaf:name "AtomGraph" ;

--- a/src/main/resources/prefix-mapping.ttl
+++ b/src/main/resources/prefix-mapping.ttl
@@ -74,5 +74,6 @@
    [ lm:prefix "http://spinrdf.org/spl" ;                                        lm:altName "etc/spl.spin.ttl" ] ,
    [ lm:prefix "https://packages.linkeddatahub.com/" ;                           lm:altName "com/linkeddatahub/packages/packages.ttl" ] ,
    [ lm:prefix "https://packages.linkeddatahub.com/skos/" ;                      lm:altName "com/linkeddatahub/packages/skos/package.ttl" ] ,
-   [ lm:prefix "https://raw.githubusercontent.com/AtomGraph/LinkedDataHub-Apps/refs/heads/master/packages/skos/ns.ttl" ; lm:altName "com/linkeddatahub/packages/skos/ns.ttl" ]
+   [ lm:prefix "https://raw.githubusercontent.com/AtomGraph/LinkedDataHub-Apps/refs/heads/master/packages/skos/ns.ttl" ; lm:altName "com/linkeddatahub/packages/skos/ns.ttl" ] ,
+   [ lm:name "https://packages.linkeddatahub.com/skos/layout.xsl" ;              lm:altName "com/linkeddatahub/packages/skos/layout.xsl" ]
 .

--- a/src/main/webapp/WEB-INF/web.xml
+++ b/src/main/webapp/WEB-INF/web.xml
@@ -363,6 +363,9 @@ support@atomgraph.com]]></param-value>
     <listener>
         <listener-class>com.atomgraph.linkeddatahub.listener.GraphVersioningListener</listener-class>
     </listener>
+    <listener>
+        <listener-class>com.atomgraph.linkeddatahub.listener.ClientStylesheetListener</listener-class>
+    </listener>
     <servlet-mapping>
         <servlet-name>default</servlet-name>
         <url-pattern>/static/*</url-pattern>

--- a/src/main/webapp/static/com/atomgraph/linkeddatahub/css/ldh.css
+++ b/src/main/webapp/static/com/atomgraph/linkeddatahub/css/ldh.css
@@ -511,6 +511,18 @@ body:has(.ldh-create-dock) .ldh-footer { margin-top: 0; }
 /* only create-bar pages need the column itself stretched (its children become flex items) */
 .document-body > .content-body:has(> .ldh-create-dock) { flex: 1 0 auto; display: flex; flex-direction: column; padding-bottom: 0; }
 
+/* ---------- ldh:ContentColumn: a package filling the slot turns the content body into two columns.
+   Values are the design system's ontology-editor grid (.ldh-onto-grid), applied to .content-body
+   itself rather than to a wrapper so the gutter, the content width and the dock's containing block
+   all stay where the rules above expect them. Written with .document-body > so it outranks the
+   flex rule directly above, which the dock's presence would otherwise win. The dock spans both
+   columns: it is the document's affordance, not the content column's. */
+.document-body > .content-body:has(> .ldh-onto-list) { display: grid; grid-template-columns: 300px minmax(0, 1fr); gap: var(--sp-5); align-items: start; }
+.document-body > .content-body:has(> .ldh-onto-list) > .ldh-create-dock { grid-column: 1 / -1; }
+@media (max-width: 900px) {
+  .document-body > .content-body:has(> .ldh-onto-list) { grid-template-columns: minmax(0, 1fr); }
+}
+
 /* ---------- .map-canvas in the design is a picture of a map: an absolute fill for a frame that
    already has a size, painted with a gradient landmass and a grid. LDH hands the same element to
    OpenLayers as a live map target, where it is an ordinary in-flow block that carries its own

--- a/src/main/webapp/static/com/atomgraph/linkeddatahub/css/ldh.css
+++ b/src/main/webapp/static/com/atomgraph/linkeddatahub/css/ldh.css
@@ -511,16 +511,19 @@ body:has(.ldh-create-dock) .ldh-footer { margin-top: 0; }
 /* only create-bar pages need the column itself stretched (its children become flex items) */
 .document-body > .content-body:has(> .ldh-create-dock) { flex: 1 0 auto; display: flex; flex-direction: column; padding-bottom: 0; }
 
-/* ---------- ldh:ContentColumn: a package filling the slot turns the content body into two columns.
-   Values are the design system's ontology-editor grid (.ldh-onto-grid), applied to .content-body
-   itself rather than to a wrapper so the gutter, the content width and the dock's containing block
-   all stay where the rules above expect them. Written with .document-body > so it outranks the
-   flex rule directly above, which the dock's presence would otherwise win. The dock spans both
-   columns: it is the document's affordance, not the content column's. */
-.document-body > .content-body:has(> .ldh-onto-list) { display: grid; grid-template-columns: 300px minmax(0, 1fr); gap: var(--sp-5); align-items: start; }
-.document-body > .content-body:has(> .ldh-onto-list) > .ldh-create-dock { grid-column: 1 / -1; }
+/* ---------- ldh:ContentColumn: a filled slot turns the content body into two columns.
+   Keyed on .ldh-content-aside, the wrapper ldh:ContentBody puts around whatever fills the slot -
+   NOT on what fills it. It was keyed on the ontology editor's .ldh-onto-list at first, which made a
+   general extension point fire only for one component's class: every package would have had to
+   borrow that card to get a column, and an aside that is not a card got no layout at all.
+   The grid applies to .content-body itself rather than to an outer wrapper so the gutter, the content
+   width and the dock's containing block all stay where the rules above expect them. Written with
+   .document-body > so it outranks the flex rule directly above, which the dock's presence would
+   otherwise win. The dock spans both columns: it is the document's affordance, not the aside's. */
+.document-body > .content-body:has(> .ldh-content-aside) { display: grid; grid-template-columns: 300px minmax(0, 1fr); gap: var(--sp-5); align-items: start; }
+.document-body > .content-body:has(> .ldh-content-aside) > .ldh-create-dock { grid-column: 1 / -1; }
 @media (max-width: 900px) {
-  .document-body > .content-body:has(> .ldh-onto-list) { grid-template-columns: minmax(0, 1fr); }
+  .document-body > .content-body:has(> .ldh-content-aside) { grid-template-columns: minmax(0, 1fr); }
 }
 
 /* ---------- .map-canvas in the design is a picture of a map: an absolute fill for a frame that

--- a/src/main/webapp/static/com/atomgraph/linkeddatahub/xsl/client.xsl
+++ b/src/main/webapp/static/com/atomgraph/linkeddatahub/xsl/client.xsl
@@ -80,6 +80,7 @@ extension-element-prefixes="ixsl"
     <xsl:include href="client/query-transforms.xsl"/>
     <xsl:include href="client/combobox.xsl"/>
     <xsl:include href="client/functions.xsl"/>
+    <xsl:include href="client/tree.xsl"/>
     <xsl:include href="client/navigation.xsl"/>
     <xsl:include href="client/block.xsl"/>
     <xsl:include href="client/modal.xsl"/>

--- a/src/main/webapp/static/com/atomgraph/linkeddatahub/xsl/client/block.xsl
+++ b/src/main/webapp/static/com/atomgraph/linkeddatahub/xsl/client/block.xsl
@@ -118,15 +118,16 @@ exclude-result-prefixes="#all"
     </xsl:variable>
     
     <!-- combined forward + inverse view-block lookup; substitutes VALUES ?type { ... } from the resource's rdf:types.
-         Besides ?block, binds the inline-creation metadata: attachment ?property, ?inverse direction flag, the ?forClass
-         to construct (property range for forward views, domain for inverse ones) and the view's ldh:container/ldh:showWhenEmpty.
-         Runs against the /ns ontology union, so ldh:container asserted on a package view from the app's own namespace is visible. -->
+         Besides ?block, binds the attachment ?property, the ?inverse direction flag, the ?forClass to construct
+         (property range for forward views, domain for inverse ones) and the view's ldh:showWhenEmpty.
+         No container: where a view creates into is a property of its results rather than of its declaration,
+         so it is determined per view by ldh:ViewContainer in block/view.xsl. -->
     <xsl:variable name="ontology-view-query" as="xs:string">
         <![CDATA[
             PREFIX  rdfs: <http://www.w3.org/2000/01/rdf-schema#>
             PREFIX  ldh:  <https://w3id.org/atomgraph/linkeddatahub#>
 
-            SELECT DISTINCT ?block ?property ?inverse ?forClass ?container ?showWhenEmpty
+            SELECT DISTINCT ?block ?property ?inverse ?forClass ?showWhenEmpty
             WHERE {
               {
                 ?property  ldh:view  ?block .
@@ -153,7 +154,6 @@ exclude-result-prefixes="#all"
                     { ?property  rdfs:subPropertyOf+/rdfs:domain  ?forClass }
                 }
               }
-              OPTIONAL { ?block  ldh:container  ?container }
               OPTIONAL { ?block  ldh:showWhenEmpty  ?showWhenEmpty }
             }
         ]]>
@@ -875,9 +875,6 @@ exclude-result-prefixes="#all"
                         <xsl:for-each select="srx:binding[@name = 'forClass']/srx:uri">
                             <xsl:sequence select="map{ 'view-for-class': xs:anyURI(.) }"/>
                         </xsl:for-each>
-                        <xsl:for-each select="srx:binding[@name = 'container']/srx:uri">
-                            <xsl:sequence select="map{ 'view-container': xs:anyURI(.) }"/>
-                        </xsl:for-each>
                         <xsl:for-each select="srx:binding[@name = 'showWhenEmpty']/srx:literal">
                             <xsl:sequence select="map{ 'view-show-when-empty': string(.) }"/>
                         </xsl:for-each>
@@ -921,33 +918,20 @@ exclude-result-prefixes="#all"
         <xsl:sequence select="$context"/>
     </xsl:function>
 
-    <!-- render one view block from its loaded RDF. Creatable views (ldh:container + inferred forClass) first HEAD the container for its acl:mode Link headers, which gate the Create button; the rest insert directly.
-         The HEAD chain is returned rather than fired: the caller has to settle after the block is in the DOM, not before it is fetched (see ldh:ontology-view-fanout) -->
+    <!-- render one view block from its loaded RDF.
+         Nothing is probed here any more: which container a view creates into is a question about its
+         results, not about its declaration, so block/view.xsl asks it once the results are in and probes
+         whichever container the answer names (ldh:ViewContainer). This stayed a thunk because the caller
+         has to settle after the block is in the DOM, not before it is fetched - see ldh:ontology-view-fanout -->
     <xsl:function name="ldh:ontology-view-render-thunk" as="item()*" ixsl:updating="yes">
         <xsl:param name="context" as="map(*)"/>
 
         <xsl:message>ldh:ontology-view-render-thunk</xsl:message>
 
-        <xsl:choose>
-            <xsl:when test="map:contains($context, 'view-container') and map:contains($context, 'view-for-class')">
-                <xsl:variable name="container-request" select="map{ 'method': 'HEAD', 'href': ldh:href($context('view-container'), map{}), 'headers': map{ 'Accept': 'application/rdf+xml' } }" as="map(*)"/>
-                <xsl:variable name="container-context" select="map:merge(($context, map{ 'container-request': $container-request }))" as="map(*)"/>
-
-                <xsl:sequence select="
-                    ixsl:resolve($container-context) =>
-                        ixsl:then(ldh:http-request-threaded(?, 'container-request', 'container-response')) =>
-                        ixsl:then(ldh:handle-response(?, 'container-response')) =>
-                        ixsl:then(ldh:set-container-acl-modes#1) =>
-                        ixsl:then(ldh:ontology-view-insert#1)
-                    "/>
-            </xsl:when>
-            <xsl:otherwise>
-                <xsl:sequence select="ldh:ontology-view-insert($context)"/>
-            </xsl:otherwise>
-        </xsl:choose>
+        <xsl:sequence select="ldh:ontology-view-insert($context)"/>
     </xsl:function>
 
-    <!-- extract acl:mode URIs from the container HEAD response's Link headers (emitted by ResponseHeadersFilter, forwarded for remote containers by ProxyRequestFilter); same parsing as ldh:rdf-document-response. A non-200 response yields no modes, which downstream reads as no Create button -->
+    <!-- extract acl:mode URIs from a container HEAD response's Link headers (emitted by ResponseHeadersFilter, forwarded for remote containers by ProxyRequestFilter); same parsing as ldh:rdf-document-response. A non-200 response yields no modes, which downstream reads as no Create button. Called from ldh:view-container-acl-thunk once a view's container has been determined -->
     <xsl:function name="ldh:set-container-acl-modes" as="map(*)" ixsl:updating="no">
         <xsl:param name="context" as="map(*)"/>
         <xsl:variable name="response" select="$context('container-response')" as="map(*)"/>
@@ -1027,14 +1011,8 @@ exclude-result-prefixes="#all"
                                     <xsl:if test="map:contains($context, 'view-for-class')">
                                         <ixsl:set-attribute name="data-for-class" select="string($context('view-for-class'))" object="."/>
                                     </xsl:if>
-                                    <xsl:if test="map:contains($context, 'view-container')">
-                                        <ixsl:set-attribute name="data-container" select="string($context('view-container'))" object="."/>
-                                    </xsl:if>
                                     <xsl:if test="map:contains($context, 'view-show-when-empty')">
                                         <ixsl:set-attribute name="data-show-when-empty" select="string($context('view-show-when-empty'))" object="."/>
-                                    </xsl:if>
-                                    <xsl:if test="map:contains($context, 'container-acl-modes')">
-                                        <ixsl:set-attribute name="data-acl-modes" select="string-join($context('container-acl-modes'), ' ')" object="."/>
                                     </xsl:if>
                                 </xsl:for-each>
 

--- a/src/main/webapp/static/com/atomgraph/linkeddatahub/xsl/client/block/view.xsl
+++ b/src/main/webapp/static/com/atomgraph/linkeddatahub/xsl/client/block/view.xsl
@@ -371,6 +371,136 @@ exclude-result-prefixes="#all"
             on-failure="ldh:promise-failure#1"/>
     </xsl:template>
     
+    <!-- container determination -->
+
+    <!-- Asks which container a new solution of this projection would be stored in, so the Create button
+         knows where to PUT. Modelled on ldh:ResultCount above, and for the same reason: the rendered rows
+         are one page, so the question has to be put to the whole result set rather than to a sample -
+         otherwise the destination could depend on which page the reader happened to be looking at.
+         LIMIT/OFFSET/ORDER BY come off first for exactly that reason; ordering is irrelevant to a set. -->
+    <xsl:template name="ldh:ViewContainer">
+        <xsl:param name="create-id" as="xs:string"/>
+        <xsl:param name="endpoint" as="xs:anyURI"/>
+        <xsl:param name="select-xml" as="document-node()"/>
+        <xsl:param name="focus-var-name" as="xs:string"/>
+        <xsl:variable name="select-xml" as="document-node()">
+            <xsl:document>
+                <xsl:variable name="select-xml" as="document-node()">
+                    <xsl:document>
+                        <xsl:apply-templates select="$select-xml" mode="ldh:replace-limit"/>
+                    </xsl:document>
+                </xsl:variable>
+                <xsl:variable name="select-xml" as="document-node()">
+                    <xsl:document>
+                        <xsl:apply-templates select="$select-xml" mode="ldh:replace-offset"/>
+                    </xsl:document>
+                </xsl:variable>
+                <xsl:variable name="select-xml" as="document-node()">
+                    <xsl:document>
+                        <xsl:apply-templates select="$select-xml" mode="ldh:replace-order-by"/>
+                    </xsl:document>
+                </xsl:variable>
+                <xsl:apply-templates select="$select-xml" mode="ldh:container-select">
+                    <xsl:with-param name="focus-var-name" select="$focus-var-name" tunnel="yes"/>
+                </xsl:apply-templates>
+            </xsl:document>
+        </xsl:variable>
+        <xsl:variable name="select-json-string" select="xml-to-json($select-xml)" as="xs:string"/>
+        <xsl:variable name="select-json" select="ixsl:call(ixsl:get(ixsl:window(), 'JSON'), 'parse', [ $select-json-string ])"/>
+        <xsl:variable name="query-string" select="ixsl:call(ixsl:call(ixsl:get(ixsl:get(ixsl:window(), 'SPARQLBuilder'), 'SelectBuilder'), 'fromQuery', [ $select-json ]), 'toString', [])" as="xs:string"/>
+        <xsl:variable name="request-uri" select="ldh:href($endpoint, map{})" as="xs:anyURI"/>
+        <xsl:variable name="request" select="map{ 'method': 'POST', 'href': $request-uri, 'media-type': 'application/sparql-query', 'body': $query-string, 'headers': map{ 'Accept': 'application/sparql-results+xml' } }" as="map(*)"/>
+        <xsl:variable name="context" as="map(*)" select="
+          map {
+            'request': $request,
+            'create-id': $create-id
+          }"/>
+
+        <ixsl:promise select="ixsl:http-request($context('request')) =>
+            ixsl:then(ldh:rethread-response($context, ?)) =>
+            ixsl:then(ldh:handle-response#1) =>
+            ixsl:then(ldh:view-container-response#1) =>
+            ixsl:then(ldh:view-container-acl-thunk#1)"
+            on-failure="ldh:promise-failure#1"/>
+    </xsl:template>
+
+    <!-- Exactly one row means the destination is determined. None means the projection is empty - there is
+         nothing to generalise from, which is the bootstrap case - and two mean the solutions span containers,
+         so nothing here can say where a new one belongs. Both non-answers leave the slot empty rather than
+         guessing: a majority would let placement be decided by counting, and picking the host's own container
+         would key it on where the view happens to be rendered rather than on what is being created. -->
+    <xsl:function name="ldh:view-container-response" as="map(*)" ixsl:updating="no">
+        <xsl:param name="context" as="map(*)"/>
+        <xsl:variable name="response" select="$context('response')" as="map(*)"/>
+
+        <xsl:choose>
+            <xsl:when test="$response?status = 200 and $response?media-type = 'application/sparql-results+xml'">
+                <xsl:variable name="containers" select="$response?body//srx:result/srx:binding/srx:uri/xs:anyURI(.)" as="xs:anyURI*"/>
+
+                <xsl:choose>
+                    <xsl:when test="count($containers) = 1">
+                        <xsl:sequence select="map:merge(($context, map{ 'create-container': $containers }))"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                        <xsl:sequence select="$context"/>
+                    </xsl:otherwise>
+                </xsl:choose>
+            </xsl:when>
+            <xsl:otherwise>
+                <xsl:sequence select="$context"/>
+            </xsl:otherwise>
+        </xsl:choose>
+    </xsl:function>
+
+    <!-- A determined container still has to be writable, and only the server knows. HEAD it for the acl:mode
+         Link headers, reusing the parse ldh:ontology-view-render-thunk already uses for the same purpose. The
+         probe follows the determination rather than preceding it, because until the query answers there is no
+         container to probe - so the button appears a moment after the toolbar, which is the honest order: one
+         that appeared and then failed its PUT would be worse. -->
+    <xsl:function name="ldh:view-container-acl-thunk" as="item()*" ixsl:updating="yes">
+        <xsl:param name="context" as="map(*)"/>
+
+        <xsl:if test="map:contains($context, 'create-container')">
+            <xsl:variable name="container-request" select="map{ 'method': 'HEAD', 'href': ldh:href($context('create-container'), map{}), 'headers': map{ 'Accept': 'application/rdf+xml' } }" as="map(*)"/>
+            <xsl:variable name="container-context" select="map:merge(($context, map{ 'container-request': $container-request }))" as="map(*)"/>
+
+            <xsl:sequence select="
+                ixsl:resolve($container-context) =>
+                    ixsl:then(ldh:http-request-threaded(?, 'container-request', 'container-response')) =>
+                    ixsl:then(ldh:handle-response(?, 'container-response')) =>
+                    ixsl:then(ldh:set-container-acl-modes#1) =>
+                    ixsl:then(ldh:view-create-insert#1)
+                "/>
+        </xsl:if>
+    </xsl:function>
+
+    <!-- Fills the toolbar's create slot. The class to construct is still read off the view card, where the
+         ontology query's range/domain inference stamped it; a view whose property has no URI range cannot be
+         constructed and gets no button. A forward view additionally PATCHes the linking triple into the
+         current document, so it needs acl:Write here as well as on the container - an inverse one ships that
+         triple inside the PUT and does not. -->
+    <xsl:function name="ldh:view-create-insert" as="item()*" ixsl:updating="yes">
+        <xsl:param name="context" as="map(*)"/>
+        <xsl:variable name="acl-modes" select="$context('container-acl-modes')" as="xs:anyURI*"/>
+
+        <xsl:if test="$acl-modes = '&acl;Write'">
+            <xsl:for-each select="id($context('create-id'), ixsl:page())">
+                <xsl:variable name="view-block" select="ancestor::div[contains-token(@class, 'block')][1]" as="element()?"/>
+                <xsl:variable name="create-for-class" select="$view-block/@data-for-class" as="xs:string?"/>
+
+                <xsl:if test="exists($create-for-class) and (exists($view-block/@data-inverse) or acl:mode() = '&acl;Write')">
+                    <xsl:result-document href="?." method="ixsl:replace-content">
+                        <button type="button" class="ac-btn in-primary ap-solid sz-sm add-instance" data-for-class="{$create-for-class}" data-container="{$context('create-container')}" title="{ac:label(key('resources', 'create-instance-title', ldh:translations()))}">
+                            <xsl:value-of>
+                                <xsl:apply-templates select="key('resources', 'create', ldh:translations())" mode="ac:label"/>
+                            </xsl:value-of>
+                        </button>
+                    </xsl:result-document>
+                </xsl:if>
+            </xsl:for-each>
+        </xsl:if>
+    </xsl:function>
+
     <!-- pager -->
 
     <!-- fills the persistent pager host emitted beside .container-results by ldh:RenderViewResults. The host
@@ -1118,17 +1248,11 @@ exclude-result-prefixes="#all"
                         <!-- facet pills are appended here by ldh:RenderFacets -->
                     </div>
                     <div class="right">
-                        <!-- inline creation: Create button for views carrying ldh:container metadata (stamped as data-* attributes by ldh:ontology-view-insert, RDFa as fallback for hand-authored view blocks). PUT into the container requires acl:Write there (checked on the parent URI for new documents); forward views additionally PATCH the linking triple into the current document, hence acl:Write here too -->
-                        <xsl:variable name="view-block" select="$container/ancestor::div[contains-token(@class, 'block')][1]" as="element()?"/>
-                        <xsl:variable name="create-container" select="($view-block/@data-container, $container/descendant::*[@property = '&ldh;container']/@resource)[1]" as="xs:string?"/>
-                        <xsl:variable name="create-for-class" select="$view-block/@data-for-class" as="xs:string?"/>
-                        <xsl:if test="exists($create-container) and exists($create-for-class) and tokenize($view-block/@data-acl-modes, ' ') = '&acl;Write' and (exists($view-block/@data-inverse) or acl:mode() = '&acl;Write')">
-                            <button type="button" class="ac-btn in-primary ap-solid sz-sm add-instance" data-for-class="{$create-for-class}" data-container="{$create-container}" title="{ac:label(key('resources', 'create-instance-title', ldh:translations()))}">
-                                <xsl:value-of>
-                                    <xsl:apply-templates select="key('resources', 'create', ldh:translations())" mode="ac:label"/>
-                                </xsl:value-of>
-                            </button>
-                        </xsl:if>
+                        <!-- inline creation: an empty slot, filled by ldh:view-create-insert once the container
+                             determination and its ACL probe have resolved. Nothing is declared and nothing is
+                             read off the view here - where a new solution of this projection would be stored is
+                             a question about the data, asked by ldh:ViewContainer -->
+                        <span id="{$container-id}-create"></span>
 
                         <span id="{$result-count-container-id}" class="count"/>
 
@@ -1221,6 +1345,19 @@ exclude-result-prefixes="#all"
 
                 <xsl:sequence select="$form-actions"/>
             </xsl:result-document>
+        </xsl:if>
+
+        <!-- the container a new solution of this projection would be stored in, asked once per view. Fired
+             after the toolbar is in the DOM, because the slot it fills has to exist before the response
+             arrives, and only on the initial load: the answer is a property of the query, so paging,
+             sorting and faceting cannot change it -->
+        <xsl:if test="$initial-load">
+            <xsl:call-template name="ldh:ViewContainer">
+                <xsl:with-param name="create-id" select="$container-id || '-create'"/>
+                <xsl:with-param name="focus-var-name" select="$focus-var-name"/>
+                <xsl:with-param name="endpoint" select="$endpoint"/>
+                <xsl:with-param name="select-xml" select="$select-xml"/>
+            </xsl:call-template>
         </xsl:if>
 
         <!-- result count: stays in sync with re-queried results (e.g. modal search keyword changes). Short-circuit the COUNT HTTP request when the entire result set fits in one page — typical for narrowed search queries. -->
@@ -3268,7 +3405,8 @@ exclude-result-prefixes="#all"
         ]]>
     </xsl:variable>
 
-    <!-- open the instance creation modal form for a view carrying ldh:container metadata (stamped as data-* attributes by ldh:ontology-view-insert) -->
+    <!-- open the instance creation modal form. @data-container was written by ldh:view-create-insert from the
+         container determination, @data-for-class by ldh:ontology-view-insert from the ontology query -->
     <xsl:template match="div[contains-token(@class, 'block')]//button[contains-token(@class, 'add-instance')][@data-for-class][@data-container]" mode="ixsl:onclick">
         <xsl:sequence select="ixsl:call(ixsl:event(), 'preventDefault', [])[current-date() lt xs:date('2000-01-01')]"/>
         <xsl:variable name="view-block" select="ancestor::div[contains-token(@class, 'block')][@data-property][1]" as="element()"/>

--- a/src/main/webapp/static/com/atomgraph/linkeddatahub/xsl/client/functions.xsl
+++ b/src/main/webapp/static/com/atomgraph/linkeddatahub/xsl/client/functions.xsl
@@ -117,6 +117,12 @@ exclude-result-prefixes="#all"
         <xsl:sequence select="if (ixsl:contains(ixsl:window(), 'LinkedDataHub.timemap') and not(ixsl:get(ixsl:window(), 'LinkedDataHub.timemap') = '')) then xs:anyURI(ixsl:get(ixsl:window(), 'LinkedDataHub.timemap')) else ()"/>
     </xsl:function>
 
+    <!-- the composed client stylesheet's URL is consumed when the bootstrap is written, which only
+         happens server-side; by the time this stylesheet runs, it is the one already running -->
+    <xsl:function name="ldh:client-stylesheet" as="xs:anyURI?">
+        <xsl:sequence select="()"/>
+    </xsl:function>
+
     <!-- Memento-Datetime is a response header, not available in the client context; ?version= pages render server-side -->
     <xsl:function name="ldh:memento-datetime" as="xs:string?">
         <xsl:sequence select="()"/>

--- a/src/main/webapp/static/com/atomgraph/linkeddatahub/xsl/client/navigation.xsl
+++ b/src/main/webapp/static/com/atomgraph/linkeddatahub/xsl/client/navigation.xsl
@@ -266,7 +266,7 @@ ORDER BY DESC(?created)
          sioc:has_container, a container at its parent with sioc:has_parent, and neither end carries
          the inverse. Shared by the disclosure and by ldh:doctree-descend, which walks the same
          relation ahead of the user -->
-    <xsl:function name="ldh:doc-tree-children-query" as="document-node()">
+    <xsl:function name="ldh:doc-tree-children-query" as="xs:string">
         <xsl:param name="uri" as="xs:anyURI"/>
 
         <xsl:sequence select="ldh:tree-children-query($uri, (xs:anyURI('&sioc;has_parent'), xs:anyURI('&sioc;has_container')), ())"/>
@@ -281,7 +281,7 @@ ORDER BY DESC(?created)
         <xsl:call-template name="ldh:TreeChildrenFetch">
             <xsl:with-param name="container" select="$container"/>
             <xsl:with-param name="uri" select="$uri"/>
-            <xsl:with-param name="select-xml" select="ldh:doc-tree-children-query($uri)"/>
+            <xsl:with-param name="query" select="ldh:doc-tree-children-query($uri)"/>
         </xsl:call-template>
     </xsl:template>
     
@@ -487,15 +487,7 @@ ORDER BY DESC(?created)
                         </xsl:for-each>
 
                         <!-- Load children and continue descent after loading -->
-                        <xsl:variable name="select-xml" select="ldh:doc-tree-children-query($current-href)" as="document-node()"/>
-
-                        <!-- Wrap SELECT into a DESCRIBE -->
-                        <xsl:variable name="query-xml" as="element()">
-                            <xsl:apply-templates select="$select-xml" mode="ldh:wrap-describe"/>
-                        </xsl:variable>
-                        <xsl:variable name="query-json-string" select="xml-to-json($query-xml)" as="xs:string"/>
-                        <xsl:variable name="query-json" select="ixsl:call(ixsl:get(ixsl:window(), 'JSON'), 'parse', [ $query-json-string ])"/>
-                        <xsl:variable name="query-string" select="ixsl:call(ixsl:call(ixsl:get(ixsl:get(ixsl:window(), 'SPARQLBuilder'), 'SelectBuilder'), 'fromQuery', [ $query-json ]), 'toString', [])" as="xs:string"/>
+                        <xsl:variable name="query-string" select="ldh:doc-tree-children-query($current-href)" as="xs:string"/>
                         <xsl:variable name="results-uri" select="ac:build-uri(sd:endpoint(), map{ 'query': $query-string })" as="xs:anyURI"/>
                         <xsl:variable name="request-uri" select="ldh:href($results-uri, map{})" as="xs:anyURI"/>
                         <xsl:variable name="request" select="map{ 'method': 'GET', 'href': $request-uri, 'headers': map{ 'Accept': 'application/rdf+xml' } }" as="map(*)"/>

--- a/src/main/webapp/static/com/atomgraph/linkeddatahub/xsl/client/navigation.xsl
+++ b/src/main/webapp/static/com/atomgraph/linkeddatahub/xsl/client/navigation.xsl
@@ -262,25 +262,14 @@ ORDER BY DESC(?created)
         </xsl:choose>
     </xsl:template>
 
-    <!-- the children of a node in the document tree, as ldh:SelectChildren asks for them: the documents
-         whose sioc:has_container is that node. Shared by the disclosure and by ldh:doctree-descend, which
-         walks the same relation ahead of the user -->
+    <!-- the document hierarchy's relation, named once: a document points at its container with
+         sioc:has_container, a container at its parent with sioc:has_parent, and neither end carries
+         the inverse. Shared by the disclosure and by ldh:doctree-descend, which walks the same
+         relation ahead of the user -->
     <xsl:function name="ldh:doc-tree-children-query" as="document-node()">
         <xsl:param name="uri" as="xs:anyURI"/>
 
-        <xsl:variable name="select-string" select="key('resources', '&ldh;SelectChildren', document(ac:document-uri('&ldh;')))/sp:text" as="xs:string"/>
-        <xsl:variable name="select-string" select="replace($select-string, '$this', '&lt;' || $uri || '&gt;', 'q')" as="xs:string"/>
-        <xsl:variable name="select-json" as="item()">
-            <xsl:variable name="select-builder" select="ixsl:call(ixsl:get(ixsl:get(ixsl:window(), 'SPARQLBuilder'), 'SelectBuilder'), 'fromString', [ $select-string ])"/>
-            <xsl:sequence select="ixsl:call($select-builder, 'build', [])"/>
-        </xsl:variable>
-        <xsl:variable name="select-json-string" select="ixsl:call(ixsl:get(ixsl:window(), 'JSON'), 'stringify', [ $select-json ])" as="xs:string"/>
-        <!-- replace ?child ?thing with ?child - we don't need the topics of documents here -->
-        <xsl:document>
-            <xsl:apply-templates select="json-to-xml($select-json-string)" mode="ldh:replace-variables">
-                <xsl:with-param name="var-names" select="('child')" tunnel="yes"/>
-            </xsl:apply-templates>
-        </xsl:document>
+        <xsl:sequence select="ldh:tree-children-query($uri, (xs:anyURI('&sioc;has_parent'), xs:anyURI('&sioc;has_container')), ())"/>
     </xsl:function>
 
     <!-- binds the drawer's tree to containment. client/tree.xsl dispatches on the disclosure button, so

--- a/src/main/webapp/static/com/atomgraph/linkeddatahub/xsl/client/navigation.xsl
+++ b/src/main/webapp/static/com/atomgraph/linkeddatahub/xsl/client/navigation.xsl
@@ -467,43 +467,30 @@ ORDER BY DESC(?created)
                 <xsl:variable name="expand-button" select="$current-li/div/button[contains-token(@class, 'btn-expand-tree')]" as="element()?"/>
 
                 <xsl:choose>
-                    <!-- Case 2a: Has expand button and not expanded yet - expand and load children -->
+                    <!-- Case 2a: Has expand button and not expanded yet - expand and load children.
+
+                         Opened and fetched with the widget's own templates, so pre-expanding a level
+                         ahead of the reader is the same act as clicking it: the loading row shows, the
+                         cursor goes busy and resets, and a failure reaches ldh:promise-failure. This
+                         used to hand-roll all three and got each one wrong - a bare <ul/> with no
+                         loading row, no cursor, and no on-failure, so a failure mid-descent was silent.
+                         The next step down rides ldh:TreeChildrenFetch's continuation. -->
                     <xsl:when test="$expand-button and not($current-li/ul)">
-                        <!-- Create <ul> for children -->
-                        <xsl:for-each select="$current-li">
-                            <xsl:result-document href="?." method="ixsl:append-content">
-                                <ul/>
-                            </xsl:result-document>
-                        </xsl:for-each>
+                        <xsl:call-template name="ldh:TreeNodeDisclose">
+                            <xsl:with-param name="li" select="$current-li"/>
+                        </xsl:call-template>
 
-                        <!-- Toggle button class -->
-                        <xsl:for-each select="$expand-button">
-                            <ixsl:set-attribute name="class" select="ldh:set-token(@class, 'btn-expand-tree', false())"/>
-                            <ixsl:set-attribute name="class" select="ldh:set-token(@class, 'btn-expanded-tree', true())"/>
-                            <ixsl:set-attribute name="aria-expanded" select="'true'"/>
-                            <xsl:for-each select="span[contains-token(@class, 'msi')]">
-                                <ixsl:set-property name="textContent" select="'expand_more'" object="."/>
-                            </xsl:for-each>
-                        </xsl:for-each>
+                        <xsl:call-template name="ldh:TreeChildrenPlaceholder">
+                            <xsl:with-param name="li" select="$current-li"/>
+                        </xsl:call-template>
 
-                        <!-- Load children and continue descent after loading -->
-                        <xsl:variable name="query-string" select="ldh:doc-tree-children-query($current-href)" as="xs:string"/>
-                        <xsl:variable name="results-uri" select="ac:build-uri(sd:endpoint(), map{ 'query': $query-string })" as="xs:anyURI"/>
-                        <xsl:variable name="request-uri" select="ldh:href($results-uri, map{})" as="xs:anyURI"/>
-                        <xsl:variable name="request" select="map{ 'method': 'GET', 'href': $request-uri, 'headers': map{ 'Accept': 'application/rdf+xml' } }" as="map(*)"/>
+                        <xsl:call-template name="ldh:TreeChildrenFetch">
+                            <xsl:with-param name="container" select="$current-li/ul"/>
+                            <xsl:with-param name="uri" select="$current-href"/>
+                            <xsl:with-param name="query" select="ldh:doc-tree-children-query($current-href)"/>
+                            <xsl:with-param name="then" select="ldh:doctree-descend-after-load(?, $current-li, $target-uri, $tree-container)"/>
+                        </xsl:call-template>
 
-                        <xsl:variable name="load-context" as="map(*)" select="
-                          map{
-                            'request': $request,
-                            'container': $current-li/ul,
-                            'uri': $current-href
-                          }"/>
-
-                        <ixsl:promise select="ixsl:http-request($load-context('request')) =>
-                            ixsl:then(ldh:rethread-response($load-context, ?)) =>
-                            ixsl:then(ldh:handle-response#1) =>
-                            ixsl:then(ldh:tree-children-response#1) =>
-                            ixsl:then(ldh:doctree-descend-after-load(?, $current-li, $target-uri, $tree-container))"/>
                         <xsl:sequence select="map{}"/>
                     </xsl:when>
 

--- a/src/main/webapp/static/com/atomgraph/linkeddatahub/xsl/client/navigation.xsl
+++ b/src/main/webapp/static/com/atomgraph/linkeddatahub/xsl/client/navigation.xsl
@@ -262,85 +262,47 @@ ORDER BY DESC(?created)
         </xsl:choose>
     </xsl:template>
 
-    <xsl:template name="ldh:DocTreeResourceLoad">
+    <!-- the children of a node in the document tree, as ldh:SelectChildren asks for them: the documents
+         whose sioc:has_container is that node. Shared by the disclosure and by ldh:doctree-descend, which
+         walks the same relation ahead of the user -->
+    <xsl:function name="ldh:doc-tree-children-query" as="document-node()">
+        <xsl:param name="uri" as="xs:anyURI"/>
+
+        <xsl:variable name="select-string" select="key('resources', '&ldh;SelectChildren', document(ac:document-uri('&ldh;')))/sp:text" as="xs:string"/>
+        <xsl:variable name="select-string" select="replace($select-string, '$this', '&lt;' || $uri || '&gt;', 'q')" as="xs:string"/>
+        <xsl:variable name="select-json" as="item()">
+            <xsl:variable name="select-builder" select="ixsl:call(ixsl:get(ixsl:get(ixsl:window(), 'SPARQLBuilder'), 'SelectBuilder'), 'fromString', [ $select-string ])"/>
+            <xsl:sequence select="ixsl:call($select-builder, 'build', [])"/>
+        </xsl:variable>
+        <xsl:variable name="select-json-string" select="ixsl:call(ixsl:get(ixsl:window(), 'JSON'), 'stringify', [ $select-json ])" as="xs:string"/>
+        <!-- replace ?child ?thing with ?child - we don't need the topics of documents here -->
+        <xsl:document>
+            <xsl:apply-templates select="json-to-xml($select-json-string)" mode="ldh:replace-variables">
+                <xsl:with-param name="var-names" select="('child')" tunnel="yes"/>
+            </xsl:apply-templates>
+        </xsl:document>
+    </xsl:function>
+
+    <!-- binds the drawer's tree to containment. client/tree.xsl dispatches on the disclosure button, so
+         matching the tree this button sits in is what selects the relation its children are loaded over -->
+    <xsl:template match="button[ancestor::div[contains-token(@class, 'document-tree')]]" mode="ldh:TreeChildrenLoad">
         <xsl:param name="container" as="element()"/>
         <xsl:param name="uri" as="xs:anyURI"/>
-        <xsl:param name="select-xml" as="document-node()"> <!-- using the ldh:SelectChildren query -->
-            <xsl:variable name="select-string" select="key('resources', '&ldh;SelectChildren', document(ac:document-uri('&ldh;')))/sp:text" as="xs:string"/>
-            <xsl:variable name="select-string" select="replace($select-string, '$this', '&lt;' || $uri || '&gt;', 'q')" as="xs:string"/>
-            <xsl:variable name="select-json" as="item()">
-                <xsl:variable name="select-builder" select="ixsl:call(ixsl:get(ixsl:get(ixsl:window(), 'SPARQLBuilder'), 'SelectBuilder'), 'fromString', [ $select-string ])"/>
-                <xsl:sequence select="ixsl:call($select-builder, 'build', [])"/>
-            </xsl:variable>
-            <xsl:variable name="select-json-string" select="ixsl:call(ixsl:get(ixsl:window(), 'JSON'), 'stringify', [ $select-json ])" as="xs:string"/>
-            <!-- replace ?child ?thing with ?child - we don't need the topics of documents here -->
-            <xsl:variable name="select-xml" as="document-node()">
-                <xsl:document>
-                    <xsl:apply-templates select="json-to-xml($select-json-string)" mode="ldh:replace-variables">
-                        <xsl:with-param name="var-names" select="('child')" tunnel="yes"/>
-                    </xsl:apply-templates>
-                </xsl:document>
-            </xsl:variable>
-            <xsl:sequence select="$select-xml"/>
-        </xsl:param>
-        <xsl:param name="endpoint" as="xs:anyURI"/>
 
-        <xsl:sequence select="ldh:busy-cursor()"/>
-        
-        <!-- wrap SELECT into a DESCRIBE -->
-        <xsl:variable name="query-xml" as="element()">
-            <xsl:apply-templates select="$select-xml" mode="ldh:wrap-describe"/>
-        </xsl:variable>
-        <xsl:variable name="query-json-string" select="xml-to-json($query-xml)" as="xs:string"/>
-        <xsl:variable name="query-json" select="ixsl:call(ixsl:get(ixsl:window(), 'JSON'), 'parse', [ $query-json-string ])"/>
-        <xsl:variable name="query-string" select="ixsl:call(ixsl:call(ixsl:get(ixsl:get(ixsl:window(), 'SPARQLBuilder'), 'SelectBuilder'), 'fromQuery', [ $query-json ]), 'toString', [])" as="xs:string"/>
-        <xsl:variable name="results-uri" select="ac:build-uri($endpoint, map{ 'query': $query-string })" as="xs:anyURI"/>
-        <xsl:variable name="request-uri" select="ldh:href($results-uri, map{})" as="xs:anyURI"/>
-        <xsl:variable name="request" select="map{ 'method': 'GET', 'href': $request-uri, 'headers': map{ 'Accept': 'application/rdf+xml' } }" as="map(*)"/>
-        <xsl:variable name="context" as="map(*)" select="
-          map{
-            'request': $request,
-            'container': $container,
-            'uri': $uri
-          }"/>
-        <ixsl:promise select="ixsl:http-request($context('request')) =>
-            ixsl:then(ldh:rethread-response($context, ?)) =>
-            ixsl:then(ldh:handle-response#1) =>
-            ixsl:then(ldh:left-sidebar-resource-response#1) =>
-            ixsl:finally(ldh:reset-cursor#0)"
-            on-failure="ldh:promise-failure#1"/>
+        <xsl:call-template name="ldh:TreeChildrenFetch">
+            <xsl:with-param name="container" select="$container"/>
+            <xsl:with-param name="uri" select="$uri"/>
+            <xsl:with-param name="select-xml" select="ldh:doc-tree-children-query($uri)"/>
+        </xsl:call-template>
     </xsl:template>
     
-    <!-- one tree node (§19): li > .tree-row > disclosure + a.tree-link; the li carries state, the row
-         carries the depth indent ramp (the depth custom property), and a leaf takes the inert spacer so labels stay aligned -->
-    <xsl:template match="*[@rdf:about]" mode="ldh:TreeNode">
-        <xsl:param name="depth" select="0" as="xs:integer"/>
-
-        <li>
-            <div class="tree-row" style="--depth: {$depth}">
-                <!-- only containers can have children resources; the disclosure is a SIBLING of the anchor,
-                     so a container can be expanded without navigating into it -->
-                <xsl:choose>
-                    <xsl:when test="sioc:has_parent">
-                        <button type="button" class="ac-iconbtn sz-xs in-neutral ap-ghost btn-expand-tree" aria-expanded="false">
-                            <span class="msi sm" aria-hidden="true">chevron_right</span>
-                        </button>
-                    </xsl:when>
-                    <xsl:otherwise>
-                        <span class="tree-spacer" aria-hidden="true"/>
-                    </xsl:otherwise>
-                </xsl:choose>
-
-                <a class="tree-link" href="{@rdf:about}" title="{@rdf:about}">
-                    <span class="msi sm tree-icon" aria-hidden="true">
-                        <xsl:value-of select="ldh:class-icon(., 'description')"/>
-                    </span>
-                    <span class="tree-label">
-                        <xsl:apply-templates select="." mode="ac:label"/>
-                    </span>
-                </a>
-            </div>
-        </li>
+    <!-- only a container can hold child documents, so only a container gets a disclosure. This is the
+         document tree's half of ldh:TreeNode - the markup itself lives in client/tree.xsl, which must not
+         know about sioc: - and the priority is what separates the two same-precedence rules -->
+    <xsl:template match="*[@rdf:about][sioc:has_parent]" mode="ldh:TreeNode" priority="1">
+        <xsl:next-match>
+            <xsl:with-param name="expandable" select="true()"/>
+        </xsl:next-match>
     </xsl:template>
     
     <!-- EVENT HANDLERS -->
@@ -428,59 +390,6 @@ ORDER BY DESC(?created)
         <xsl:next-match/>
     </xsl:template>
     
-    <!-- expands tree -->
-    
-    <xsl:template match="button[contains-token(@class, 'btn-expand-tree')]" mode="ixsl:onclick">
-        <xsl:variable name="href" select="following-sibling::a/@href" as="xs:anyURI"/>
-        <xsl:variable name="container" select="../.." as="element()"/> <!-- the row's parent <li> -->
-        <xsl:variable name="depth" select="count(ancestor::li)" as="xs:integer"/> <!-- children sit one level below this row -->
-
-        <ixsl:set-attribute name="class" select="ldh:set-token(@class, 'btn-expand-tree', false())"/>
-        <ixsl:set-attribute name="class" select="ldh:set-token(@class, 'btn-expanded-tree', true())"/>
-        <ixsl:set-attribute name="aria-expanded" select="'true'"/>
-        <xsl:for-each select="span[contains-token(@class, 'msi')]">
-            <ixsl:set-property name="textContent" select="'expand_more'" object="."/>
-        </xsl:for-each>
-
-        <xsl:choose>
-            <!-- if children list does not exist, create it with a lazy-loading row -->
-            <xsl:when test="not($container/ul)">
-                <xsl:for-each select="$container">
-                    <xsl:result-document href="?." method="ixsl:append-content">
-                        <ul>
-                            <!-- replaced by the list items when ldh:DocTreeResourceLoad's response lands -->
-                            <li class="tree-loading" style="--depth: {$depth}">
-                                <span class="msi sm" aria-hidden="true">progress_activity</span>
-                                <span>
-                                    <xsl:apply-templates select="key('resources', 'loading', ldh:translations())" mode="ac:label"/>
-                                </span>
-                            </li>
-                        </ul>
-                    </xsl:result-document>
-                </xsl:for-each>
-
-                <xsl:call-template name="ldh:DocTreeResourceLoad">
-                    <xsl:with-param name="container" select="$container/ul"/>
-                    <xsl:with-param name="uri" select="$href"/>
-                    <xsl:with-param name="endpoint" select="sd:endpoint()"/>
-                </xsl:call-template>
-            </xsl:when>
-            <!-- a present children list re-shows via the toggle's aria-expanded state (ldh.css) -->
-        </xsl:choose>
-    </xsl:template>
-
-    <!-- collapses tree -->
-
-    <xsl:template match="button[contains-token(@class, 'btn-expanded-tree')]" mode="ixsl:onclick">
-        <xsl:variable name="container" select="../.." as="element()"/> <!-- the row's parent <li> -->
-
-        <ixsl:set-attribute name="class" select="ldh:set-token(@class, 'btn-expand-tree', true())"/>
-        <ixsl:set-attribute name="class" select="ldh:set-token(@class, 'btn-expanded-tree', false())"/>
-        <ixsl:set-attribute name="aria-expanded" select="'false'"/>
-        <xsl:for-each select="span[contains-token(@class, 'msi')]">
-            <ixsl:set-property name="textContent" select="'chevron_right'" object="."/>
-        </xsl:for-each>
-    </xsl:template>
 
     <!-- backlinks load from the block links popover - the trigger is the tb-links onclick in block.xsl -->
 
@@ -589,21 +498,7 @@ ORDER BY DESC(?created)
                         </xsl:for-each>
 
                         <!-- Load children and continue descent after loading -->
-                        <!-- Build query to load children (inline from ldh:DocTreeResourceLoad) -->
-                        <xsl:variable name="select-string" select="key('resources', '&ldh;SelectChildren', document(ac:document-uri('&ldh;')))/sp:text" as="xs:string"/>
-                        <xsl:variable name="select-string" select="replace($select-string, '$this', '&lt;' || $current-href || '&gt;', 'q')" as="xs:string"/>
-                        <xsl:variable name="select-json" as="item()">
-                            <xsl:variable name="select-builder" select="ixsl:call(ixsl:get(ixsl:get(ixsl:window(), 'SPARQLBuilder'), 'SelectBuilder'), 'fromString', [ $select-string ])"/>
-                            <xsl:sequence select="ixsl:call($select-builder, 'build', [])"/>
-                        </xsl:variable>
-                        <xsl:variable name="select-json-string" select="ixsl:call(ixsl:get(ixsl:window(), 'JSON'), 'stringify', [ $select-json ])" as="xs:string"/>
-                        <xsl:variable name="select-xml" as="document-node()">
-                            <xsl:document>
-                                <xsl:apply-templates select="json-to-xml($select-json-string)" mode="ldh:replace-variables">
-                                    <xsl:with-param name="var-names" select="('child')" tunnel="yes"/>
-                                </xsl:apply-templates>
-                            </xsl:document>
-                        </xsl:variable>
+                        <xsl:variable name="select-xml" select="ldh:doc-tree-children-query($current-href)" as="document-node()"/>
 
                         <!-- Wrap SELECT into a DESCRIBE -->
                         <xsl:variable name="query-xml" as="element()">
@@ -626,7 +521,7 @@ ORDER BY DESC(?created)
                         <ixsl:promise select="ixsl:http-request($load-context('request')) =>
                             ixsl:then(ldh:rethread-response($load-context, ?)) =>
                             ixsl:then(ldh:handle-response#1) =>
-                            ixsl:then(ldh:left-sidebar-resource-response#1) =>
+                            ixsl:then(ldh:tree-children-response#1) =>
                             ixsl:then(ldh:doctree-descend-after-load(?, $current-li, $target-uri, $tree-container))"/>
                         <xsl:sequence select="map{}"/>
                     </xsl:when>
@@ -690,43 +585,6 @@ ORDER BY DESC(?created)
         </xsl:choose>
     </xsl:function>
 
-    <xsl:function name="ldh:left-sidebar-resource-response" as="map(*)" ixsl:updating="yes">
-        <xsl:param name="context" as="map(*)"/>
-        <xsl:variable name="response" select="$context('response')" as="map(*)"/>
-        <xsl:variable name="container" select="$context('container')" as="element()"/> <!-- <ul> element -->
-        <xsl:variable name="uri" select="$context('uri')" as="xs:anyURI"/>
-
-        <xsl:message>ldh:left-sidebar-resource-response</xsl:message>
-        
-        <xsl:for-each select="$response">
-            <xsl:choose>
-                <xsl:when test="?status = 200 and ?media-type = 'application/rdf+xml'">
-                    <xsl:for-each select="?body">
-                        <xsl:variable name="resources" select="rdf:RDF/*[@rdf:about]" as="element()*"/>
-                        <!-- replace the doc tree list's content (the lazy-loading row goes with it) -->
-                        <xsl:for-each select="$container">
-                            <xsl:variable name="depth" select="count(ancestor::li)" as="xs:integer"/>
-                            <xsl:result-document href="?." method="ixsl:replace-content">
-                                <xsl:apply-templates select="$resources" mode="ldh:TreeNode">
-                                    <xsl:sort select="ac:label(.)"/>
-                                    <xsl:with-param name="depth" select="$depth"/>
-                                </xsl:apply-templates>
-                            </xsl:result-document>
-                        </xsl:for-each>
-
-                        <ixsl:set-style name="cursor" select="'default'" object="ixsl:page()//body"/>
-                    </xsl:for-each>
-                </xsl:when>
-                <xsl:otherwise>
-                    <xsl:message>
-                        Error loading document tree for URI :<xsl:value-of select="$uri"/>
-                    </xsl:message>
-                </xsl:otherwise>
-            </xsl:choose>
-        </xsl:for-each>
-        
-        <xsl:sequence select="$context"/>
-    </xsl:function>
     
     <xsl:function name="ldh:backlinks-response" as="map(*)" ixsl:updating="yes">
         <xsl:param name="context" as="map(*)"/>

--- a/src/main/webapp/static/com/atomgraph/linkeddatahub/xsl/client/query-transforms.xsl
+++ b/src/main/webapp/static/com/atomgraph/linkeddatahub/xsl/client/query-transforms.xsl
@@ -3,6 +3,7 @@
     <!ENTITY ac         "https://w3id.org/atomgraph/client#">
     <!ENTITY ldh        "https://w3id.org/atomgraph/linkeddatahub#">
     <!ENTITY rdf        "http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+    <!ENTITY sioc       "http://rdfs.org/sioc/ns#">
     <!ENTITY xsd        "http://www.w3.org/2001/XMLSchema#">
 ]>
 <xsl:stylesheet version="3.0"
@@ -901,6 +902,121 @@ extension-element-prefixes="ixsl"
         </xsl:copy>
     </xsl:template>
     
+    <!-- container of the projected resource -->
+
+    <!-- Rewrites a view's SELECT into the question "which container would a new solution of this
+         projection be stored in?".
+
+         A solution's resource is described in a graph, that graph IS its document, and the document's
+         container is a triple the platform asserts on every one of them - so two joins answer it with
+         no string operations on URIs and no vocabulary knowledge. Deliberately not via
+         foaf:primaryTopic: a document's fragment entities link back to it differently from one
+         vocabulary to the next (Northwind's #delivery uses foaf:page), while every document has
+         sioc:has_container.
+
+         DISTINCT with LIMIT 2 is the whole result: one row means the destination is determined, two
+         mean it is ambiguous, and no row beyond the second carries information. DISTINCT is
+         load-bearing rather than tidy - without it two solutions in the same container return two
+         rows and read as ambiguity.
+
+         The caller strips LIMIT/OFFSET/ORDER BY first (ldh:replace-limit and friends), the same way
+         ldh:ResultCount does, so this asks about the whole result set rather than a page. -->
+
+    <!-- identity transform -->
+    <xsl:template match="@* | node()" mode="ldh:container-select">
+        <xsl:copy>
+            <xsl:apply-templates select="@* | node()" mode="#current"/>
+        </xsl:copy>
+    </xsl:template>
+
+    <xsl:template match="/json:map" mode="ldh:container-select" priority="1">
+        <!-- every helper name is derived here and passed on, so no downstream template has to re-derive it
+             from $uuid - a tunnel parameter declared without a default downstream is a required one, and the
+             whole rewrite failed outright without it -->
+        <xsl:param name="uuid" select="ac:uuid()" as="xs:string" tunnel="yes"/>
+        <xsl:param name="container-var-name" select="'container' || translate($uuid, '-', '_')" as="xs:string" tunnel="yes"/>
+        <xsl:param name="doc-var-name" select="'doc' || translate($uuid, '-', '_')" as="xs:string" tunnel="yes"/>
+        <xsl:variable name="suffix" select="translate($uuid, '-', '_')" as="xs:string"/>
+
+        <xsl:copy>
+            <xsl:apply-templates select="@* | node()" mode="#current">
+                <xsl:with-param name="container-var-name" select="$container-var-name" tunnel="yes"/>
+                <xsl:with-param name="doc-var-name" select="$doc-var-name" tunnel="yes"/>
+                <xsl:with-param name="predicate-var-name" select="'p' || $suffix" tunnel="yes"/>
+                <xsl:with-param name="object-var-name" select="'o' || $suffix" tunnel="yes"/>
+                <xsl:with-param name="container-graph-var-name" select="'cg' || $suffix" tunnel="yes"/>
+            </xsl:apply-templates>
+
+            <!-- the projection is a set of containers, so duplicates are noise that would read as ambiguity -->
+            <xsl:if test="not(json:boolean[@key = 'distinct'])">
+                <json:boolean key="distinct">true</json:boolean>
+            </xsl:if>
+            <json:number key="limit">2</json:number>
+        </xsl:copy>
+    </xsl:template>
+
+    <!-- project the container alone -->
+    <xsl:template match="/json:map/json:array[@key = 'variables']" mode="ldh:container-select" priority="1">
+        <xsl:param name="container-var-name" as="xs:string" tunnel="yes"/>
+
+        <xsl:copy>
+            <xsl:apply-templates select="@*" mode="#current"/>
+
+            <json:string><xsl:text>?</xsl:text><xsl:value-of select="$container-var-name"/></json:string>
+        </xsl:copy>
+    </xsl:template>
+
+    <!-- the two joins, appended to the view's own pattern. Scoped to the outermost where: a nested one
+         belongs to a subquery or a group whose scope the focus variable may not even reach -->
+    <xsl:template match="/json:map/json:array[@key = 'where']" mode="ldh:container-select" priority="1">
+        <xsl:param name="focus-var-name" as="xs:string" tunnel="yes"/>
+        <xsl:param name="container-var-name" as="xs:string" tunnel="yes"/>
+        <xsl:param name="doc-var-name" as="xs:string" tunnel="yes"/>
+        <xsl:param name="predicate-var-name" as="xs:string" tunnel="yes"/>
+        <xsl:param name="object-var-name" as="xs:string" tunnel="yes"/>
+        <xsl:param name="container-graph-var-name" as="xs:string" tunnel="yes"/>
+
+        <xsl:copy>
+            <xsl:apply-templates select="@* | node()" mode="#current"/>
+
+            <!-- the graph the solution is described in, which is its document -->
+            <json:map>
+                <json:string key="type">graph</json:string>
+                <json:array key="patterns">
+                    <json:map>
+                        <json:string key="type">bgp</json:string>
+                        <json:array key="triples">
+                            <json:map>
+                                <json:string key="subject"><xsl:text>?</xsl:text><xsl:value-of select="$focus-var-name"/></json:string>
+                                <json:string key="predicate"><xsl:text>?</xsl:text><xsl:value-of select="$predicate-var-name"/></json:string>
+                                <json:string key="object"><xsl:text>?</xsl:text><xsl:value-of select="$object-var-name"/></json:string>
+                            </json:map>
+                        </json:array>
+                    </json:map>
+                </json:array>
+                <json:string key="name"><xsl:text>?</xsl:text><xsl:value-of select="$doc-var-name"/></json:string>
+            </json:map>
+
+            <!-- that document's container -->
+            <json:map>
+                <json:string key="type">graph</json:string>
+                <json:array key="patterns">
+                    <json:map>
+                        <json:string key="type">bgp</json:string>
+                        <json:array key="triples">
+                            <json:map>
+                                <json:string key="subject"><xsl:text>?</xsl:text><xsl:value-of select="$doc-var-name"/></json:string>
+                                <json:string key="predicate">&sioc;has_container</json:string>
+                                <json:string key="object"><xsl:text>?</xsl:text><xsl:value-of select="$container-var-name"/></json:string>
+                            </json:map>
+                        </json:array>
+                    </json:map>
+                </json:array>
+                <json:string key="name"><xsl:text>?</xsl:text><xsl:value-of select="$container-graph-var-name"/></json:string>
+            </json:map>
+        </xsl:copy>
+    </xsl:template>
+
     <!-- constructor template -->
     
     <!-- identity transform -->

--- a/src/main/webapp/static/com/atomgraph/linkeddatahub/xsl/client/tree.xsl
+++ b/src/main/webapp/static/com/atomgraph/linkeddatahub/xsl/client/tree.xsl
@@ -27,56 +27,14 @@ exclude-result-prefixes="#all"
 >
 
     <!--
-        A lazily expanded tree of resources, over whatever relation the caller's domain uses.
+        The interactive half of the resource tree; the emitter it drives lives in the shared tree.xsl.
 
-        The hierarchy this renders is not the document hierarchy: the drawer's document tree is one
-        consumer, a SKOS concept tree is another, and the two share every part of the widget except
-        the query that produces a node's children and the test for whether a node has any. Those two
-        are the extension points - a domain supplies them by matching in ldh:TreeChildrenLoad and
-        ldh:TreeNode - and nothing else here knows what it is rendering.
-
-        Deliberately not a role="tree": a tree widget owes a roving tabindex and typeahead over
-        non-navigational items, while this is a nested list of links, which is what the markup says
-        and what screen readers announce.
+        Everything here needs the browser - the disclosure handlers and the fetch that appends the
+        results - which is exactly why the markup is not here: see tree.xsl for why that division is
+        load-bearing rather than cosmetic.
     -->
 
-    <!-- one tree node: li > .tree-row > disclosure + a.tree-link. The li carries state, the row carries
-         the depth indent ramp, and a node with no children takes the inert spacer so labels stay aligned.
-         Whether a node can be expanded is the domain's to decide, so it is a parameter rather than a test
-         on some predicate this module would have to know about; a domain narrows the match and supplies it
-         through xsl:next-match. -->
-    <xsl:template match="*[@rdf:about]" mode="ldh:TreeNode">
-        <xsl:param name="depth" select="0" as="xs:integer"/>
-        <xsl:param name="expandable" select="false()" as="xs:boolean"/>
-
-        <li>
-            <div class="tree-row" style="--depth: {$depth}">
-                <!-- the disclosure is a SIBLING of the anchor, so a node can be expanded without
-                     navigating into it, and so the anchor holds no nested interactive content -->
-                <xsl:choose>
-                    <xsl:when test="$expandable">
-                        <button type="button" class="ac-iconbtn sz-xs in-neutral ap-ghost btn-expand-tree" aria-expanded="false">
-                            <span class="msi sm" aria-hidden="true">chevron_right</span>
-                        </button>
-                    </xsl:when>
-                    <xsl:otherwise>
-                        <span class="tree-spacer" aria-hidden="true"/>
-                    </xsl:otherwise>
-                </xsl:choose>
-
-                <a class="tree-link" href="{@rdf:about}" title="{@rdf:about}">
-                    <span class="msi sm tree-icon" aria-hidden="true">
-                        <xsl:value-of select="ldh:class-icon(., 'description')"/>
-                    </span>
-                    <span class="tree-label">
-                        <xsl:apply-templates select="." mode="ac:label"/>
-                    </span>
-                </a>
-            </div>
-        </li>
-    </xsl:template>
-
-    <!-- The children of a node, as a SELECT this module generates rather than one the domain writes.
+    <!-- The children of a node, as a query this module generates rather than one the domain writes.
          A tree is defined by the relation it follows, so that relation is the parameter: properties
          asserted on the child pointing at its parent, and - since RDF lets either end carry the link -
          properties asserted on the parent pointing at its children. The document hierarchy has two of
@@ -87,7 +45,7 @@ exclude-result-prefixes="#all"
          stored ldh:SelectChildren asked for; its ORDER BY and its ?thing binding are deliberately not
          reproduced, because the children are sorted by ac:label() when they are rendered and the topic
          was already being stripped out before the query ran. -->
-    <xsl:function name="ldh:tree-children-query" as="document-node()">
+    <xsl:function name="ldh:tree-children-query" as="xs:string">
         <xsl:param name="uri" as="xs:anyURI"/>
         <xsl:param name="parent-properties" as="xs:anyURI*"/> <!-- asserted on the child: ?child P $this -->
         <xsl:param name="child-properties" as="xs:anyURI*"/> <!-- asserted on the parent: $this P ?child -->
@@ -103,19 +61,21 @@ exclude-result-prefixes="#all"
              asserted on the parent, because each document is its own graph: a scheme's
              skos:hasTopConcept lives in the scheme's graph while the concept's rdf:type lives in the
              concept's. Scoping both to one GRAPH silently drops every child linked from above -
-             measured against a fixture where it returned one top concept of two -->
-        <xsl:variable name="select-string" select="
-            'SELECT DISTINCT ?child WHERE { GRAPH ?linkGraph { ' ||
+             measured against a fixture where it returned one top concept of two. -->
+        <!-- A DESCRIBE, written out whole rather than a SELECT for something else to wrap, and handed
+             to the endpoint as the string it already is. It used to go through SPARQLBuilder twice -
+             parsed from a string here, re-serialised in the fetch - and that round-trip MERGED the two
+             sibling GRAPH blocks into one keeping only the last graph variable, putting the type
+             requirement back inside the link's graph and silently dropping every child linked from the
+             parent side. Measured: the query left here correctly scoped and arrived at the endpoint as
+             GRAPH ?childGraph { {..} UNION {..} ?child a ?Type }, returning one top concept of two.
+             Wrapping the second block in a group did not survive either. Nothing needed the parse -
+             this query is generated, not authored or edited - so the scoping the comment above
+             describes is now the scoping that gets sent. -->
+        <xsl:sequence select="
+            'DESCRIBE ?child WHERE { GRAPH ?linkGraph { ' ||
             string-join($branches, ' UNION ') ||
-            ' } GRAPH ?childGraph { ?child a ?Type } }'" as="xs:string"/>
-        <xsl:variable name="select-json" as="item()">
-            <xsl:variable name="select-builder" select="ixsl:call(ixsl:get(ixsl:get(ixsl:window(), 'SPARQLBuilder'), 'SelectBuilder'), 'fromString', [ $select-string ])"/>
-            <xsl:sequence select="ixsl:call($select-builder, 'build', [])"/>
-        </xsl:variable>
-        <xsl:variable name="select-json-string" select="ixsl:call(ixsl:get(ixsl:window(), 'JSON'), 'stringify', [ $select-json ])" as="xs:string"/>
-        <xsl:document>
-            <xsl:sequence select="json-to-xml($select-json-string)"/>
-        </xsl:document>
+            ' } GRAPH ?childGraph { ?child a ?Type } }'"/>
     </xsl:function>
 
     <!-- EVENT HANDLERS -->
@@ -176,19 +136,12 @@ exclude-result-prefixes="#all"
     <xsl:template name="ldh:TreeChildrenFetch">
         <xsl:param name="container" as="element()"/> <!-- the <ul> the children are rendered into -->
         <xsl:param name="uri" as="xs:anyURI"/>
-        <xsl:param name="select-xml" as="document-node()"/>
+        <xsl:param name="query" as="xs:string"/> <!-- a DESCRIBE of the children, sent as given -->
         <xsl:param name="endpoint" select="sd:endpoint()" as="xs:anyURI"/>
 
         <xsl:sequence select="ldh:busy-cursor()"/>
 
-        <!-- wrap SELECT into a DESCRIBE -->
-        <xsl:variable name="query-xml" as="element()">
-            <xsl:apply-templates select="$select-xml" mode="ldh:wrap-describe"/>
-        </xsl:variable>
-        <xsl:variable name="query-json-string" select="xml-to-json($query-xml)" as="xs:string"/>
-        <xsl:variable name="query-json" select="ixsl:call(ixsl:get(ixsl:window(), 'JSON'), 'parse', [ $query-json-string ])"/>
-        <xsl:variable name="query-string" select="ixsl:call(ixsl:call(ixsl:get(ixsl:get(ixsl:window(), 'SPARQLBuilder'), 'SelectBuilder'), 'fromQuery', [ $query-json ]), 'toString', [])" as="xs:string"/>
-        <xsl:variable name="results-uri" select="ac:build-uri($endpoint, map{ 'query': $query-string })" as="xs:anyURI"/>
+        <xsl:variable name="results-uri" select="ac:build-uri($endpoint, map{ 'query': $query })" as="xs:anyURI"/>
         <xsl:variable name="request-uri" select="ldh:href($results-uri, map{})" as="xs:anyURI"/>
         <xsl:variable name="request" select="map{ 'method': 'GET', 'href': $request-uri, 'headers': map{ 'Accept': 'application/rdf+xml' } }" as="map(*)"/>
         <xsl:variable name="context" as="map(*)" select="

--- a/src/main/webapp/static/com/atomgraph/linkeddatahub/xsl/client/tree.xsl
+++ b/src/main/webapp/static/com/atomgraph/linkeddatahub/xsl/client/tree.xsl
@@ -1,0 +1,207 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE xsl:stylesheet [
+    <!ENTITY ldh    "https://w3id.org/atomgraph/linkeddatahub#">
+    <!ENTITY ac     "https://w3id.org/atomgraph/client#">
+    <!ENTITY rdf    "http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+    <!ENTITY xsd    "http://www.w3.org/2001/XMLSchema#">
+    <!ENTITY srx    "http://www.w3.org/2005/sparql-results#">
+    <!ENTITY sd     "http://www.w3.org/ns/sparql-service-description#">
+    <!ENTITY sp     "http://spinrdf.org/sp#">
+]>
+<xsl:stylesheet version="3.0"
+xmlns="http://www.w3.org/1999/xhtml"
+xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
+xmlns:ixsl="http://saxonica.com/ns/interactiveXSLT"
+xmlns:xhtml="http://www.w3.org/1999/xhtml"
+xmlns:xs="http://www.w3.org/2001/XMLSchema"
+xmlns:map="http://www.w3.org/2005/xpath-functions/map"
+xmlns:json="http://www.w3.org/2005/xpath-functions"
+xmlns:ac="&ac;"
+xmlns:ldh="&ldh;"
+xmlns:rdf="&rdf;"
+xmlns:srx="&srx;"
+xmlns:sd="&sd;"
+xmlns:sp="&sp;"
+extension-element-prefixes="ixsl"
+exclude-result-prefixes="#all"
+>
+
+    <!--
+        A lazily expanded tree of resources, over whatever relation the caller's domain uses.
+
+        The hierarchy this renders is not the document hierarchy: the drawer's document tree is one
+        consumer, a SKOS concept tree is another, and the two share every part of the widget except
+        the query that produces a node's children and the test for whether a node has any. Those two
+        are the extension points - a domain supplies them by matching in ldh:TreeChildrenLoad and
+        ldh:TreeNode - and nothing else here knows what it is rendering.
+
+        Deliberately not a role="tree": a tree widget owes a roving tabindex and typeahead over
+        non-navigational items, while this is a nested list of links, which is what the markup says
+        and what screen readers announce.
+    -->
+
+    <!-- one tree node: li > .tree-row > disclosure + a.tree-link. The li carries state, the row carries
+         the depth indent ramp, and a node with no children takes the inert spacer so labels stay aligned.
+         Whether a node can be expanded is the domain's to decide, so it is a parameter rather than a test
+         on some predicate this module would have to know about; a domain narrows the match and supplies it
+         through xsl:next-match. -->
+    <xsl:template match="*[@rdf:about]" mode="ldh:TreeNode">
+        <xsl:param name="depth" select="0" as="xs:integer"/>
+        <xsl:param name="expandable" select="false()" as="xs:boolean"/>
+
+        <li>
+            <div class="tree-row" style="--depth: {$depth}">
+                <!-- the disclosure is a SIBLING of the anchor, so a node can be expanded without
+                     navigating into it, and so the anchor holds no nested interactive content -->
+                <xsl:choose>
+                    <xsl:when test="$expandable">
+                        <button type="button" class="ac-iconbtn sz-xs in-neutral ap-ghost btn-expand-tree" aria-expanded="false">
+                            <span class="msi sm" aria-hidden="true">chevron_right</span>
+                        </button>
+                    </xsl:when>
+                    <xsl:otherwise>
+                        <span class="tree-spacer" aria-hidden="true"/>
+                    </xsl:otherwise>
+                </xsl:choose>
+
+                <a class="tree-link" href="{@rdf:about}" title="{@rdf:about}">
+                    <span class="msi sm tree-icon" aria-hidden="true">
+                        <xsl:value-of select="ldh:class-icon(., 'description')"/>
+                    </span>
+                    <span class="tree-label">
+                        <xsl:apply-templates select="." mode="ac:label"/>
+                    </span>
+                </a>
+            </div>
+        </li>
+    </xsl:template>
+
+    <!-- EVENT HANDLERS -->
+
+    <!-- expands a node: flips the disclosure, appends a placeholder list, and hands off to the domain
+         to load the children into it. A list that is already present re-shows through the toggle's
+         aria-expanded state alone (ldh.css), so children are fetched exactly once. -->
+    <xsl:template match="button[contains-token(@class, 'btn-expand-tree')]" mode="ixsl:onclick">
+        <xsl:variable name="href" select="following-sibling::a/@href" as="xs:anyURI"/>
+        <xsl:variable name="container" select="../.." as="element()"/> <!-- the row's parent <li> -->
+        <xsl:variable name="depth" select="count(ancestor::li)" as="xs:integer"/> <!-- children sit one level below this row -->
+
+        <ixsl:set-attribute name="class" select="ldh:set-token(@class, 'btn-expand-tree', false())"/>
+        <ixsl:set-attribute name="class" select="ldh:set-token(@class, 'btn-expanded-tree', true())"/>
+        <ixsl:set-attribute name="aria-expanded" select="'true'"/>
+        <xsl:for-each select="span[contains-token(@class, 'msi')]">
+            <ixsl:set-property name="textContent" select="'expand_more'" object="."/>
+        </xsl:for-each>
+
+        <xsl:if test="not($container/ul)">
+            <xsl:for-each select="$container">
+                <xsl:result-document href="?." method="ixsl:append-content">
+                    <ul>
+                        <!-- replaced by the list items when the children response lands -->
+                        <li class="tree-loading" style="--depth: {$depth}">
+                            <span class="msi sm" aria-hidden="true">progress_activity</span>
+                            <span>
+                                <xsl:apply-templates select="key('resources', 'loading', ldh:translations())" mode="ac:label"/>
+                            </span>
+                        </li>
+                    </ul>
+                </xsl:result-document>
+            </xsl:for-each>
+
+            <!-- dispatched on the button, so a domain selects its loader by matching the tree it sits in -->
+            <xsl:apply-templates select="." mode="ldh:TreeChildrenLoad">
+                <xsl:with-param name="container" select="$container/ul"/>
+                <xsl:with-param name="uri" select="$href"/>
+            </xsl:apply-templates>
+        </xsl:if>
+    </xsl:template>
+
+    <!-- collapses a node; the children stay in the DOM and are never refetched -->
+    <xsl:template match="button[contains-token(@class, 'btn-expanded-tree')]" mode="ixsl:onclick">
+        <ixsl:set-attribute name="class" select="ldh:set-token(@class, 'btn-expand-tree', true())"/>
+        <ixsl:set-attribute name="class" select="ldh:set-token(@class, 'btn-expanded-tree', false())"/>
+        <ixsl:set-attribute name="aria-expanded" select="'false'"/>
+        <xsl:for-each select="span[contains-token(@class, 'msi')]">
+            <ixsl:set-property name="textContent" select="'chevron_right'" object="."/>
+        </xsl:for-each>
+    </xsl:template>
+
+    <!-- LOADING -->
+
+    <!-- Fetches a node's children and renders them into the placeholder list. The SELECT is the
+         caller's - this wraps it in a DESCRIBE, runs it, and applies ldh:TreeNode to whatever comes
+         back - so the relation the tree follows lives entirely in the domain's query. -->
+    <xsl:template name="ldh:TreeChildrenFetch">
+        <xsl:param name="container" as="element()"/> <!-- the <ul> the children are rendered into -->
+        <xsl:param name="uri" as="xs:anyURI"/>
+        <xsl:param name="select-xml" as="document-node()"/>
+        <xsl:param name="endpoint" select="sd:endpoint()" as="xs:anyURI"/>
+
+        <xsl:sequence select="ldh:busy-cursor()"/>
+
+        <!-- wrap SELECT into a DESCRIBE -->
+        <xsl:variable name="query-xml" as="element()">
+            <xsl:apply-templates select="$select-xml" mode="ldh:wrap-describe"/>
+        </xsl:variable>
+        <xsl:variable name="query-json-string" select="xml-to-json($query-xml)" as="xs:string"/>
+        <xsl:variable name="query-json" select="ixsl:call(ixsl:get(ixsl:window(), 'JSON'), 'parse', [ $query-json-string ])"/>
+        <xsl:variable name="query-string" select="ixsl:call(ixsl:call(ixsl:get(ixsl:get(ixsl:window(), 'SPARQLBuilder'), 'SelectBuilder'), 'fromQuery', [ $query-json ]), 'toString', [])" as="xs:string"/>
+        <xsl:variable name="results-uri" select="ac:build-uri($endpoint, map{ 'query': $query-string })" as="xs:anyURI"/>
+        <xsl:variable name="request-uri" select="ldh:href($results-uri, map{})" as="xs:anyURI"/>
+        <xsl:variable name="request" select="map{ 'method': 'GET', 'href': $request-uri, 'headers': map{ 'Accept': 'application/rdf+xml' } }" as="map(*)"/>
+        <xsl:variable name="context" as="map(*)" select="
+          map{
+            'request': $request,
+            'container': $container,
+            'uri': $uri
+          }"/>
+        <ixsl:promise select="ixsl:http-request($context('request')) =>
+            ixsl:then(ldh:rethread-response($context, ?)) =>
+            ixsl:then(ldh:handle-response#1) =>
+            ixsl:then(ldh:tree-children-response#1) =>
+            ixsl:finally(ldh:reset-cursor#0)"
+            on-failure="ldh:promise-failure#1"/>
+    </xsl:template>
+
+    <!-- CALLBACKS -->
+
+    <!-- replaces the placeholder list's content with the children, sorted by label -->
+    <xsl:function name="ldh:tree-children-response" as="map(*)" ixsl:updating="yes">
+        <xsl:param name="context" as="map(*)"/>
+        <xsl:variable name="response" select="$context('response')" as="map(*)"/>
+        <xsl:variable name="container" select="$context('container')" as="element()"/> <!-- <ul> element -->
+        <xsl:variable name="uri" select="$context('uri')" as="xs:anyURI"/>
+
+        <xsl:message>ldh:tree-children-response</xsl:message>
+
+        <xsl:for-each select="$response">
+            <xsl:choose>
+                <xsl:when test="?status = 200 and ?media-type = 'application/rdf+xml'">
+                    <xsl:for-each select="?body">
+                        <xsl:variable name="resources" select="rdf:RDF/*[@rdf:about]" as="element()*"/>
+                        <!-- replaces the list's content, so the lazy-loading row goes with it -->
+                        <xsl:for-each select="$container">
+                            <xsl:variable name="depth" select="count(ancestor::li)" as="xs:integer"/>
+                            <xsl:result-document href="?." method="ixsl:replace-content">
+                                <xsl:apply-templates select="$resources" mode="ldh:TreeNode">
+                                    <xsl:sort select="ac:label(.)"/>
+                                    <xsl:with-param name="depth" select="$depth"/>
+                                </xsl:apply-templates>
+                            </xsl:result-document>
+                        </xsl:for-each>
+
+                        <ixsl:set-style name="cursor" select="'default'" object="ixsl:page()//body"/>
+                    </xsl:for-each>
+                </xsl:when>
+                <xsl:otherwise>
+                    <xsl:message>
+                        Error loading tree children for URI: <xsl:value-of select="$uri"/>
+                    </xsl:message>
+                </xsl:otherwise>
+            </xsl:choose>
+        </xsl:for-each>
+
+        <xsl:sequence select="$context"/>
+    </xsl:function>
+
+</xsl:stylesheet>

--- a/src/main/webapp/static/com/atomgraph/linkeddatahub/xsl/client/tree.xsl
+++ b/src/main/webapp/static/com/atomgraph/linkeddatahub/xsl/client/tree.xsl
@@ -99,10 +99,15 @@ exclude-result-prefixes="#all"
             <xsl:message terminate="yes">ldh:tree-children-query requires at least one parent or child property</xsl:message>
         </xsl:if>
 
+        <!-- the link and the child's own description are in DIFFERENT graphs whenever the link is
+             asserted on the parent, because each document is its own graph: a scheme's
+             skos:hasTopConcept lives in the scheme's graph while the concept's rdf:type lives in the
+             concept's. Scoping both to one GRAPH silently drops every child linked from above -
+             measured against a fixture where it returned one top concept of two -->
         <xsl:variable name="select-string" select="
-            'SELECT DISTINCT ?child WHERE { GRAPH ?childGraph { ' ||
+            'SELECT DISTINCT ?child WHERE { GRAPH ?linkGraph { ' ||
             string-join($branches, ' UNION ') ||
-            ' ?child a ?Type } }'" as="xs:string"/>
+            ' } GRAPH ?childGraph { ?child a ?Type } }'" as="xs:string"/>
         <xsl:variable name="select-json" as="item()">
             <xsl:variable name="select-builder" select="ixsl:call(ixsl:get(ixsl:get(ixsl:window(), 'SPARQLBuilder'), 'SelectBuilder'), 'fromString', [ $select-string ])"/>
             <xsl:sequence select="ixsl:call($select-builder, 'build', [])"/>

--- a/src/main/webapp/static/com/atomgraph/linkeddatahub/xsl/client/tree.xsl
+++ b/src/main/webapp/static/com/atomgraph/linkeddatahub/xsl/client/tree.xsl
@@ -180,7 +180,10 @@ exclude-result-prefixes="#all"
                             <xsl:result-document href="?." method="ixsl:replace-content">
                                 <xsl:apply-templates select="$resources" mode="ldh:TreeNode">
                                     <xsl:sort select="ac:label(.)"/>
-                                    <xsl:with-param name="depth" select="$depth"/>
+                                    <!-- tunnelled: a domain narrows ldh:TreeNode by matching and delegating with
+                                         xsl:next-match, which forwards only the parameters it names, so a plain
+                                         parameter here arrives as its default 0 and the whole tree renders flat -->
+                                    <xsl:with-param name="depth" select="$depth" tunnel="yes"/>
                                 </xsl:apply-templates>
                             </xsl:result-document>
                         </xsl:for-each>

--- a/src/main/webapp/static/com/atomgraph/linkeddatahub/xsl/client/tree.xsl
+++ b/src/main/webapp/static/com/atomgraph/linkeddatahub/xsl/client/tree.xsl
@@ -76,6 +76,43 @@ exclude-result-prefixes="#all"
         </li>
     </xsl:template>
 
+    <!-- The children of a node, as a SELECT this module generates rather than one the domain writes.
+         A tree is defined by the relation it follows, so that relation is the parameter: properties
+         asserted on the child pointing at its parent, and - since RDF lets either end carry the link -
+         properties asserted on the parent pointing at its children. The document hierarchy has two of
+         the first kind and none of the second; a SKOS tree asserts skos:broader on the child and may
+         also carry skos:narrower on the parent, and gets both branches for free.
+
+         The type requirement keeps a tree to resources that describe themselves, which is what the
+         stored ldh:SelectChildren asked for; its ORDER BY and its ?thing binding are deliberately not
+         reproduced, because the children are sorted by ac:label() when they are rendered and the topic
+         was already being stripped out before the query ran. -->
+    <xsl:function name="ldh:tree-children-query" as="document-node()">
+        <xsl:param name="uri" as="xs:anyURI"/>
+        <xsl:param name="parent-properties" as="xs:anyURI*"/> <!-- asserted on the child: ?child P $this -->
+        <xsl:param name="child-properties" as="xs:anyURI*"/> <!-- asserted on the parent: $this P ?child -->
+
+        <xsl:variable name="branches" as="xs:string*" select="
+            (for $property in $parent-properties return '{ ?child &lt;' || $property || '&gt; &lt;' || $uri || '&gt; }'),
+            (for $property in $child-properties return '{ &lt;' || $uri || '&gt; &lt;' || $property || '&gt; ?child }')"/>
+        <xsl:if test="empty($branches)">
+            <xsl:message terminate="yes">ldh:tree-children-query requires at least one parent or child property</xsl:message>
+        </xsl:if>
+
+        <xsl:variable name="select-string" select="
+            'SELECT DISTINCT ?child WHERE { GRAPH ?childGraph { ' ||
+            string-join($branches, ' UNION ') ||
+            ' ?child a ?Type } }'" as="xs:string"/>
+        <xsl:variable name="select-json" as="item()">
+            <xsl:variable name="select-builder" select="ixsl:call(ixsl:get(ixsl:get(ixsl:window(), 'SPARQLBuilder'), 'SelectBuilder'), 'fromString', [ $select-string ])"/>
+            <xsl:sequence select="ixsl:call($select-builder, 'build', [])"/>
+        </xsl:variable>
+        <xsl:variable name="select-json-string" select="ixsl:call(ixsl:get(ixsl:window(), 'JSON'), 'stringify', [ $select-json ])" as="xs:string"/>
+        <xsl:document>
+            <xsl:sequence select="json-to-xml($select-json-string)"/>
+        </xsl:document>
+    </xsl:function>
+
     <!-- EVENT HANDLERS -->
 
     <!-- expands a node: flips the disclosure, appends a placeholder list, and hands off to the domain

--- a/src/main/webapp/static/com/atomgraph/linkeddatahub/xsl/client/tree.xsl
+++ b/src/main/webapp/static/com/atomgraph/linkeddatahub/xsl/client/tree.xsl
@@ -86,29 +86,17 @@ exclude-result-prefixes="#all"
     <xsl:template match="button[contains-token(@class, 'btn-expand-tree')]" mode="ixsl:onclick">
         <xsl:variable name="href" select="following-sibling::a/@href" as="xs:anyURI"/>
         <xsl:variable name="container" select="../.." as="element()"/> <!-- the row's parent <li> -->
-        <xsl:variable name="depth" select="count(ancestor::li)" as="xs:integer"/> <!-- children sit one level below this row -->
 
-        <ixsl:set-attribute name="class" select="ldh:set-token(@class, 'btn-expand-tree', false())"/>
-        <ixsl:set-attribute name="class" select="ldh:set-token(@class, 'btn-expanded-tree', true())"/>
-        <ixsl:set-attribute name="aria-expanded" select="'true'"/>
-        <xsl:for-each select="span[contains-token(@class, 'msi')]">
-            <ixsl:set-property name="textContent" select="'expand_more'" object="."/>
-        </xsl:for-each>
+        <!-- the flip is deliberately OUTSIDE the guard below: a node whose children are already in the
+             DOM re-shows through aria-expanded alone, so clicking it must still flip -->
+        <xsl:call-template name="ldh:TreeNodeDisclose">
+            <xsl:with-param name="li" select="$container"/>
+        </xsl:call-template>
 
         <xsl:if test="not($container/ul)">
-            <xsl:for-each select="$container">
-                <xsl:result-document href="?." method="ixsl:append-content">
-                    <ul>
-                        <!-- replaced by the list items when the children response lands -->
-                        <li class="tree-loading" style="--depth: {$depth}">
-                            <span class="msi sm" aria-hidden="true">progress_activity</span>
-                            <span>
-                                <xsl:apply-templates select="key('resources', 'loading', ldh:translations())" mode="ac:label"/>
-                            </span>
-                        </li>
-                    </ul>
-                </xsl:result-document>
-            </xsl:for-each>
+            <xsl:call-template name="ldh:TreeChildrenPlaceholder">
+                <xsl:with-param name="li" select="$container"/>
+            </xsl:call-template>
 
             <!-- dispatched on the button, so a domain selects its loader by matching the tree it sits in -->
             <xsl:apply-templates select="." mode="ldh:TreeChildrenLoad">
@@ -130,6 +118,44 @@ exclude-result-prefixes="#all"
 
     <!-- LOADING -->
 
+    <!-- Opening a node is two things, and both are shared: ldh:doctree-descend opens the path down to
+         the document being viewed ahead of the reader, and a pre-expanded level has to be
+         indistinguishable from a clicked one. Splitting them is what the click handler needs - it
+         flips unconditionally, because a node whose children are already loaded re-shows off
+         aria-expanded, and only appends a placeholder when there is nothing to re-show. -->
+    <xsl:template name="ldh:TreeNodeDisclose">
+        <xsl:param name="li" as="element()"/>
+
+        <xsl:for-each select="$li/div/button">
+            <ixsl:set-attribute name="class" select="ldh:set-token(@class, 'btn-expand-tree', false())"/>
+            <ixsl:set-attribute name="class" select="ldh:set-token(@class, 'btn-expanded-tree', true())"/>
+            <ixsl:set-attribute name="aria-expanded" select="'true'"/>
+            <xsl:for-each select="span[contains-token(@class, 'msi')]">
+                <ixsl:set-property name="textContent" select="'expand_more'" object="."/>
+            </xsl:for-each>
+        </xsl:for-each>
+    </xsl:template>
+
+    <!-- the list the children are rendered into, carrying the loading row until they land -->
+    <xsl:template name="ldh:TreeChildrenPlaceholder">
+        <xsl:param name="li" as="element()"/>
+        <xsl:variable name="depth" select="count($li/ancestor::li) + 1" as="xs:integer"/> <!-- children sit one level below this row -->
+
+        <xsl:for-each select="$li">
+            <xsl:result-document href="?." method="ixsl:append-content">
+                <ul>
+                    <!-- replaced by the list items when the children response lands -->
+                    <li class="tree-loading" style="--depth: {$depth}">
+                        <span class="msi sm" aria-hidden="true">progress_activity</span>
+                        <span>
+                            <xsl:apply-templates select="key('resources', 'loading', ldh:translations())" mode="ac:label"/>
+                        </span>
+                    </li>
+                </ul>
+            </xsl:result-document>
+        </xsl:for-each>
+    </xsl:template>
+
     <!-- Fetches a node's children and renders them into the placeholder list. The SELECT is the
          caller's - this wraps it in a DESCRIBE, runs it, and applies ldh:TreeNode to whatever comes
          back - so the relation the tree follows lives entirely in the domain's query. -->
@@ -138,6 +164,10 @@ exclude-result-prefixes="#all"
         <xsl:param name="uri" as="xs:anyURI"/>
         <xsl:param name="query" as="xs:string"/> <!-- a DESCRIBE of the children, sent as given -->
         <xsl:param name="endpoint" select="sd:endpoint()" as="xs:anyURI"/>
+        <!-- what to do once the children are in the DOM. ldh:doctree-descend passes its next step here
+             rather than repeating this fetch, which is how it used to continue: its copy had no busy
+             cursor, no loading row and no failure handler, so a failure mid-descent was silent. -->
+        <xsl:param name="then" select="()" as="(function(map(*)) as item()*)?"/>
 
         <xsl:sequence select="ldh:busy-cursor()"/>
 
@@ -154,6 +184,7 @@ exclude-result-prefixes="#all"
             ixsl:then(ldh:rethread-response($context, ?)) =>
             ixsl:then(ldh:handle-response#1) =>
             ixsl:then(ldh:tree-children-response#1) =>
+            ixsl:then(ldh:tree-children-continue($then, ?)) =>
             ixsl:finally(ldh:reset-cursor#0)"
             on-failure="ldh:promise-failure#1"/>
     </xsl:template>
@@ -161,6 +192,22 @@ exclude-result-prefixes="#all"
     <!-- CALLBACKS -->
 
     <!-- replaces the placeholder list's content with the children, sorted by label -->
+    <!-- applies ldh:TreeChildrenFetch's continuation if it was given one, so the chain is written once
+         whether or not a caller carries on from it -->
+    <xsl:function name="ldh:tree-children-continue" as="item()*" ixsl:updating="yes">
+        <xsl:param name="then" as="(function(map(*)) as item()*)?"/>
+        <xsl:param name="context" as="map(*)"/>
+
+        <xsl:choose>
+            <xsl:when test="exists($then)">
+                <xsl:sequence select="$then($context)"/>
+            </xsl:when>
+            <xsl:otherwise>
+                <xsl:sequence select="$context"/>
+            </xsl:otherwise>
+        </xsl:choose>
+    </xsl:function>
+
     <xsl:function name="ldh:tree-children-response" as="map(*)" ixsl:updating="yes">
         <xsl:param name="context" as="map(*)"/>
         <xsl:variable name="response" select="$context('response')" as="map(*)"/>

--- a/src/main/webapp/static/com/atomgraph/linkeddatahub/xsl/common.xsl
+++ b/src/main/webapp/static/com/atomgraph/linkeddatahub/xsl/common.xsl
@@ -26,6 +26,7 @@ exclude-result-prefixes="#all">
     <xsl:import href="imports/sp.xsl"/>
     <xsl:import href="imports/memento.xsl"/>
     <xsl:import href="imports/services/youtube.xsl"/>
+    <xsl:import href="tree.xsl"/>
     <xsl:import href="document.xsl"/>
 
 </xsl:stylesheet>

--- a/src/main/webapp/static/com/atomgraph/linkeddatahub/xsl/document.xsl
+++ b/src/main/webapp/static/com/atomgraph/linkeddatahub/xsl/document.xsl
@@ -62,6 +62,17 @@ exclude-result-prefixes="#all"
     
     <xsl:mode name="ldh:Shape" on-no-match="deep-skip"/>
 
+    <!-- a navigation column beside the document's content, for a vocabulary that has a shape worth
+         navigating: a taxonomy's concept tree, an ontology's class list. Empty unless something fills
+         it, and deep-skip rather than a no-op rule so an unfilled slot costs nothing.
+
+         It is a slot INSIDE the content body rather than a wrapper around it because .content-body
+         carries the page gutter and content width, is addressed by rules as a direct child of
+         .document-body, and is the containing block the sticky create dock measures its full bleed
+         against - so a column emitted around it loses the gutter and breaks the dock, while one
+         emitted into it leaves every existing rule matching. -->
+    <xsl:mode name="ldh:ContentColumn" on-no-match="deep-skip"/>
+
 
     <!-- schema.org BREADCRUMBS -->
     
@@ -614,6 +625,8 @@ exclude-result-prefixes="#all"
             <xsl:if test="$class">
                 <xsl:attribute name="class" select="$class"/>
             </xsl:if>
+
+            <xsl:apply-templates select="." mode="ldh:ContentColumn"/>
 
             <xsl:choose>
                 <xsl:when test="$mode = '&ldh;ContentMode'">

--- a/src/main/webapp/static/com/atomgraph/linkeddatahub/xsl/document.xsl
+++ b/src/main/webapp/static/com/atomgraph/linkeddatahub/xsl/document.xsl
@@ -76,7 +76,12 @@ exclude-result-prefixes="#all"
          the two-column layout keys on. The filler therefore needs no layout class of its own and may
          look like anything - a card, a bare list, a full-height panel - where keying the grid on the
          filler's own class would have meant every package borrowing one component's arrangement to
-         use a general slot. -->
+         use a general slot.
+
+         The active mode is passed in rather than filtered here: which modes a column belongs in is
+         the filler's judgement, not the platform's. A taxonomy tree is a reading affordance and
+         restricts itself to ReadMode; an editor's class list might well want to stay visible while
+         its document's content is being authored. -->
     <xsl:mode name="ldh:ContentColumn" on-no-match="deep-skip"/>
 
 
@@ -637,7 +642,9 @@ exclude-result-prefixes="#all"
                  one component's private arrangement. Materialised first so an unfilled slot emits no
                  wrapper at all and the content body stays single-column. -->
             <xsl:variable name="content-column" as="item()*">
-                <xsl:apply-templates select="." mode="ldh:ContentColumn"/>
+                <xsl:apply-templates select="." mode="ldh:ContentColumn">
+                    <xsl:with-param name="mode" select="$mode"/>
+                </xsl:apply-templates>
             </xsl:variable>
             <xsl:if test="exists($content-column)">
                 <div class="ldh-content-aside">

--- a/src/main/webapp/static/com/atomgraph/linkeddatahub/xsl/document.xsl
+++ b/src/main/webapp/static/com/atomgraph/linkeddatahub/xsl/document.xsl
@@ -70,7 +70,13 @@ exclude-result-prefixes="#all"
          carries the page gutter and content width, is addressed by rules as a direct child of
          .document-body, and is the containing block the sticky create dock measures its full bleed
          against - so a column emitted around it loses the gutter and breaks the dock, while one
-         emitted into it leaves every existing rule matching. -->
+         emitted into it leaves every existing rule matching.
+
+         Whatever fills it is wrapped in .ldh-content-aside by ldh:ContentBody, and that class is what
+         the two-column layout keys on. The filler therefore needs no layout class of its own and may
+         look like anything - a card, a bare list, a full-height panel - where keying the grid on the
+         filler's own class would have meant every package borrowing one component's arrangement to
+         use a general slot. -->
     <xsl:mode name="ldh:ContentColumn" on-no-match="deep-skip"/>
 
 
@@ -626,7 +632,18 @@ exclude-result-prefixes="#all"
                 <xsl:attribute name="class" select="$class"/>
             </xsl:if>
 
-            <xsl:apply-templates select="." mode="ldh:ContentColumn"/>
+            <!-- The wrapper is the platform's, not the filler's: a slot that only lays out when its
+                 content happens to carry one particular class is not an extension point, it is that
+                 one component's private arrangement. Materialised first so an unfilled slot emits no
+                 wrapper at all and the content body stays single-column. -->
+            <xsl:variable name="content-column" as="item()*">
+                <xsl:apply-templates select="." mode="ldh:ContentColumn"/>
+            </xsl:variable>
+            <xsl:if test="exists($content-column)">
+                <div class="ldh-content-aside">
+                    <xsl:sequence select="$content-column"/>
+                </div>
+            </xsl:if>
 
             <xsl:choose>
                 <xsl:when test="$mode = '&ldh;ContentMode'">

--- a/src/main/webapp/static/com/atomgraph/linkeddatahub/xsl/imports/default.xsl
+++ b/src/main/webapp/static/com/atomgraph/linkeddatahub/xsl/imports/default.xsl
@@ -1707,6 +1707,65 @@ exclude-result-prefixes="#all"
         </xsl:if>
     </xsl:template>
 
+    <!-- A blank node typed rdf:langString is a LANGUAGE-TAGGED literal: a value input plus a language
+         field, never a datatype and never a resource. Web-Client carries the same rule, and this is a
+         deliberate shadow of it rather than a duplicate by accident: LDH imports Web-Client, so ANY
+         LDH template matching this node wins on import precedence whatever priority the Client's
+         carries. Measured while fixing it - excluding rdf:langString from LDH's non-XSD resource
+         lookup did not reach the Client's rule, it merely handed the node to LDH's generic bnode
+         control, which rendered an ob (object blank node) field for a property that takes text. The
+         xsd:* template above shadows the Client's the same way and for the same reason.
+
+         Why not a datatype: RDF 1.1 requires an rdf:langString literal to carry a language tag and
+         forbids it carrying a datatype attribute, so emitting lt=rdf:langString would encode an
+         ill-formed literal. The language field, its ll input and the annotation are all reached by
+         synthesising the value node this control produces, so the constructor-driven field and the
+         one rendered from existing data are the same emitters rather than two that can drift. It is
+         prefilled from ac:langs(), the reader's own accepted list.
+
+         What this cost before it was fixed: with the marker treated as a resource, an empty combobox
+         still submitted its generated id URI as the object, so saving the form wrote
+         skos:altLabel <...#id03f1366d-...> into the data instead of a literal. -->
+    <xsl:template match="*[@rdf:about or @rdf:nodeID]/*/@rdf:nodeID[key('resources', .)[not(* except rdf:type[@rdf:resource = '&rdf;langString'])]]" mode="ac:FormControl" priority="3">
+        <xsl:param name="type" select="'text'" as="xs:string"/>
+        <xsl:param name="id" select="generate-id()" as="xs:string"/>
+        <xsl:param name="class" as="xs:string?"/>
+        <xsl:param name="disabled" select="false()" as="xs:boolean"/>
+        <xsl:param name="required" select="false()" as="xs:boolean"/>
+        <xsl:param name="type-label" select="true()" as="xs:boolean"/>
+        <xsl:variable name="value" as="element()">
+            <xsl:element name="{../name()}" namespace="{../namespace-uri()}">
+                <xsl:attribute name="xml:lang" select="ac:langs()[1]"/>
+            </xsl:element>
+        </xsl:variable>
+
+        <xsl:apply-templates select="." mode="ac:FieldShell">
+            <xsl:with-param name="type" select="$type"/>
+            <xsl:with-param name="control" as="item()*">
+                <xsl:call-template name="xhtml:Input">
+                    <xsl:with-param name="name" select="'ol'"/>
+                    <xsl:with-param name="type" select="$type"/>
+                    <xsl:with-param name="id" select="$id"/>
+                    <xsl:with-param name="class" select="$class"/>
+                    <xsl:with-param name="disabled" select="$disabled"/>
+                </xsl:call-template>
+            </xsl:with-param>
+        </xsl:apply-templates>
+
+        <xsl:if test="$type-label">
+            <xsl:apply-templates select="." mode="ac:AnnotationTag">
+                <xsl:with-param name="class" select="'ac-tag sz-sm em-quiet co-neutral'"/>
+                <xsl:with-param name="title" select="'&rdf;langString'"/>
+                <xsl:with-param name="label" select="'rdf:langString'"/>
+            </xsl:apply-templates>
+        </xsl:if>
+
+        <xsl:apply-templates select="$value/@xml:lang" mode="ac:FormControl">
+            <xsl:with-param name="type" select="$type"/>
+            <xsl:with-param name="disabled" select="$disabled"/>
+        </xsl:apply-templates>
+    </xsl:template>
+
     <!-- special case for owl:NamedIndividual bnode instances which become comboboxes -->
     <xsl:template match="*[@rdf:nodeID]/*/@rdf:nodeID[key('resources', .)/rdf:type/@rdf:resource = '&owl;NamedIndividual']" mode="ac:FormControl" priority="2">
         <xsl:param name="type" select="'text'" as="xs:string"/>
@@ -1729,8 +1788,14 @@ exclude-result-prefixes="#all"
         </xsl:if>
     </xsl:template>
 
-    <!-- blank nodes that only have non-XSD rdf:type and no other properties become resource lookups -->
-    <xsl:template match="*[@rdf:about or @rdf:nodeID]/*/@rdf:nodeID[key('resources', .)[not(* except rdf:type[not(starts-with(@rdf:resource, '&xsd;'))])]]" mode="ac:FormControl" priority="1">
+    <!-- blank nodes that only have non-XSD rdf:type and no other properties become resource lookups.
+         rdf:langString is excluded because it is a LITERAL datatype that merely happens to live outside
+         the xsd: namespace: a marker typed with it means "text with a language tag", and treating it as
+         a class handed the author a URI picker for a property that takes text - which is exactly what a
+         constructor declaring [ a rdf:langString ] got. Excluded here rather than shadowed by a second
+         copy of the literal control: with no LDH template claiming it, Web-Client's own langString rule
+         applies, so the control has one implementation in the layer that owns generic form behaviour. -->
+    <xsl:template match="*[@rdf:about or @rdf:nodeID]/*/@rdf:nodeID[key('resources', .)[not(* except rdf:type[not(starts-with(@rdf:resource, '&xsd;'))][not(@rdf:resource = '&rdf;langString')])]]" mode="ac:FormControl" priority="1">
         <xsl:param name="type" select="'text'" as="xs:string"/>
         <xsl:param name="id" select="generate-id()" as="xs:string"/>
         <xsl:param name="class" select="'resource-combobox combobox'" as="xs:string?"/>
@@ -2096,6 +2161,23 @@ exclude-result-prefixes="#all"
                     </xsl:apply-templates>
                 </xsl:otherwise>
             </xsl:choose>
+        </xsl:if>
+    </xsl:template>
+
+    <!-- A literal carrying a language tag IS an rdf:langString, and is named as one. RDF 1.1 gives
+         every tagged literal that datatype, so "Literal" said less than the data does - and said
+         something different from the field the same property gets before a value exists, which
+         announces rdf:langString from the constructor. Same tag treatment as any other datatype,
+         because that is what it is; the untagged case keeps the plain term tag below. -->
+    <xsl:template match="text()[../@xml:lang]" mode="ac:ValueAnnotations" priority="1">
+        <xsl:param name="type" as="xs:string?"/>
+
+        <xsl:if test="not($type = 'hidden')">
+            <xsl:apply-templates select="." mode="ac:AnnotationTag">
+                <xsl:with-param name="class" select="'ac-tag sz-sm em-quiet co-neutral'"/>
+                <xsl:with-param name="title" select="'&rdf;langString'"/>
+                <xsl:with-param name="label" select="'rdf:langString'"/>
+            </xsl:apply-templates>
         </xsl:if>
     </xsl:template>
 

--- a/src/main/webapp/static/com/atomgraph/linkeddatahub/xsl/layout.xsl
+++ b/src/main/webapp/static/com/atomgraph/linkeddatahub/xsl/layout.xsl
@@ -272,7 +272,9 @@ exclude-result-prefixes="#all">
     <!-- SCRIPT -->
 
     <xsl:template match="rdf:RDF[lapp:origin()] | srx:sparql[lapp:origin()]" mode="xhtml:Script">
-        <xsl:param name="client-stylesheet" select="resolve-uri('static/com/atomgraph/linkeddatahub/xsl/client.xsl.sef.json', lapp:origin())" as="xs:anyURI"/>
+        <!-- the stylesheet composed with this application's packages when one has been compiled, otherwise
+             the one built into the webapp. Both are absolute on this application's origin -->
+        <xsl:param name="client-stylesheet" select="(ldh:client-stylesheet(), resolve-uri('static/com/atomgraph/linkeddatahub/xsl/client.xsl.sef.json', lapp:origin()))[1]" as="xs:anyURI"/>
         <xsl:param name="saxon-js-log-level" select="10" as="xs:integer"/>
         <xsl:param name="load-yasqe" select="not(ac:mode(root()) = ('&ac;ModalMode', '&ldht;InfoWindowMode'))" as="xs:boolean"/>
         <xsl:param name="load-saxon-js" select="$ldh:ajaxRendering and not(ac:mode(root()) = ('&ac;ModalMode', '&ldht;InfoWindowMode'))" as="xs:boolean"/>

--- a/src/main/webapp/static/com/atomgraph/linkeddatahub/xsl/server.xsl
+++ b/src/main/webapp/static/com/atomgraph/linkeddatahub/xsl/server.xsl
@@ -46,6 +46,24 @@ exclude-result-prefixes="#all">
         <xsl:sequence select="ldh:link-targets($ldh:httpHeaders('Link'), 'rel=timemap')[1]"/>
     </xsl:function>
 
+    <!-- Compiled client stylesheet composed with this application's imported packages, from the Link
+         response header. Absent until the composed stylesheet exists, so the bootstrap falls back to the
+         stylesheet built into the webapp. The rel is matched against the vocabulary term rather than a
+         restated literal, with its dots escaped so they cannot act as regex wildcards -->
+    <xsl:function name="ldh:client-stylesheet" as="xs:anyURI?">
+        <xsl:variable name="entries" as="xs:string*">
+            <xsl:for-each select="$ldh:httpHeaders('Link')">
+                <xsl:analyze-string select="." regex="&lt;[^&gt;]+&gt;[^&lt;]*">
+                    <xsl:matching-substring>
+                        <xsl:sequence select="."/>
+                    </xsl:matching-substring>
+                </xsl:analyze-string>
+            </xsl:for-each>
+        </xsl:variable>
+        <xsl:variable name="rel" select="replace('&ldh;clientStylesheet', '\.', '\\.')" as="xs:string"/>
+        <xsl:sequence select="(for $entry in $entries return if (matches($entry, '^&lt;[^&gt;]+&gt;\s*;.*[;\s]rel\s*=\s*&quot;?' || $rel || '&quot;?([;,\s]|$)')) then xs:anyURI(replace($entry, '^&lt;([^&gt;]+)&gt;.*$', '$1')) else ())[1]"/>
+    </xsl:function>
+
     <!-- Memento-Datetime response header value, present on ?version= responses -->
     <xsl:function name="ldh:memento-datetime" as="xs:string?">
         <xsl:sequence select="$ldh:httpHeaders('Memento-Datetime')[1]"/>

--- a/src/main/webapp/static/com/atomgraph/linkeddatahub/xsl/tree.xsl
+++ b/src/main/webapp/static/com/atomgraph/linkeddatahub/xsl/tree.xsl
@@ -60,7 +60,13 @@ exclude-result-prefixes="#all"
          on some predicate this module would have to know about; a domain narrows the match and supplies it
          through xsl:next-match. -->
     <xsl:template match="*[@rdf:about]" mode="ldh:TreeNode">
-        <xsl:param name="depth" select="0" as="xs:integer"/>
+        <!-- depth is TUNNELLED, expandable is not, and the difference is deliberate: the indent ramp is
+             ambient state belonging to the level being rendered, while whether a node opens is a
+             per-node decision the domain makes. A domain narrows this template by matching and
+             delegating with xsl:next-match, which forwards only the parameters it names - so a plain
+             depth parameter silently became 0 in every domain override and the tree rendered flat with
+             correct nesting, which is exactly how it shipped. -->
+        <xsl:param name="depth" select="0" as="xs:integer" tunnel="yes"/>
         <xsl:param name="expandable" select="false()" as="xs:boolean"/>
 
         <li>

--- a/src/main/webapp/static/com/atomgraph/linkeddatahub/xsl/tree.xsl
+++ b/src/main/webapp/static/com/atomgraph/linkeddatahub/xsl/tree.xsl
@@ -1,0 +1,93 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+Copyright 2025 Martynas Jusevičius <martynas@atomgraph.com>
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-->
+<!DOCTYPE xsl:stylesheet [
+    <!ENTITY ldh    "https://w3id.org/atomgraph/linkeddatahub#">
+    <!ENTITY ac     "https://w3id.org/atomgraph/client#">
+    <!ENTITY rdf    "http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+    <!ENTITY xsd    "http://www.w3.org/2001/XMLSchema#">
+]>
+<xsl:stylesheet version="3.0"
+xmlns="http://www.w3.org/1999/xhtml"
+xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
+xmlns:xhtml="http://www.w3.org/1999/xhtml"
+xmlns:xs="http://www.w3.org/2001/XMLSchema"
+xmlns:ac="&ac;"
+xmlns:ldh="&ldh;"
+xmlns:rdf="&rdf;"
+exclude-result-prefixes="#all"
+>
+
+    <!--
+        A lazily expanded tree of resources, over whatever relation the caller's domain uses.
+
+        The hierarchy this renders is not the document hierarchy: the drawer's document tree is one
+        consumer, a SKOS concept tree is another, and the two share every part of the widget except
+        the query that produces a node's children and the test for whether a node has any. Those two
+        are the extension points - a domain supplies them by matching in ldh:TreeChildrenLoad and
+        ldh:TreeNode - and nothing else here knows what it is rendering.
+
+        Deliberately not a role="tree": a tree widget owes a roving tabindex and typeahead over
+        non-navigational items, while this is a nested list of links, which is what the markup says
+        and what screen readers announce.
+    -->
+
+    <!-- This module is the half of the widget that is pure markup, so it sits in the shared trunk and
+         renders on the server as well as in the browser. That split is not tidiness: the client keeps
+         the server-rendered body on a direct page load, so a tree emitted only client-side would be
+         absent from every bookmarked or shared URL until the reader navigated somewhere else. What
+         genuinely needs the browser - the disclosure handlers and the fetch - stays in
+         client/tree.xsl. The two meet at the button
+         this template emits: the server paints it, the client binds it. -->
+
+
+    <!-- one tree node: li > .tree-row > disclosure + a.tree-link. The li carries state, the row carries
+         the depth indent ramp, and a node with no children takes the inert spacer so labels stay aligned.
+         Whether a node can be expanded is the domain's to decide, so it is a parameter rather than a test
+         on some predicate this module would have to know about; a domain narrows the match and supplies it
+         through xsl:next-match. -->
+    <xsl:template match="*[@rdf:about]" mode="ldh:TreeNode">
+        <xsl:param name="depth" select="0" as="xs:integer"/>
+        <xsl:param name="expandable" select="false()" as="xs:boolean"/>
+
+        <li>
+            <div class="tree-row" style="--depth: {$depth}">
+                <!-- the disclosure is a SIBLING of the anchor, so a node can be expanded without
+                     navigating into it, and so the anchor holds no nested interactive content -->
+                <xsl:choose>
+                    <xsl:when test="$expandable">
+                        <button type="button" class="ac-iconbtn sz-xs in-neutral ap-ghost btn-expand-tree" aria-expanded="false">
+                            <span class="msi sm" aria-hidden="true">chevron_right</span>
+                        </button>
+                    </xsl:when>
+                    <xsl:otherwise>
+                        <span class="tree-spacer" aria-hidden="true"/>
+                    </xsl:otherwise>
+                </xsl:choose>
+
+                <a class="tree-link" href="{@rdf:about}" title="{@rdf:about}">
+                    <span class="msi sm tree-icon" aria-hidden="true">
+                        <xsl:value-of select="ldh:class-icon(., 'description')"/>
+                    </span>
+                    <span class="tree-label">
+                        <xsl:apply-templates select="." mode="ac:label"/>
+                    </span>
+                </a>
+            </div>
+        </li>
+    </xsl:template>
+
+</xsl:stylesheet>


### PR DESCRIPTION
A package's `ac:stylesheet` has only ever affected server-rendered output. The client SEF is compiled at build time from `client.xsl` alone, so the first time `client.xsl:1104` intercepts a link and re-renders the pane, every package rule disappears — right on load, wrong on the first click, with no error anywhere. `client.xsl:428` documents the symptom and works around it by keeping the server-rendered body on the initial load.

Saxon-JS cannot close this in the browser (`SaxonJS.compile()` is gated on `inBrowser()` and throws `SXJS0006`), and per-package prebuilt SEFs cannot compose, because `xsl:import` precedence is resolved at compile time. So the composition happens server-side, once per distinct import set.

## How

**A generated wrapper, not an edit to `client.xsl`.** `client.xsl` pulls its 14 modules in with `xsl:include`, and an included module shares the includer's precedence — which beats template priority outright. Appending a package import *into* `client.xsl` would place it below all of `client/**`, unable to override `ldh:TreeNode`, `ldh:RenderRow`, any `ixsl:on*` handler, or the form and modal machinery: it would compile cleanly and do almost nothing. The wrapper imports `client.xsl` first and packages after. Measured on a composed build, the package lands at import precedence **40** against **39** for `client.xsl` and every module it includes.

**Out-of-process compiler.** The compile peaks at 1,495,990,272 bytes resident — measured — which beside a Tomcat heap at 75% of a 2 GB limit is an OOM. The `sef-compiler` service is built from the same Dockerfile and takes the static tree by `COPY --from` the Maven stage, so the modules it compiles are the deployed bytes by construction: no mount, no shared volume, nothing to drift. It is stateless and never touches the network.

**Keyed on inputs, not output.** A SEF carries a build timestamp, so content-addressing the result would mint a new URI per compile and per node. The key is SHA-1 over the digest of the stock `client.xsl.sef.json` plus the sorted package URIs — so a platform upgrade invalidates every composed stylesheet and nodes agree on one URI per import set.

**Served from `/static/xsl/sef/`** through a Tomcat alias onto a directory outside the WAR — public by construction, inheriting the immutable caching, CORS and gzip the built-in stylesheets get. Not the upload store, which would need an invented owning document, an anonymous-read authorization per dataspace, and three SPARQL round-trips before streaming 19 MB.

**Server-side composition is never withheld.** Packages compose on every request exactly as they do today; the compiled SEF is an addition the client picks up once it exists. An earlier commit here got that wrong and is corrected in `062ae7d6f`.

## Verified

`mvn compile` clean. The composition compiles end to end through the service against the real `client.xsl` and the SKOS package — 200 in 19.6 s, 19,166,264 bytes, 927,372 gzipped, package rule at precedence 40, stylesheet directory restored exactly afterwards. The `Link` rel matcher is unit-tested on SaxonJS across five header shapes. `docker buildx --check` and `docker compose config` clean.

## Not mergeable yet — blocked on a cross-repo dependency

**CI is red, and no further change on this branch fixes it.** `src/main/resources/com/linkeddatahub/packages/skos/package.ttl:17` pins `ac:stylesheet` to a branch URL:

```
raw.githubusercontent.com/AtomGraph/LinkedDataHub-Apps/refs/heads/develop/packages/skos/layout.xsl
```

so the platform fetches that stylesheet from Apps `develop` at runtime. The Phase 0 change this needs — making a package `ac:stylesheet` a **leaf module**, with no static parameters and no import of the host layout — exists only on an unpushed Apps feature branch. `layout.xsl` is not in the client closure, and `xslt3-he` has no CLI option for static parameters, so the live copy cannot be composed: the container dies on 833 `XPST0008` errors before the healthcheck passes.

Two coupled problems to sequence before this can go green:

1. The leaf-module fix must land on **LinkedDataHub-Apps `develop`** and be pushed.
2. Apps `develop` is already one commit ahead unpushed, and that commit removes the Bootstrap stylesheet injection — the very marker `http-tests/misc/PATCH-settings-package-import.sh` asserts on. Pushing it makes that test fail for a second, independent reason, on `develop` as well as here. The test needs a new observable first, since the package no longer emits anything into `<head>`.

## Follow-ups this creates

- **A declared extension surface.** With the wrapper a package can override anything, including `client/**` internals never meant as API — so any rename silently breaks packages, as the `bs2:` → `ac:` move would have.
- **Integrity pinning.** Package code now runs in every visitor's browser on the app's origin, while `ldh:import` remains a mutable reference to a `develop` URL.
- **Negative caching.** While a key is unpublished every render submits a build; a persistently unreachable compiler means one attempt per request.
- A compile failure is deliberately invisible on the page, since the server still composes — it surfaces only in the log.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BSRUJBNKKjdgJeP3qRZTPd